### PR TITLE
Default kubernetes namespace

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+# Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+
+# What has changed
+<!--- What code changes has been made -->
+<!--- Has there been any refactoring -->
+<!--- What tests have been written -->
+
+# How to test?
+<!--- Describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
+<!--- Are there any automated tests that mean changes don't need to be manually changed -->
+
+# Links
+<!--- Add any links to issues (trello, github issues) -->
+<!--- Links to any documentation -->
+<!--- Links to any related PRs -->
+
+# Screenshots (if appropriate):

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Create a secrets YAML file containing the required configuration:
 
 | Variable | Format | Description |
 | --- | --- | ---: |
-| kubernetes-namespace | String | The kubernetes namespace for concourse to deploy to |
 | kubernetes-cluster-name | String | The name of the kubernetes cluster |
 | github-private-key | \| <br>-----BEGIN PRIVATE KEY----- <br>\<private key> <br>-----END PRIVATE KEY----- | A private SSH key for Github with permissions to clone private repositories |
 | gcp-service-account-json | \| <br>\<GCP service account key json> | JSON representation of a GCloud service account access key with required IAM permissions |

--- a/example-secrets/ci-kubernetes-secrets.yml.example
+++ b/example-secrets/ci-kubernetes-secrets.yml.example
@@ -1,4 +1,3 @@
-kubernetes-namespace:
 kubernetes-cluster-name:
 github-private-key:
 gcp-service-account-json:

--- a/pipelines/ci-kubernetes-pipeline.yml
+++ b/pipelines/ci-kubernetes-pipeline.yml
@@ -137,7 +137,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: actionsvc
       KUBERNETES_SELECTOR: app=actionsvc
@@ -162,7 +161,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: actionexportersvc
       KUBERNETES_SELECTOR: app=actionexportersvc
@@ -187,7 +185,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: casesvc
       KUBERNETES_SELECTOR: app=casesvc
@@ -212,7 +209,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: collectionexercisesvc
       KUBERNETES_SELECTOR: app=collectionexercisesvc
@@ -237,7 +233,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: collectioninstrumentsvc
       KUBERNETES_SELECTOR: app=collectioninstrumentsvc
@@ -262,7 +257,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: iacsvc
       KUBERNETES_SELECTOR: app=iacsvc
@@ -287,7 +281,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: samplesvc-stub
       KUBERNETES_SELECTOR: app=samplesvc-stub
@@ -312,7 +305,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: surveysvc
       KUBERNETES_SELECTOR: app=surveysvc
@@ -337,7 +329,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: partysvc
       KUBERNETES_SELECTOR: app=partysvc
@@ -362,7 +353,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: pubsubsvc
       KUBERNETES_SELECTOR: app=pubsubsvc
@@ -387,7 +377,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: ops
       KUBERNETES_SELECTOR: app=ops
@@ -412,7 +401,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: actionsvc
       KUBERNETES_SELECTOR: app=actionsvc
@@ -434,7 +422,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: actionexportersvc
       KUBERNETES_SELECTOR: app=actionexportersvc
@@ -456,7 +443,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: casesvc
       KUBERNETES_SELECTOR: app=casesvc
@@ -478,7 +464,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: collectionexercisesvc
       KUBERNETES_SELECTOR: app=collectionexercisesvc
@@ -500,7 +485,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: collectioninstrumentsvc
       KUBERNETES_SELECTOR: app=collectioninstrumentsvc
@@ -522,7 +506,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: iacsvc
       KUBERNETES_SELECTOR: app=iacsvc
@@ -544,7 +527,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: samplesvc-stub
       KUBERNETES_SELECTOR: app=samplesvc-stub
@@ -566,7 +548,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: surveysvc
       KUBERNETES_SELECTOR: app=surveysvc
@@ -588,7 +569,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: partysvc
       KUBERNETES_SELECTOR: app=partysvc-stub
@@ -610,7 +590,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: pubsubsvc
       KUBERNETES_SELECTOR: app=pubsubsvc
@@ -632,7 +611,6 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: ops
       KUBERNETES_SELECTOR: app=ops
@@ -710,6 +688,5 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_NAMESPACE: ((kubernetes-namespace))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
     input_mapping: {acceptance-tests-repo: acceptance-tests-repo}

--- a/tasks/kubectl-apply-deployment.yml
+++ b/tasks/kubectl-apply-deployment.yml
@@ -7,7 +7,6 @@ image_resource:
 
 params:
   SERVICE_ACCOUNT_JSON:
-  KUBERNETES_NAMESPACE:
   KUBERNETES_CLUSTER:
   GCP_PROJECT_NAME:
   KUBERNETES_DEPLOYMENT_NAME:
