### PR TITLE
Add case-api to pipeline

### DIFF
--- a/pipelines/ci-kubernetes-pipeline.yml
+++ b/pipelines/ci-kubernetes-pipeline.yml
@@ -68,6 +68,13 @@ resources:
     username: _json_key
     password: ((gcp-service-account-json))
 
+- name: case-api-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-case-api
+    username: _json_key
+    password: ((gcp-service-account-json))
+
 - name: case-processor-docker-latest
   type: docker-image
   source:
@@ -102,7 +109,7 @@ jobs:
 
 - name: deploy-infrastructure
   serial: true
-  serial_groups: [action-scheduler, actionexportersvc, case-processor, iacsvc, ops, pubsubsvc]
+  serial_groups: [action-scheduler, actionexportersvc, case-api, case-processor, iacsvc, ops, pubsubsvc]
   max_in_flight: 1
   plan:
   - get: census-rm-terraform
@@ -201,6 +208,33 @@ jobs:
       KUBERNETES_FILE_PREFIX: actionexporter
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-handlers-repo}
+
+- name: case-api-apply-config
+  serial: true
+  serial_groups: [case-api]
+  plan:
+  - get: census-rm-terraform
+    trigger: true
+    passed: [deploy-infrastructure]
+  - get: census-rm-kubernetes-microservices-repo
+    trigger: true
+  - get: case-api-docker-latest
+    trigger: true
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: case-api
+      KUBERNETES_SELECTOR: app=case-api
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: case-api
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
 - name: case-processor-apply-config
   serial: true
@@ -365,6 +399,33 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {docker-image-resource: actionexportersvc-docker-latest}
 
+- name: case-api-deploy-latest
+  serial: true
+  serial_groups: [case-api]
+  plan:
+  - get: census-rm-kubernetes-microservices-repo
+    trigger: true
+    passed: [case-api-apply-config]
+  - get: census-rm-terraform
+    trigger: true
+    passed: [case-api-apply-config]
+  - get: case-api-docker-latest
+    trigger: true
+    passed: [case-api-apply-config]
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: patch-to-pull-latest-image
+    file: census-rm-deploy/tasks/kubectl-patch-to-latest.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: case-api
+      KUBERNETES_SELECTOR: app=case-api
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {docker-image-resource: case-api-docker-latest}
+
 - name: case-processor-deploy-latest
   serial: true
   serial_groups: [case-processor]
@@ -476,11 +537,11 @@ jobs:
 
 - name: "Acceptance Tests"
   serial: true
-  serial_groups: [action-scheduler, actionexportersvc, case-processor, iacsvc, pubsubsvc]
+  serial_groups: [action-scheduler, actionexportersvc, case-api, case-processor, iacsvc, pubsubsvc]
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: [action-scheduler-deploy-latest, actionexportersvc-deploy-latest, case-processor-deploy-latest, iacsvc-deploy-latest, pubsubsvc-deploy-latest]
+    passed: [action-scheduler-deploy-latest, actionexportersvc-deploy-latest, case-api-deploy-latest, case-processor-deploy-latest, iacsvc-deploy-latest, pubsubsvc-deploy-latest]
   - get: acceptance-tests-repo
   - get: acceptance-tests-docker-image
     trigger: true
@@ -491,7 +552,7 @@ jobs:
     passed: [actionexportersvc-deploy-latest]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
-    passed: [action-scheduler-deploy-latest, case-processor-deploy-latest, iacsvc-deploy-latest, pubsubsvc-deploy-latest]
+    passed: [action-scheduler-deploy-latest, case-api-deploy-latest, case-processor-deploy-latest, iacsvc-deploy-latest, pubsubsvc-deploy-latest]
   - get: action-scheduler-docker-latest
     trigger: true
     passed: [action-scheduler-deploy-latest]
@@ -500,6 +561,11 @@ jobs:
   - get: actionexportersvc-docker-latest
     trigger: true
     passed: [actionexportersvc-deploy-latest]
