### PR TITLE
Revert "Fix filename prefix for new UAC service (#31)"

### DIFF
--- a/pipelines/ci-sit-kubernetes-pipeline.yml
+++ b/pipelines/ci-sit-kubernetes-pipeline.yml
@@ -299,7 +299,7 @@ jobs:
       KUBERNETES_DEPLOYMENT_NAME: uacqidservice
       KUBERNETES_SELECTOR: app=uacqidservice
       KUBERNETES_FILE_PATH: kubernetes-repo/microservices
-      KUBERNETES_FILE_PREFIX: uac-qid
+      KUBERNETES_FILE_PREFIX: uac-qid-service
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
@@ -571,7 +571,7 @@ jobs:
       KUBERNETES_DEPLOYMENT_NAME: uacqidservice
       KUBERNETES_SELECTOR: app=uacqidservice
       KUBERNETES_FILE_PATH: kubernetes-repo/microservices
-      KUBERNETES_FILE_PREFIX: uac-qid
+      KUBERNETES_FILE_PREFIX: uac-qid-service
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 


### PR DESCRIPTION
This reverts commit d11227570519e8fdb8bc1d8ee1d6c619b3a8b900.

Depends on changes from https://github.com/ONSdigital/census-rm-kubernetes/pull/72