### PR TITLE
Allow configurable acceptance tests image

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,16 @@ This pipeline has three sections:
 Create a secrets YAML file containing the required configuration:
 
 | Variable                 | Format                                                                              | Description                                                                              |
-| ------------------------ | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| ------------------------ | ----------------------------------------------------------------------------------- | -----------------------------------------------------------------------------------------|
 | kubernetes-cluster-name  | String                                                                              | The name of the kubernetes cluster                                                       |
+| acceptance-tests-image   | String                                                                              | The name of the acceptance tests image to run                                            |
 | github-private-key       | \| <br>-----BEGIN PRIVATE KEY----- <br>\<private key> <br>-----END PRIVATE KEY----- | A private SSH key for Github with permissions to clone private repositories              |
 | gcp-service-account-json | \| <br>\<GCP service account key json>                                              | JSON representation of a GCloud service account access key with required IAM permissions |
 | gcp-project-name         | String                                                                              | The name of the GCP project the targeted cluster belongs to                              |
+| gcp-admin-account-json   | \| <br>\<GCP Concourse admin account key json                                       | CI or dev only - JSON representation of a GCloud account access key with IAM permissions |
+| gcp-environment-name     | String                                                                              | CI or dev only - The name of the GCP project suffix the targeted cluster belongs to      |
+| terraform-branch         | String                                                                              | CI or dev only - The name of the terraform branch                                        |
+
 
 Then run the fly command:
 ```bash

--- a/example-secrets/ci-kubernetes-secrets.yml.example
+++ b/example-secrets/ci-kubernetes-secrets.yml.example
@@ -5,4 +5,4 @@ gcp-service-account-json:
 github-private-key:
 kubernetes-cluster-name:
 terraform-branch: master
-acceptance-tests-image:
+acceptance-tests-image: eu.gcr.io/census-rm-ci/rm/census-rm-acceptance-tests:latest

--- a/example-secrets/ci-kubernetes-secrets.yml.example
+++ b/example-secrets/ci-kubernetes-secrets.yml.example
@@ -5,3 +5,4 @@ gcp-service-account-json:
 github-private-key:
 kubernetes-cluster-name:
 terraform-branch: master
+acceptance-tests-image:

--- a/pipelines/ci-kubernetes-pipeline.yml
+++ b/pipelines/ci-kubernetes-pipeline.yml
@@ -523,4 +523,5 @@ jobs:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      ACCEPTANCE_TESTS_IMAGE: ((acceptance-tests-image))
     input_mapping: {acceptance-tests-repo: acceptance-tests-repo}

--- a/pipelines/dev-kubernetes-pipeline.yml
+++ b/pipelines/dev-kubernetes-pipeline.yml
@@ -524,4 +524,5 @@ jobs:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      ACCEPTANCE_TESTS_IMAGE: ((acceptance-tests-image))
     input_mapping: {acceptance-tests-repo: acceptance-tests-repo}

--- a/pipelines/manual-ci-kubernetes-pipeline.yml
+++ b/pipelines/manual-ci-kubernetes-pipeline.yml
@@ -392,4 +392,5 @@ jobs:
       SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
       GCP_PROJECT_NAME: ((gcp-project-name))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      ACCEPTANCE_TESTS_IMAGE: ((acceptance-tests-image))
     input_mapping: {acceptance-tests-repo: acceptance-tests-repo}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Acceptance tests are currently set to run using the CI image each time the job is triggered. It would be useful to run acceptance tests from the pipeline against a custom image, especially now that we can configure our own dev pipelines.  

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Updated README to reflect recent var changes
* Updated pipeline files to allow configurable acceptance test images

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
* In the pipeline file, add the following to `acceptance-tests-repo` resource:
```yaml
branch: allow-configurable-image-name
```
* fly your own pipeline, ensuring that you set an acceptance tests image in your secrets file

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/yYcJCaRz/761-make-acceptance-tests-image-configurable-in-pipeline