### PR TITLE
Remove unnecessary services

### DIFF
--- a/pipelines/ci-kubernetes-pipeline.yml
+++ b/pipelines/ci-kubernetes-pipeline.yml
@@ -46,11 +46,6 @@ resources:
   source:
     repository: eu.gcr.io/census-ci/census-rm-collectioninstrumentsvc
 
-- name: commstemplatesvc-docker-latest
-  type: docker-image
-  source:
-    repository: eu.gcr.io/census-ci/census-rm-commstemplatesvc
-
 - name: iacsvc-docker-latest
   type: docker-image
   source:
@@ -65,16 +60,6 @@ resources:
   type: docker-image
   source:
     repository: eu.gcr.io/census-ci/census-rm-surveysvc
-
-- name: fwmtjobsvc-docker-latest
-  type: docker-image
-  source:
-    repository: eu.gcr.io/census-ci/census-rm-fwmtjobsvc
-
-- name: fwmtrmadapter-docker-latest
-  type: docker-image
-  source:
-    repository: eu.gcr.io/census-ci/census-rm-fwmtrmadapter
 
 - name: partysvc-stub-docker-latest
   type: docker-image
@@ -209,31 +194,6 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
-- name: commstemplatesvc-apply-config
-  serial: true
-  serial_groups: [commstemplatesvc]
-  plan:
-  - get: census-rm-kubernetes-microservices-repo
-    trigger: true
-  - get: commstemplatesvc-docker-latest
-    trigger: true
-    params:
-      skip_download: true
-  - get: census-rm-deploy
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
-      GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
-      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: commstemplatesvc
-      KUBERNETES_SELECTOR: app=commstemplatesvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
-      KUBERNETES_FILE_PREFIX: commstemplate
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
-
 - name: iacsvc-apply-config
   serial: true
   serial_groups: [iacsvc]
@@ -308,56 +268,6 @@ jobs:
       KUBERNETES_FILE_PREFIX: survey
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
-
-- name: fwmtjobsvc-apply-config
-  serial: true
-  serial_groups: [fwmtjobsvc]
-  plan:
-  - get: census-rm-kubernetes-handlers-repo
-    trigger: true
-  - get: fwmtjobsvc-docker-latest
-    trigger: true
-    params:
-      skip_download: true
-  - get: census-rm-deploy
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
-      GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
-      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: fwmtgatewayjobsvc
-      KUBERNETES_SELECTOR: app=fwmtgatewayjobsvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/handlers
-      KUBERNETES_FILE_PREFIX: fwmtgateway-job
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-handlers-repo}
-
-- name: fwmtadaptersvc-apply-config
-  serial: true
-  serial_groups: [fwmtadaptersvc]
-  plan:
-  - get: census-rm-kubernetes-handlers-repo
-    trigger: true
-  - get: fwmtrmadapter-docker-latest
-    trigger: true
-    params:
-      skip_download: true
-  - get: census-rm-deploy
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
-      GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
-      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: fwmtgatewayrmadapter
-      KUBERNETES_SELECTOR: app=fwmtgatewayrmadapter
-      KUBERNETES_FILE_PATH: kubernetes-repo/handlers
-      KUBERNETES_FILE_PREFIX: fwmtgateway-rmadapter
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-handlers-repo}
 
 - name: partysvc-stub-apply-config
   serial: true
@@ -495,28 +405,6 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 60s
     input_mapping: {docker-image-resource: collectioninstrumentsvc-docker-latest}
 
-- name: commstemplatesvc-deploy-latest
-  serial: true
-  serial_groups: [commstemplatesvc]
-  plan:
-  - get: commstemplatesvc-docker-latest
-    trigger: true
-    passed: [commstemplatesvc-apply-config]
-    params:
-      skip_download: true
-  - get: census-rm-deploy
-  - task: patch-to-pull-latest-image
-    file: census-rm-deploy/tasks/kubectl-patch-to-latest.yml
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
-      GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
-      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: commstemplatesvc
-      KUBERNETES_SELECTOR: app=commstemplatesvc
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 60s
-    input_mapping: {docker-image-resource: commstemplatesvc-docker-latest}
-
 - name: iacsvc-deploy-latest
   serial: true
   serial_groups: [iacsvc]
