### PR TITLE
Correct census rm ops image source repository

### DIFF
--- a/pipelines/ci-kubernetes-pipeline.yml
+++ b/pipelines/ci-kubernetes-pipeline.yml
@@ -114,7 +114,7 @@ resources:
 - name: ops-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/census-rm-ops
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-ops
     username: _json_key
     password: ((gcp-service-account-json))
 


### PR DESCRIPTION
The image source for census-rm-ops added in #9 was missing the /rm path.

## Links
https://trello.com/c/Ff1ZKDwP/584-fork-and-deploy-census-rm-ops-tool
#9 