### PR TITLE
Remove scale down from CI pipeline

### DIFF
--- a/pipelines/ci-kubernetes-pipeline.yml
+++ b/pipelines/ci-kubernetes-pipeline.yml
@@ -131,7 +131,7 @@ jobs:
         args:
           - -exc
           - |
-            apt-get install -y unzip procps
+            apt-get install -y unzip procps  # NB: procps is used by Helm
             git clone https://github.com/kamatama41/tfenv.git ~/.tfenv && \
             ln -s /root/.tfenv/bin/* /usr/local/bin
             cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL

--- a/pipelines/dev-kubernetes-pipeline.yml
+++ b/pipelines/dev-kubernetes-pipeline.yml
@@ -118,6 +118,7 @@ jobs:
       params:
         AUTO_APPLY: true
         DEV_PUBSUB: true
+        DEV_SCALE_DOWN: true
         DISABLE_CI_BINDING: true
         ENV: ((gcp-environment-name))
         GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
CI project should not "scale down" (unlike other dev projects).

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Separated dev and CI pipelines
- Removed `DEV_SCALE_DOWN` flag from CI

NB: already in flight.