### PR TITLE
image location changes

### DIFF
--- a/pipelines/ci-kubernetes-pipeline.yml
+++ b/pipelines/ci-kubernetes-pipeline.yml
@@ -30,77 +30,77 @@ resources:
 - name: acceptance-tests-docker-image
   type: docker-image
   source:
-    repository: eu.gcr.io/census-ci/rm/census-rm-acceptance-tests
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-acceptance-tests
     username: _json_key
     password: ((gcp-service-account-json))
 
 - name: actionsvc-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-ci/rm/census-rm-actionsvc
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-actionsvc
     username: _json_key
     password: ((gcp-service-account-json))
 
 - name: actionexportersvc-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-ci/rm/census-rm-actionexportersvc
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-actionexportersvc
     username: _json_key
     password: ((gcp-service-account-json))
 
 - name: casesvc-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-ci/rm/census-rm-casesvc
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-casesvc
     username: _json_key
     password: ((gcp-service-account-json))
 
 - name: collectionexercisesvc-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-ci/rm/census-rm-collectionexercisesvc
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-collectionexercisesvc
     username: _json_key
     password: ((gcp-service-account-json))
 
 - name: collectioninstrumentsvc-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-ci/rm/census-rm-collectioninstrumentsvc
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-collectioninstrumentsvc
     username: _json_key
     password: ((gcp-service-account-json))
 
 - name: iacsvc-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-ci/census-rm-iacsvc
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-iacsvc
     username: _json_key
     password: ((gcp-service-account-json))
 
 - name: samplesvc-stub-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-ci/rm/census-rm-samplesvc-stub
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-samplesvc-stub
     username: _json_key
     password: ((gcp-service-account-json))
 
 - name: surveysvc-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-ci/rm/census-rm-surveysvc
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-surveysvc
     username: _json_key
     password: ((gcp-service-account-json))
 
 - name: partysvc-stub-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-ci/rm/census-rm-partysvc-stub
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-partysvc-stub
     username: _json_key
     password: ((gcp-service-account-json))
 
 - name: pubsubsvc-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-ci/rm/census-rm-pubsub
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-pubsub
     username: _json_key
     password: ((gcp-service-account-json))
 


### PR DESCRIPTION
# Motivation and Context
RM docker image location changed

# What has changed
Image location points to "census-rm-ci" private registry

# How to test?
ensure "Storage Object Viewer" Role has been added to "census-rm-ci" concourse service account
checkout this branch
obtain the concourse secrets file and fly the rm concourse pipeline e.g -

fly -t census set-pipeline -p {pipeline name} -c pipelines/ci-kubernetes-pipeline.yml -l example-secrets/census-rm-ci-secrets.yml

check pipeline successful at https://concourse.catd.census-gcp.onsdigital.uk/

# Links
[Trello](https://trello.com/c/btlTncMZ/585-concourse-to-point-at-new-location)