+    params:
+      skip_download: true
+  - get: case-api-docker-latest
+    trigger: true
+    passed: [case-api-deploy-latest]
     params:
       skip_download: true
   - get: case-processor-docker-latest

--- a/pipelines/dev-kubernetes-pipeline.yml
+++ b/pipelines/dev-kubernetes-pipeline.yml
@@ -68,6 +68,13 @@ resources:
     username: _json_key
     password: ((gcp-service-account-json))
 
+- name: case-api-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-case-api
+    username: _json_key
+    password: ((gcp-service-account-json))
+
 - name: case-processor-docker-latest
   type: docker-image
   source:
@@ -102,7 +109,7 @@ jobs:
 
 - name: deploy-infrastructure
   serial: true
-  serial_groups: [action-scheduler, actionexportersvc, case-processor, iacsvc, ops, pubsubsvc]
+  serial_groups: [action-scheduler, actionexportersvc, case-api, case-processor, iacsvc, ops, pubsubsvc]
   max_in_flight: 1
   plan:
   - get: census-rm-terraform
@@ -202,6 +209,33 @@ jobs:
       KUBERNETES_FILE_PREFIX: actionexporter
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-handlers-repo}
+
+- name: case-api-apply-config
+  serial: true
+  serial_groups: [case-api]
+  plan:
+  - get: census-rm-terraform
+    trigger: true
+    passed: [deploy-infrastructure]
+  - get: census-rm-kubernetes-microservices-repo
+    trigger: true
+  - get: case-api-docker-latest
+    trigger: true
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: case-api
+      KUBERNETES_SELECTOR: app=case-api
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: case-api
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
 - name: case-processor-apply-config
   serial: true
@@ -366,6 +400,33 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {docker-image-resource: actionexportersvc-docker-latest}
 
+- name: case-api-deploy-latest
+  serial: true
+  serial_groups: [case-api]
+  plan:
+  - get: census-rm-kubernetes-microservices-repo
+    trigger: true
+    passed: [case-api-apply-config]
+  - get: census-rm-terraform
+    trigger: true
+    passed: [case-api-apply-config]
+  - get: case-api-docker-latest
+    trigger: true
+    passed: [case-api-apply-config]
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: patch-to-pull-latest-image
+    file: census-rm-deploy/tasks/kubectl-patch-to-latest.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: case-api
+      KUBERNETES_SELECTOR: app=case-api
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {docker-image-resource: case-api-docker-latest}
+
 - name: case-processor-deploy-latest
   serial: true
   serial_groups: [case-processor]
@@ -477,11 +538,11 @@ jobs:
 
 - name: "Acceptance Tests"
   serial: true
-  serial_groups: [action-scheduler, actionexportersvc, case-processor, iacsvc, pubsubsvc]
+  serial_groups: [action-scheduler, actionexportersvc, case-api, case-processor, iacsvc, pubsubsvc]
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: [action-scheduler-deploy-latest, actionexportersvc-deploy-latest, case-processor-deploy-latest, iacsvc-deploy-latest, pubsubsvc-deploy-latest]
+    passed: [action-scheduler-deploy-latest, actionexportersvc-deploy-latest, case-api-deploy-latest, case-processor-deploy-latest, iacsvc-deploy-latest, pubsubsvc-deploy-latest]
   - get: acceptance-tests-repo
   - get: acceptance-tests-docker-image
     trigger: true
@@ -492,7 +553,7 @@ jobs:
     passed: [actionexportersvc-deploy-latest]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
-    passed: [action-scheduler-deploy-latest, case-processor-deploy-latest, iacsvc-deploy-latest, pubsubsvc-deploy-latest]
+    passed: [action-scheduler-deploy-latest, case-api-deploy-latest, case-processor-deploy-latest, iacsvc-deploy-latest, pubsubsvc-deploy-latest]
   - get: action-scheduler-docker-latest
     trigger: true
     passed: [action-scheduler-deploy-latest]