@@ -32,10 +31,10 @@ run:
       gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
       # Apply deployment config
-      kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-deployment.yml --namespace=${KUBERNETES_NAMESPACE} --record
+      kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-deployment.yml --record
 
       # Wait for rollout to finish
-      kubectl rollout status deploy ${KUBERNETES_DEPLOYMENT_NAME} --watch=true --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT} --namespace=${KUBERNETES_NAMESPACE}
+      kubectl rollout status deploy ${KUBERNETES_DEPLOYMENT_NAME} --watch=true --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT}
 
       # Get deployment status
-      kubectl get deployments "-l ${KUBERNETES_SELECTOR}" -o wide --namespace=${KUBERNETES_NAMESPACE}
+      kubectl get deployments "-l ${KUBERNETES_SELECTOR}" -o wide

--- a/tasks/kubectl-apply-service-and-deploy.yml
+++ b/tasks/kubectl-apply-service-and-deploy.yml
@@ -7,7 +7,6 @@ image_resource:
 
 params:
   SERVICE_ACCOUNT_JSON:
-  KUBERNETES_NAMESPACE:
   KUBERNETES_CLUSTER:
   GCP_PROJECT_NAME:
   KUBERNETES_DEPLOYMENT_NAME:
@@ -32,13 +31,13 @@ run:
       gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
       # Apply service config
-      kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-service.yml --namespace=${KUBERNETES_NAMESPACE} --record
+      kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-service.yml --record
 
       # Apply deployment config
-      kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-deployment.yml --namespace=${KUBERNETES_NAMESPACE} --record
+      kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-deployment.yml --record
 
       # Wait for rollout to finish
-      kubectl rollout status deploy ${KUBERNETES_DEPLOYMENT_NAME} --watch=true --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT} --namespace=${KUBERNETES_NAMESPACE}
+      kubectl rollout status deploy ${KUBERNETES_DEPLOYMENT_NAME} --watch=true --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT}
 
       # Get deployment status
-      kubectl get deployments "-l ${KUBERNETES_SELECTOR}" -o wide --namespace=${KUBERNETES_NAMESPACE}
+      kubectl get deployments "-l ${KUBERNETES_SELECTOR}" -o wide

--- a/tasks/kubectl-patch-to-latest.yml
+++ b/tasks/kubectl-patch-to-latest.yml
@@ -7,7 +7,6 @@ image_resource:
 
 params:
   SERVICE_ACCOUNT_JSON:
-  KUBERNETES_NAMESPACE:
   KUBERNETES_CLUSTER:
   GCP_PROJECT_NAME:
   KUBERNETES_DEPLOYMENT_NAME:
@@ -31,10 +30,10 @@ run:
       gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
       # Patch a timestamp and image digest label to trigger an image pull
-      kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"timestamp\":\"`date +'%s'`\",\"image-digest\":\"$(cat docker-image-resource/digest | cut -d':' -f2 | cut -c1-60)\"}}}}}" --namespace=${KUBERNETES_NAMESPACE} --record
+      kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"timestamp\":\"`date +'%s'`\",\"image-digest\":\"$(cat docker-image-resource/digest | cut -d':' -f2 | cut -c1-60)\"}}}}}" --record
 
       # Wait for rollout to finish
-      kubectl rollout status deploy ${KUBERNETES_DEPLOYMENT_NAME} --watch=true --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT} --namespace=${KUBERNETES_NAMESPACE}
+      kubectl rollout status deploy ${KUBERNETES_DEPLOYMENT_NAME} --watch=true --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT}
 
       # Get deployment status
-      kubectl get deployments "-l ${KUBERNETES_SELECTOR}" -o wide --namespace=${KUBERNETES_NAMESPACE}
+      kubectl get deployments "-l ${KUBERNETES_SELECTOR}" -o wide


### PR DESCRIPTION
# Motivation and Context
GCP projects to use "default" namespace
<!--- Why is this change required? What problem does it solve? -->

# What has changed
Namespace references removed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
1. ensure target GCP project infrastructure is up to date

2. checkout this branch and add line "branch: default-kubernetes-namespace" to "census-rm-deploy" resource in pipelines/ci-kubernetes-pipeline.yml

3. Fly pipeline against target GCP project e.g - fly -t census set-pipeline -p {pipeline name} -c pipelines/ci-kubernetes-pipeline.yml -l {target gcp secrets file}

4. Check outcome at https://concourse.catd.census-gcp.onsdigital.uk

<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
[Acceptance Tests](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/30)
[Trello](https://trello.com/c/oWQh9Dm4/579-remove-all-references-to-the-response-management-env-kubernetes-namespace)
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
