### PR TITLE
Add pubsub receipting service to CI pipeline

### DIFF
--- a/pipelines/ci-kubernetes-pipeline.yml
+++ b/pipelines/ci-kubernetes-pipeline.yml
@@ -309,7 +309,7 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-deploy
-  - task: apply-service-and-deploy
+  - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))

--- a/pipelines/ci-kubernetes-pipeline.yml
+++ b/pipelines/ci-kubernetes-pipeline.yml
@@ -84,7 +84,7 @@ resources:
 - name: pubsubsvc-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-ci/census-rm-pubsub
+    repository: eu.gcr.io/census-ci/rm/census-rm-pubsub
 
 jobs:
 

--- a/pipelines/ci-kubernetes-pipeline.yml
+++ b/pipelines/ci-kubernetes-pipeline.yml
@@ -310,7 +310,7 @@ jobs:
       skip_download: true
   - get: census-rm-deploy
   - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))

--- a/pipelines/ci-kubernetes-pipeline.yml
+++ b/pipelines/ci-kubernetes-pipeline.yml
@@ -81,6 +81,11 @@ resources:
   source:
     repository: eu.gcr.io/census-ci/census-rm-partysvcstub
 
+- name: pubsubsvc-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-ci/census-rm-pubsub
+
 jobs:
 
 # Kubernetes Config
@@ -384,6 +389,31 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
+- name: pubsubsvc-apply-config
+  serial: true
+  serial_groups: [pubsubsvc]
+  plan:
+  - get: census-rm-kubernetes-microservices-repo
+    trigger: true
+  - get: pubsubsvc-docker-latest
+    trigger: true
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: pubsubsvc
+      KUBERNETES_SELECTOR: app=pubsubsvc
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: pubsub
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+
 # Patch to trigger Kubernetes image pull on new latest tag builds
 - name: actionsvc-deploy-latest
   serial: true
@@ -648,3 +678,25 @@ jobs:
       KUBERNETES_SELECTOR: app=partysvc-stub
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 60s
     input_mapping: {docker-image-resource: partysvc-stub-docker-latest}
+
+- name: pubsubsvc-deploy-latest
+  serial: true
+  serial_groups: [pubsubsvc]
+  plan:
+  - get: pubsubsvc-docker-latest
+    trigger: true
+    passed: [pubsubsvc-apply-config]
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: patch-to-pull-latest-image
+    file: census-rm-deploy/tasks/kubectl-patch-to-latest.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: pubsubsvc
+      KUBERNETES_SELECTOR: app=pubsubsvc
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {docker-image-resource: pubsubsvc-docker-latest}

--- a/tasks/kubectl-apply-deployment.yml
+++ b/tasks/kubectl-apply-deployment.yml
@@ -1,0 +1,44 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: google/cloud-sdk
+    tag: slim
+
+params:
+  SERVICE_ACCOUNT_JSON:
+  KUBERNETES_NAMESPACE:
+  KUBERNETES_CLUSTER:
+  GCP_PROJECT_NAME:
+  KUBERNETES_DEPLOYMENT_NAME:
+  KUBERNETES_SELECTOR:
+  KUBERNETES_FILE_PATH:
+  KUBERNETES_FILE_PREFIX:
+  WAIT_UNTIL_AVAILABLE_TIMEOUT:
+
+inputs:
+  - name: kubernetes-repo
+run:
+  path: sh
+  args:
+    - -exc
+    - |
+      apt install kubectl
+
+      cat >~/gcloud-service-key.json <<EOL
+      $SERVICE_ACCOUNT_JSON
+      EOL
+
+      # Use gcloud service account to configure kubectl
+      gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+      gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
+
+      # Apply deployment config
+      kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-deployment.yml --namespace=${KUBERNETES_NAMESPACE} --record
+
+      # Wait for rollout to finish
+      kubectl rollout status deploy ${KUBERNETES_DEPLOYMENT_NAME} --watch=true --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT} --namespace=${KUBERNETES_NAMESPACE}
+
+      # Get deployment status
+      kubectl get deployments "-l ${KUBERNETES_SELECTOR}" -o wide --namespace=${KUBERNETES_NAMESPACE}


### PR DESCRIPTION
## Motivation and Context
We have a new receipting service, it needs to be automatically deployed to our CI environments

## What has Changed
- Added docker image resource for census-rm-pubsub
- Added config and latest image deploys for census-rm-pubsub

## How to test
Testing this is blocked waiting on the PR for the kubernetes files: https://github.com/ONSdigital/census-rm-kubernetes/pull/9

## Links
https://github.com/ONSdigital/census-rm-kubernetes/pull/9
https://trello.com/c/UDZtgxSZ/483-deploy-census-rm-pubsub-to-kubernetes-8
https://github.com/ONSdigital/census-rm-pubsub/pull/4