### PR TITLE
census-qid-batch-runner image change to trigger acceptance tests

### DIFF
--- a/pipelines/ci-kubernetes-pipeline.yml
+++ b/pipelines/ci-kubernetes-pipeline.yml
@@ -19,6 +19,12 @@ resources:
     uri: git@github.com:ONSdigital/census-rm-terraform.git
     private_key: ((github-private-key))
 
+- name: batch-runner-repo
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-qid-batch-runner.git
+    private_key: ((github-private-key))
+
 - name: census-rm-kubernetes-microservices-repo
   type: git
   source:
@@ -549,6 +555,7 @@ jobs:
     trigger: true
     passed: [action-scheduler-deploy-latest, actionexportersvc-deploy-latest, case-api-deploy-latest, case-processor-deploy-latest, iacsvc-deploy-latest, pubsubsvc-deploy-latest]
   - get: acceptance-tests-repo
+  - get: batch-runner-repo
   - get: acceptance-tests-docker-image
     trigger: true
     params:

--- a/pipelines/ci-kubernetes-pipeline.yml
+++ b/pipelines/ci-kubernetes-pipeline.yml
@@ -103,6 +103,12 @@ resources:
     username: _json_key
     password: ((gcp-service-account-json))
 
+- name: qid-batch-runner-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-qid-batch-runner
+    username: _json_key
+    password: ((gcp-service-account-json))
 
 jobs:
 
@@ -581,6 +587,10 @@ jobs:
   - get: pubsubsvc-docker-latest
     trigger: true
     passed: [pubsubsvc-deploy-latest]
+    params:
+      skip_download: true
+  - get: qid-batch-runner-docker-latest
+    trigger: true
     params:
       skip_download: true
   - task: "Run Acceptance Tests (in K8s)"

--- a/pipelines/dev-kubernetes-pipeline.yml
+++ b/pipelines/dev-kubernetes-pipeline.yml
@@ -19,6 +19,12 @@ resources:
     uri: git@github.com:ONSdigital/census-rm-terraform.git
     private_key: ((github-private-key))
 
+- name: batch-runner-repo
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-qid-batch-runner.git
+    private_key: ((github-private-key))
+
 - name: census-rm-kubernetes-microservices-repo
   type: git
   source:
@@ -550,6 +556,7 @@ jobs:
     trigger: true
     passed: [action-scheduler-deploy-latest, actionexportersvc-deploy-latest, case-api-deploy-latest, case-processor-deploy-latest, iacsvc-deploy-latest, pubsubsvc-deploy-latest]
   - get: acceptance-tests-repo
+  - get: batch-runner-repo
   - get: acceptance-tests-docker-image
     trigger: true
     params:

--- a/pipelines/dev-kubernetes-pipeline.yml
+++ b/pipelines/dev-kubernetes-pipeline.yml
@@ -103,6 +103,12 @@ resources:
     username: _json_key
     password: ((gcp-service-account-json))
 
+- name: qid-batch-runner-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-qid-batch-runner
+    username: _json_key
+    password: ((gcp-service-account-json))
 
 jobs:
 
@@ -582,6 +588,10 @@ jobs:
   - get: pubsubsvc-docker-latest
     trigger: true
     passed: [pubsubsvc-deploy-latest]
+    params:
+      skip_download: true
+  - get: qid-batch-runner-docker-latest
+    trigger: true
     params:
       skip_download: true
   - task: "Run Acceptance Tests (in K8s)"

--- a/pipelines/manual-ci-kubernetes-pipeline.yml
+++ b/pipelines/manual-ci-kubernetes-pipeline.yml
@@ -90,6 +90,13 @@ resources:
     username: _json_key
     password: ((gcp-service-account-json))
 
+- name: qid-batch-runner-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-qid-batch-runner
+    username: _json_key
+    password: ((gcp-service-account-json))
+
 jobs:
 
 # Kubernetes Config
@@ -439,6 +446,10 @@ jobs:
       skip_download: true
   - get: pubsubsvc-docker-latest
     passed: [pubsubsvc-deploy-latest]
+    params:
+      skip_download: true
+  - get: qid-batch-runner-docker-latest
+    trigger: true
     params:
       skip_download: true
   - task: "Run Acceptance Tests (in K8s)"

--- a/pipelines/manual-ci-kubernetes-pipeline.yml
+++ b/pipelines/manual-ci-kubernetes-pipeline.yml
@@ -456,7 +456,6 @@ jobs:
     params:
       skip_download: true
   - get: qid-batch-runner-docker-latest
-    trigger: true
     params:
       skip_download: true
   - task: "Run Acceptance Tests (in K8s)"

--- a/pipelines/manual-ci-kubernetes-pipeline.yml
+++ b/pipelines/manual-ci-kubernetes-pipeline.yml
@@ -13,6 +13,12 @@ resources:
     private_key: ((github-private-key))
     paths: [microservices/*]
 
+- name: batch-runner-repo
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-qid-batch-runner.git
+    private_key: ((github-private-key))
+
 - name: census-rm-kubernetes-handlers-repo
   type: git
   source:
@@ -417,6 +423,7 @@ jobs:
   serial_groups: [action-scheduler, actionexportersvc, case-api, case-processor, iacsvc, pubsubsvc]
   plan:
   - get: acceptance-tests-repo
+  - get: batch-runner-repo
   - get: acceptance-tests-docker-image
     params:
       skip_download: true


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to trigger the acceptance tests whenever the census-rm-qid-batch-loader image changes. 

See related changes for [acceptance tests](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/67) and [qid-batch-runner]()

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Updated the 3 pipeline configs

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
This has already been fly'd in CI. You should be able to see the `qid-batch-runner-docker-latest` resource just before the acceptance test job.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/tT4XZ09B/784-acceptance-tests-for-unaddressed-print-files-13