@@ -501,6 +562,11 @@ jobs:
   - get: actionexportersvc-docker-latest
     trigger: true
     passed: [actionexportersvc-deploy-latest]
+    params:
+      skip_download: true
+  - get: case-api-docker-latest
+    trigger: true
+    passed: [case-api-deploy-latest]
     params:
       skip_download: true
   - get: case-processor-docker-latest

--- a/pipelines/manual-ci-kubernetes-pipeline.yml
+++ b/pipelines/manual-ci-kubernetes-pipeline.yml
@@ -55,6 +55,13 @@ resources:
     username: _json_key
     password: ((gcp-service-account-json))
 
+- name: case-api-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-case-api
+    username: _json_key
+    password: ((gcp-service-account-json))
+
 - name: case-processor-docker-latest
   type: docker-image
   source:
@@ -131,6 +138,28 @@ jobs:
       KUBERNETES_FILE_PREFIX: actionexporter
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-handlers-repo}
+
+- name: case-api-apply-config
+  serial: true
+  serial_groups: [case-api]
+  plan:
+  - get: census-rm-kubernetes-microservices-repo
+  - get: case-api-docker-latest
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: case-api
+      KUBERNETES_SELECTOR: app=case-api
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: case-api
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
 - name: case-processor-apply-config
   serial: true
@@ -265,6 +294,28 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {docker-image-resource: actionexportersvc-docker-latest}
 
+- name: case-api-deploy-latest
+  serial: true
+  serial_groups: [case-api]
+  plan:
+  - get: census-rm-kubernetes-microservices-repo
+    passed: [case-api-apply-config]
+  - get: case-api-docker-latest
+    passed: [case-api-apply-config]
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: patch-to-pull-latest-image
+    file: census-rm-deploy/tasks/kubectl-patch-to-latest.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp-service-account-json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: case-api
+      KUBERNETES_SELECTOR: app=case-api
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {docker-image-resource: case-api-docker-latest}
+
 - name: case-processor-deploy-latest
   serial: true
   serial_groups: [case-processor]
@@ -356,7 +407,7 @@ jobs:
 
 - name: "Acceptance Tests"
   serial: true
-  serial_groups: [action-scheduler, actionexportersvc, case-processor, iacsvc, pubsubsvc]
+  serial_groups: [action-scheduler, actionexportersvc, case-api, case-processor, iacsvc, pubsubsvc]
   plan:
   - get: acceptance-tests-repo
   - get: acceptance-tests-docker-image
@@ -365,13 +416,17 @@ jobs:
   - get: census-rm-kubernetes-handlers-repo
     passed: [actionexportersvc-deploy-latest]
   - get: census-rm-kubernetes-microservices-repo
-    passed: [action-scheduler-deploy-latest, case-processor-deploy-latest, iacsvc-deploy-latest, pubsubsvc-deploy-latest]
+    passed: [action-scheduler-deploy-latest, case-api-deploy-latest, case-processor-deploy-latest, iacsvc-deploy-latest, pubsubsvc-deploy-latest]
   - get: action-scheduler-docker-latest
     passed: [action-scheduler-deploy-latest]
     params:
       skip_download: true
   - get: actionexportersvc-docker-latest
     passed: [actionexportersvc-deploy-latest]
+    params:
+      skip_download: true
+  - get: case-api-docker-latest
+    passed: [case-api-deploy-latest]
     params:
       skip_download: true
   - get: case-processor-docker-latest


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change adds the census-rm-case-api service to the Concourse deployment pipeline.

This PR was created off the back of [here](https://github.com/ONSdigital/census-rm-deploy/pull/17)

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* all pipelines updated with new case-api service

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Pipeline has already been fly'd-ed, so just need to merge this in 

~fly the pipeline and check the deployment is successful and the acceptance tests pass.~

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/Tg697scy/633-rmc-139-provide-case-look-up-for-cc-13#