@@ -582,50 +470,6 @@ jobs:
       KUBERNETES_SELECTOR: app=surveysvc
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 60s
     input_mapping: {docker-image-resource: surveysvc-docker-latest}
-
-- name: fwmtjobsvc-deploy-latest
-  serial: true
-  serial_groups: [fwmtjobsvc]
-  plan:
-  - get: fwmtjobsvc-docker-latest
-    trigger: true
-    passed: [fwmtjobsvc-apply-config]
-    params:
-      skip_download: true
-  - get: census-rm-deploy
-  - task: patch-to-pull-latest-image
-    file: census-rm-deploy/tasks/kubectl-patch-to-latest.yml
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
-      GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
-      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: fwmtgatewayjobsvc
-      KUBERNETES_SELECTOR: app=fwmtgatewayjobsvc
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {docker-image-resource: fwmtjobsvc-docker-latest}
-
-- name: fwmtrmadapter-deploy-latest
-  serial: true
-  serial_groups: [fwmtadaptersvc]
-  plan:
-  - get: fwmtrmadapter-docker-latest
-    trigger: true
-    passed: [fwmtadaptersvc-apply-config]
-    params:
-      skip_download: true
-  - get: census-rm-deploy
-  - task: patch-to-pull-latest-image
-    file: census-rm-deploy/tasks/kubectl-patch-to-latest.yml
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
-      GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
-      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: fwmtgatewayrmadapter
-      KUBERNETES_SELECTOR: app=fwmtgatewayrmadapter
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {docker-image-resource: fwmtrmadapter-docker-latest}
 
 - name: partysvc-stub-deploy-latest
   serial: true

--- a/tasks/kubectl-apply-service-and-deploy.yml
+++ b/tasks/kubectl-apply-service-and-deploy.yml
@@ -35,10 +35,10 @@ run:
       gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
       # Apply service config
-      kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-service.yml --namespace=${KUBERNETES_NAMESPACE}
+      kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-service.yml --namespace=${KUBERNETES_NAMESPACE} --record
 
       # Apply deployment config
-      kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-deployment.yml --namespace=${KUBERNETES_NAMESPACE}
+      kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-deployment.yml --namespace=${KUBERNETES_NAMESPACE} --record
 
       # Wait for rollout to finish
       kubectl rollout status deploy ${KUBERNETES_DEPLOYMENT_NAME} --watch=true --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT} --namespace=${KUBERNETES_NAMESPACE}

--- a/tasks/kubectl-patch-to-latest.yml
+++ b/tasks/kubectl-patch-to-latest.yml
@@ -34,7 +34,7 @@ run:
       gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
       # Patch a timestamp and image digest label to trigger an image pull
-      kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"timestamp\":\"`date +'%s'`\",\"image-digest\":\"$(cat docker-image-resource/digest | cut -d':' -f2 | cut -c1-60)\"}}}}}" --namespace=${KUBERNETES_NAMESPACE}
+      kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"timestamp\":\"`date +'%s'`\",\"image-digest\":\"$(cat docker-image-resource/digest | cut -d':' -f2 | cut -c1-60)\"}}}}}" --namespace=${KUBERNETES_NAMESPACE} --record
 
       # Wait for rollout to finish
       kubectl rollout status deploy ${KUBERNETES_DEPLOYMENT_NAME} --watch=true --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT} --namespace=${KUBERNETES_NAMESPACE}


### PR DESCRIPTION
## Motivation and Context
We are no longer using several services in our CI environments, they can be removed from the deployment pipeline

## What has Changed
- Deleted fwmtjobsvc, fwmtadaptersvc, commstemplatesvc from pipeline
- Added record flag to kubectl commands

## Links
https://trello.com/c/pL82Zh9L/505-remove-unused-services-from-pipeline