### PR TITLE
Add manual version of CI pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,37 @@
 Response management Concourse pipelines and documentation
 
 ## Pipelines
-### CI Kubernetes Pipeline
-Specified in `pipelines/ci-kubernetes-pipeline.yml`, this pipeline has three sections.
+### [CI Kubernetes Pipeline](pipelines/ci-kubernetes-pipeline.yml)
+This pipeline has three sections:
 
-The first pulls from the [`census-rm-kubernetes`](https://github.com/ONSdigital/census-rm-kubernetes) repo triggered by commits to master and applies the latest microservice and handler configs to the kubernetes cluster specified by the pipeline configuration.
+1.The first pulls from the [`census-rm-kubernetes`](https://github.com/ONSdigital/census-rm-kubernetes) repo triggered by commits to master and applies the latest microservice and handler configs to the kubernetes cluster specified by the pipeline configuration.
 
-The second checks for new builds for the `latest` tag for the RM container registry images. On being triggered by a new image build it runs the config apply to ensure the config is in line with master, then runs `kubectl patch` for the newly built images deployment giving them a timestamp and image digest label. This causes kubernetes to re-pull the latest image and bring up new pods while we are using `imagePullPolicy: Always`.
+1.The second checks for new builds for the `latest` tag for the RM container registry images. On being triggered by a new image build it runs the config apply to ensure the config is in line with master, then runs `kubectl patch` for the newly built images deployment giving them a timestamp and image digest label. This causes kubernetes to re-pull the latest image and bring up new pods while we are using `imagePullPolicy: Always`.
 
 Lastly the pipelines runs the [`acceptance tests`](https://github.com/ONSdigital/census-rm-acceptance-tests) in kubernetes against the deployed services.
 
 #### How to fly
 Create a secrets YAML file containing the required configuration:
 
-| Variable | Format | Description |
-| --- | --- | ---: |
-| kubernetes-cluster-name | String | The name of the kubernetes cluster |
-| github-private-key | \| <br>-----BEGIN PRIVATE KEY----- <br>\<private key> <br>-----END PRIVATE KEY----- | A private SSH key for Github with permissions to clone private repositories |
-| gcp-service-account-json | \| <br>\<GCP service account key json> | JSON representation of a GCloud service account access key with required IAM permissions |
-| gcp-project-name | String | The name of the GCP project the targeted cluster belongs to |
+| Variable                 | Format                                                                              | Description                                                                              |
+| ------------------------ | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| kubernetes-cluster-name  | String                                                                              | The name of the kubernetes cluster                                                       |
+| github-private-key       | \| <br>-----BEGIN PRIVATE KEY----- <br>\<private key> <br>-----END PRIVATE KEY----- | A private SSH key for Github with permissions to clone private repositories              |
+| gcp-service-account-json | \| <br>\<GCP service account key json>                                              | JSON representation of a GCloud service account access key with required IAM permissions |
+| gcp-project-name         | String                                                                              | The name of the GCP project the targeted cluster belongs to                              |
 
 Then run the fly command:
 ```bash
 fly -t <target> set-pipeline -p <pipeline-name> -c pipelines/ci-kubernetes-pipeline.yml -l <path-to-secrets-yml>
 ```
 This should give you a diff view of the proposed pipeline changes, check the changes and accept if they are correct.
+
+### [Manual CI Kubernetes Pipeline](pipelines/manual-ci-kubernetes-pipeline.yml)
+This is a copy of the [CI Kubernetes Pipeline](#ci-kuberenetes-pipeline) with all the automatic triggers removed. This is useful for any environment where we want to be deploying the latest docker image builds, but not necessarily as soon as they're built.
+
+#### How to fly
+
+Uses the same configuration as the [CI Kubernetes Pipeline](#ci-kubernetes-pipeline).
+```bash
+fly -t <target> set-pipeline -p <pipeline-name> -c pipelines/manual-ci-kubernetes-pipeline.yml -l <path-to-secrets-yml>
+```

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Response management Concourse pipelines and documentation
 ### [CI Kubernetes Pipeline](pipelines/ci-kubernetes-pipeline.yml)
 This pipeline has three sections:
 
-1.The first pulls from the [`census-rm-kubernetes`](https://github.com/ONSdigital/census-rm-kubernetes) repo triggered by commits to master and applies the latest microservice and handler configs to the kubernetes cluster specified by the pipeline configuration.
+1. The first pulls from the [`census-rm-kubernetes`](https://github.com/ONSdigital/census-rm-kubernetes) repo triggered by commits to master and applies the latest microservice and handler configs to the kubernetes cluster specified by the pipeline configuration.
 
-1.The second checks for new builds for the `latest` tag for the RM container registry images. On being triggered by a new image build it runs the config apply to ensure the config is in line with master, then runs `kubectl patch` for the newly built images deployment giving them a timestamp and image digest label. This causes kubernetes to re-pull the latest image and bring up new pods while we are using `imagePullPolicy: Always`.
+1. The second checks for new builds for the `latest` tag for the RM container registry images. On being triggered by a new image build it runs the config apply to ensure the config is in line with master, then runs `kubectl patch` for the newly built images deployment giving them a timestamp and image digest label. This causes kubernetes to re-pull the latest image and bring up new pods while we are using `imagePullPolicy: Always`.
 
-Lastly the pipelines runs the [`acceptance tests`](https://github.com/ONSdigital/census-rm-acceptance-tests) in kubernetes against the deployed services.
+1. Lastly the pipelines runs the [`acceptance tests`](https://github.com/ONSdigital/census-rm-acceptance-tests) in kubernetes against the deployed services.
 
 #### How to fly
 Create a secrets YAML file containing the required configuration:

--- a/pipelines/manual-ci-kubernetes-pipeline.yml
+++ b/pipelines/manual-ci-kubernetes-pipeline.yml
@@ -220,11 +220,13 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-ops-repo}
 
-# Patch to trigger Kubernetes image pull on new latest tag builds
+# Patch to trigger Kubernetes to pull the latest docker image
 - name: action-scheduler-deploy-latest
   serial: true
   serial_groups: [action-scheduler]
   plan:
+  - get: census-rm-kubernetes-microservices-repo
+    passed: [action-scheduler-apply-config]
   - get: action-scheduler-docker-latest
     passed: [action-scheduler-apply-config]
     params:
@@ -245,6 +247,8 @@ jobs:
   serial: true
   serial_groups: [actionexportersvc]
   plan:
+  - get: census-rm-kubernetes-handlers-repo
+    passed: [actionexportersvc-apply-config]
   - get: actionexportersvc-docker-latest
     passed: [actionexportersvc-apply-config]
     params:
@@ -265,6 +269,8 @@ jobs:
   serial: true
   serial_groups: [case-processor]
   plan:
+  - get: census-rm-kubernetes-microservices-repo
+    passed: [case-processor-apply-config]
   - get: case-processor-docker-latest
     passed: [case-processor-apply-config]
     params:
@@ -285,8 +291,9 @@ jobs:
   serial: true
   serial_groups: [iacsvc]
   plan:
+  - get: census-rm-kubernetes-microservices-repo
+    passed: [iacsvc-apply-config]
   - get: iacsvc-docker-latest
-    
     passed: [iacsvc-apply-config]
     params:
       skip_download: true
@@ -306,6 +313,8 @@ jobs:
   serial: true
   serial_groups: [pubsubsvc]
   plan:
+  - get: census-rm-kubernetes-microservices-repo
+    passed: [pubsubsvc-apply-config]
   - get: pubsubsvc-docker-latest
     passed: [pubsubsvc-apply-config]
     params:
@@ -326,6 +335,8 @@ jobs:
   serial: true
   serial_groups: [ops]
   plan:
+  - get: census-rm-kubernetes-ops-repo
+    passed: [ops-apply-config]
   - get: ops-docker-latest
     passed: [ops-apply-config]
     params:
@@ -352,9 +363,9 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-kubernetes-handlers-repo
-    passed: [actionexportersvc-apply-config]
+    passed: [actionexportersvc-deploy-latest]
   - get: census-rm-kubernetes-microservices-repo
-    passed: [action-scheduler-apply-config, case-processor-apply-config, iacsvc-apply-config, pubsubsvc-apply-config]
+    passed: [action-scheduler-deploy-latest, case-processor-deploy-latest, iacsvc-deploy-latest, pubsubsvc-deploy-latest]
   - get: action-scheduler-docker-latest
     passed: [action-scheduler-deploy-latest]
     params:

--- a/pipelines/manual-ci-kubernetes-pipeline.yml
+++ b/pipelines/manual-ci-kubernetes-pipeline.yml
@@ -1,0 +1,384 @@
+---
+resources:
+- name: census-rm-deploy
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-deploy.git
+    private_key: ((github-private-key))
+
+- name: census-rm-kubernetes-microservices-repo
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-kubernetes.git
+    private_key: ((github-private-key))
+    paths: [microservices/*]
+
+- name: census-rm-kubernetes-handlers-repo
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-kubernetes.git
+    private_key: ((github-private-key))
+    paths: [handlers/*]
+
+- name: census-rm-kubernetes-ops-repo
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-kubernetes.git
+    private_key: ((github-private-key))
+    paths: [optional/ops-*]
+
+- name: acceptance-tests-repo
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-acceptance-tests.git
+    private_key: ((github-private-key))
+    paths: [kubernetes.env, tasks/*]
+
+- name: acceptance-tests-docker-image
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-acceptance-tests
+    username: _json_key
+    password: ((gcp-service-account-json))
+
+- name: action-scheduler-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-action-scheduler
+    username: _json_key
+    password: ((gcp-service-account-json))
+
+- name: actionexportersvc-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-actionexportersvc
+    username: _json_key
+    password: ((gcp-service-account-json))
+
+- name: case-processor-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-case-processor
+    username: _json_key
+    password: ((gcp-service-account-json))
+
+- name: iacsvc-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-iacsvc
+    username: _json_key
+    password: ((gcp-service-account-json))
+
+- name: pubsubsvc-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-pubsub
+    username: _json_key
+    password: ((gcp-service-account-json))
+
+- name: ops-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-ops
+    username: _json_key
+    password: ((gcp-service-account-json))
+
+jobs:
+
+# Kubernetes Config
+- name: action-scheduler-apply-config
+  serial: true
+  serial_groups: [action-scheduler]
+  plan:
+  - get: census-rm-kubernetes-microservices-repo
+    
+  - get: action-scheduler-docker-latest
+    
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: action-scheduler
+      KUBERNETES_SELECTOR: app=action-scheduler
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: action-scheduler
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+
+- name: actionexportersvc-apply-config
+  serial: true
+  serial_groups: [actionexportersvc]
+  plan:
+  - get: census-rm-kubernetes-handlers-repo
+  - get: actionexportersvc-docker-latest
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: actionexportersvc
+      KUBERNETES_SELECTOR: app=actionexportersvc
+      KUBERNETES_FILE_PATH: kubernetes-repo/handlers
+      KUBERNETES_FILE_PREFIX: actionexporter
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-handlers-repo}
+
+- name: case-processor-apply-config
+  serial: true
+  serial_groups: [case-processor]
+  plan:
+  - get: census-rm-kubernetes-microservices-repo
+  - get: case-processor-docker-latest
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: case-processor
+      KUBERNETES_SELECTOR: app=case-processor
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: case-processor
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+
+- name: iacsvc-apply-config
+  serial: true
+  serial_groups: [iacsvc]
+  plan:
+  - get: census-rm-kubernetes-microservices-repo
+  - get: iacsvc-docker-latest
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: iacsvc
+      KUBERNETES_SELECTOR: app=iacsvc
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: iac
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+
+- name: pubsubsvc-apply-config
+  serial: true
+  serial_groups: [pubsubsvc]
+  plan:
+  - get: census-rm-kubernetes-microservices-repo
+  - get: pubsubsvc-docker-latest
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: pubsubsvc
+      KUBERNETES_SELECTOR: app=pubsubsvc
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: pubsub
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+
+- name: ops-apply-config
+  serial: true
+  serial_groups: [ops]
+  plan:
+  - get: census-rm-kubernetes-ops-repo
+  - get: ops-docker-latest
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: ops
+      KUBERNETES_SELECTOR: app=ops
+      KUBERNETES_FILE_PATH: kubernetes-repo/optional
+      KUBERNETES_FILE_PREFIX: ops
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-ops-repo}
+
+# Patch to trigger Kubernetes image pull on new latest tag builds
+- name: action-scheduler-deploy-latest
+  serial: true
+  serial_groups: [action-scheduler]
+  plan:
+  - get: action-scheduler-docker-latest
+    passed: [action-scheduler-apply-config]
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: patch-to-pull-latest-image
+    file: census-rm-deploy/tasks/kubectl-patch-to-latest.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: action-scheduler
+      KUBERNETES_SELECTOR: app=action-scheduler
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {docker-image-resource: action-scheduler-docker-latest}
+
+- name: actionexportersvc-deploy-latest
+  serial: true
+  serial_groups: [actionexportersvc]
+  plan:
+  - get: actionexportersvc-docker-latest
+    passed: [actionexportersvc-apply-config]
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: patch-to-pull-latest-image
+    file: census-rm-deploy/tasks/kubectl-patch-to-latest.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: actionexportersvc
+      KUBERNETES_SELECTOR: app=actionexportersvc
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {docker-image-resource: actionexportersvc-docker-latest}
+
+- name: case-processor-deploy-latest
+  serial: true
+  serial_groups: [case-processor]
+  plan:
+  - get: case-processor-docker-latest
+    passed: [case-processor-apply-config]
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: patch-to-pull-latest-image
+    file: census-rm-deploy/tasks/kubectl-patch-to-latest.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: case-processor
+      KUBERNETES_SELECTOR: app=case-processor
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {docker-image-resource: case-processor-docker-latest}
+
+- name: iacsvc-deploy-latest
+  serial: true
+  serial_groups: [iacsvc]
+  plan:
+  - get: iacsvc-docker-latest
+    
+    passed: [iacsvc-apply-config]
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: patch-to-pull-latest-image
+    file: census-rm-deploy/tasks/kubectl-patch-to-latest.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: iacsvc
+      KUBERNETES_SELECTOR: app=iacsvc
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {docker-image-resource: iacsvc-docker-latest}
+
+- name: pubsubsvc-deploy-latest
+  serial: true
+  serial_groups: [pubsubsvc]
+  plan:
+  - get: pubsubsvc-docker-latest
+    passed: [pubsubsvc-apply-config]
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: patch-to-pull-latest-image
+    file: census-rm-deploy/tasks/kubectl-patch-to-latest.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: pubsubsvc
+      KUBERNETES_SELECTOR: app=pubsubsvc
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {docker-image-resource: pubsubsvc-docker-latest}
+
+- name: ops-deploy-latest
+  serial: true
+  serial_groups: [ops]
+  plan:
+  - get: ops-docker-latest
+    passed: [ops-apply-config]
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: patch-to-pull-latest-image
+    file: census-rm-deploy/tasks/kubectl-patch-to-latest.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: ops
+      KUBERNETES_SELECTOR: app=ops
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {docker-image-resource: ops-docker-latest}
+
+
+- name: "Acceptance Tests"
+  serial: true
+  serial_groups: [action-scheduler, actionexportersvc, case-processor, iacsvc, pubsubsvc]
+  plan:
+  - get: acceptance-tests-repo
+  - get: acceptance-tests-docker-image
+    params:
+      skip_download: true
+  - get: census-rm-kubernetes-handlers-repo
+    passed: [actionexportersvc-apply-config]
+  - get: census-rm-kubernetes-microservices-repo
+    passed: [action-scheduler-apply-config, case-processor-apply-config, iacsvc-apply-config, pubsubsvc-apply-config]
+  - get: action-scheduler-docker-latest
+    passed: [action-scheduler-deploy-latest]
+    params:
+      skip_download: true
+  - get: actionexportersvc-docker-latest
+    passed: [actionexportersvc-deploy-latest]
+    params:
+      skip_download: true
+  - get: case-processor-docker-latest
+    passed: [case-processor-deploy-latest]
+    params:
+      skip_download: true
+  - get: iacsvc-docker-latest
+    passed: [iacsvc-deploy-latest]
+    params:
+      skip_download: true
+  - get: pubsubsvc-docker-latest
+    passed: [pubsubsvc-deploy-latest]
+    params:
+      skip_download: true
+  - task: "Run Acceptance Tests (in K8s)"
+    file: acceptance-tests-repo/tasks/kubectl-run-acceptance-tests.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+    input_mapping: {acceptance-tests-repo: acceptance-tests-repo}


### PR DESCRIPTION
# Motivation and Context
We have some environments where we want to be able to deploy the latest changes, but not necessarily as soon as they're merged. This pipeline is a short term solution, allowing deployments by simply triggering the jobs but not doing anything automatically.

# What has changed
- Add manual ci pipeline
- Update README

# Links
https://trello.com/c/uXYpj2yE/672-deployment-to-white-lodge-5