### PR TITLE
Use the version of gcloud-kubectl from census-gcr

### DIFF
--- a/tasks/kubectl-apply-deployment.yml
+++ b/tasks/kubectl-apply-deployment.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: eu.gcr.io/census-ci/gcloud-kubectl
+    repository: eu.gcr.io/census-gcr/gcloud-kubectl
 
 params:
   SERVICE_ACCOUNT_JSON:

--- a/tasks/kubectl-apply-service-and-deploy.yml
+++ b/tasks/kubectl-apply-service-and-deploy.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: eu.gcr.io/census-ci/gcloud-kubectl
+    repository: eu.gcr.io/census-gcr/gcloud-kubectl
 
 params:
   SERVICE_ACCOUNT_JSON:

--- a/tasks/kubectl-patch-to-latest.yml
+++ b/tasks/kubectl-patch-to-latest.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: eu.gcr.io/census-ci/gcloud-kubectl
+    repository: eu.gcr.io/census-gcr/gcloud-kubectl
 
 params:
   SERVICE_ACCOUNT_JSON:


### PR DESCRIPTION
The goal is to only rely on images that we are happy have been built in-house.  This copy of `gcloud-kubectl` is built by a Concourse pipeline and pushed into a GCR that only Concourse has push permissions on (not Travis or individual users).