### PR TITLE
Remove development branch from git repo resource

### DIFF
--- a/pipelines/ci-kubernetes-pipeline.yml
+++ b/pipelines/ci-kubernetes-pipeline.yml
@@ -5,7 +5,6 @@ resources:
   source:
     uri: git@github.com:ONSdigital/census-rm-deploy.git
     private_key: ((github-private-key))
-    branch: initial-ci-pipelines
 
 - name: census-rm-kubernetes-microservices-repo
   type: git


### PR DESCRIPTION
The census-rm-deploy git resource was accidentally left pointing at the branch the pipeline was developed on, it should now be pointing at master.

https://github.com/ONSdigital/census-rm-deploy/pull/1