### PR TITLE
Use glcoud kubectl image

### DIFF
--- a/tasks/kubectl-apply-deployment.yml
+++ b/tasks/kubectl-apply-deployment.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/gcloud-kubectl
+    repository: eu.gcr.io/census-ci/gcloud-kubectl
 
 params:
   SERVICE_ACCOUNT_JSON:

--- a/tasks/kubectl-apply-deployment.yml
+++ b/tasks/kubectl-apply-deployment.yml
@@ -3,8 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: google/cloud-sdk
-    tag: slim
+    repository: eu.gcr.io/census-rm-ci/gcloud-kubectl
 
 params:
   SERVICE_ACCOUNT_JSON:
@@ -24,8 +23,6 @@ run:
   args:
     - -exc
     - |
-      apt install kubectl
-
       cat >~/gcloud-service-key.json <<EOL
       $SERVICE_ACCOUNT_JSON
       EOL

--- a/tasks/kubectl-apply-service-and-deploy.yml
+++ b/tasks/kubectl-apply-service-and-deploy.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/gcloud-kubectl
+    repository: eu.gcr.io/census-ci/gcloud-kubectl
 
 params:
   SERVICE_ACCOUNT_JSON:

--- a/tasks/kubectl-apply-service-and-deploy.yml
+++ b/tasks/kubectl-apply-service-and-deploy.yml
@@ -3,8 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: google/cloud-sdk
-    tag: slim
+    repository: eu.gcr.io/census-rm-ci/gcloud-kubectl
 
 params:
   SERVICE_ACCOUNT_JSON:
@@ -24,8 +23,6 @@ run:
   args:
     - -exc
     - |
-      apt install kubectl
-
       cat >~/gcloud-service-key.json <<EOL
       $SERVICE_ACCOUNT_JSON
       EOL

--- a/tasks/kubectl-patch-to-latest.yml
+++ b/tasks/kubectl-patch-to-latest.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/gcloud-kubectl
+    repository: eu.gcr.io/census-ci/gcloud-kubectl
 
 params:
   SERVICE_ACCOUNT_JSON:

--- a/tasks/kubectl-patch-to-latest.yml
+++ b/tasks/kubectl-patch-to-latest.yml
@@ -3,8 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: google/cloud-sdk
-    tag: slim
+    repository: eu.gcr.io/census-rm-ci/gcloud-kubectl
 
 params:
   SERVICE_ACCOUNT_JSON:
@@ -23,8 +22,6 @@ run:
   args:
     - -exc
     - |
-      apt install kubectl
-
       cat >~/gcloud-service-key.json <<EOL
       $SERVICE_ACCOUNT_JSON
       EOL


### PR DESCRIPTION
## Motivation and Context
Our tasks were using the cloud-sdk slim image and install kubectl on every run. We have now rolled our own image which is just the cloud-sdk slim image plus kubectl, so the tasks can use this instead.

## What has Changed
- Use gcloud-kubectl image for tasks
- Remove install kubectl command from tasks

## How to Test
I have flown the pipeline pointing at this branch and my gcp project and it successfully deploys and runs the acceptance tests

## Links
https://trello.com/c/ct1SqOX5/548-create-gcloud-kubectl-docker-image-for-concourse-jobs
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/23