### PR TITLE
Add print file service to CI pipelines and remove exporter

### DIFF
--- a/pipelines/ci-sit-kubernetes-pipeline.yml
+++ b/pipelines/ci-sit-kubernetes-pipeline.yml
@@ -32,13 +32,6 @@ resources:
     private_key: ((github.service_account_private_key))
     paths: [microservices/*]
 
-- name: census-rm-kubernetes-handlers-repo
-  type: git
-  source:
-    uri: git@github.com:ONSdigital/census-rm-kubernetes.git
-    private_key: ((github.service_account_private_key))
-    paths: [handlers/*]
-
 - name: census-rm-kubernetes-ops-repo
   type: git
   source:
@@ -64,13 +57,6 @@ resources:
   type: docker-image
   source:
     repository: eu.gcr.io/census-rm-ci/rm/census-rm-action-scheduler
-    username: _json_key
-    password: ((gcp.service_account_json))
-
-- name: actionexportersvc-docker-latest
-  type: docker-image
-  source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-actionexportersvc
     username: _json_key
     password: ((gcp.service_account_json))
 
@@ -116,13 +102,21 @@ resources:
     username: _json_key
     password: ((gcp.service_account_json))
 
+- name: print-file-service-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-print-file-service
+    username: _json_key
+    password: ((gcp.service_account_json))
+
+
 jobs:
 
 
 # CI
 - name: "CI Deploy Infrastructure"
   serial: true
-  serial_groups: [ci-action-scheduler, ci-actionexportersvc, ci-case-api, ci-case-processor, ci-uac-qid-service, ci-ops-tool, ci-pubsubsvc]
+  serial_groups: [ci-action-scheduler, ci-case-api, ci-case-processor, ci-uac-qid-service, ci-ops-tool, ci-pubsubsvc, ci-print-file-service]
   max_in_flight: 1
   plan:
   - get: census-rm-terraform
@@ -194,33 +188,6 @@ jobs:
       KUBERNETES_FILE_PREFIX: action-scheduler
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
-
-- name: "CI Deploy Actionexporter"
-  serial: true
-  serial_groups: [ci-actionexportersvc]
-  plan:
-  - get: census-rm-terraform
-    trigger: true
-    passed: ["CI Deploy Infrastructure"]
-  - get: census-rm-kubernetes-handlers-repo
-    trigger: true
-  - get: actionexportersvc-docker-latest
-    trigger: true
-    params:
-      skip_download: true
-  - get: census-rm-deploy
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((ci-gcp-project-name))
-      KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: actionexportersvc
-      KUBERNETES_SELECTOR: app=actionexportersvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/handlers
-      KUBERNETES_FILE_PREFIX: actionexporter
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-handlers-repo}
 
 - name: "CI Deploy Case-API"
   serial: true
@@ -357,42 +324,62 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-ops-repo}
 
+- name: "CI Deploy Print File Service"
+  serial: true
+  serial_groups: [ci-print-file-service]
+  plan:
+  - get: census-rm-terraform
+    trigger: true
+    passed: ["CI Deploy Infrastructure"]
+  - get: census-rm-kubernetes-microservices-repo
+    trigger: true
+  - get: print-file-service-docker-latest
+    trigger: true
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((ci-gcp-project-name))
+      KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: printfilesvc
+      KUBERNETES_SELECTOR: app=printfilesvc
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: print-file-service
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+
 - name: "CI Acceptance Tests"
   serial: true
-  serial_groups: [ci-action-scheduler, ci-actionexportersvc, ci-case-api, ci-case-processor, ci-uac-qid-service, ci-pubsubsvc]
+  serial_groups: [ci-action-scheduler, ci-case-api, ci-case-processor, ci-uac-qid-service, ci-pubsubsvc, ci-print-file-service]
   plan:
   - get: census-rm-terraform
     trigger: true
     passed: ["CI Deploy Action-Scheduler", 
-             "CI Deploy Actionexporter", 
              "CI Deploy Case-API", 
              "CI Deploy Case-Processor", 
              "CI Deploy UAC QID Service", 
-             "CI Deploy PubSub Service"]
+             "CI Deploy PubSub Service",
+             "CI Deploy Print File Service"]
   - get: acceptance-tests-repo
   - get: batch-runner-repo
   - get: acceptance-tests-docker-image
     trigger: true
     params:
       skip_download: true
-  - get: census-rm-kubernetes-handlers-repo
-    trigger: true
-    passed: ["CI Deploy Actionexporter"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Deploy Action-Scheduler", 
              "CI Deploy Case-API", 
              "CI Deploy Case-Processor", 
              "CI Deploy UAC QID Service", 
-             "CI Deploy PubSub Service"]
+             "CI Deploy PubSub Service",
+             "CI Deploy Print File Service"]
   - get: action-scheduler-docker-latest
     trigger: true
     passed: ["CI Deploy Action-Scheduler"]
-    params:
-      skip_download: true
-  - get: actionexportersvc-docker-latest
-    trigger: true
-    passed: ["CI Deploy Actionexporter"]
     params:
       skip_download: true
   - get: case-api-docker-latest
@@ -417,6 +404,11 @@ jobs:
       skip_download: true
   - get: qid-batch-runner-docker-latest
     trigger: true
+    params:
+      skip_download: true
+  - get: print-file-service-docker-latest
+    trigger: true
+    passed: ["CI Deploy Print File Service"]
     params:
       skip_download: true
   - task: "Run Acceptance Tests (in K8s)"
@@ -459,17 +451,17 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
-- name: "SIT Deploy Actionexporter"
+- name: "SIT Deploy Print File Service"
   serial: true
-  serial_groups: [sit-actionexportersvc]
+  serial_groups: [sit-print-file-service]
   plan:
   - get: census-rm-terraform
     trigger: true
     passed: ["CI Acceptance Tests"]
-  - get: census-rm-kubernetes-handlers-repo
+  - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
-  - get: actionexportersvc-docker-latest
+  - get: print-file-service-docker-latest
     trigger: true
     passed: ["CI Acceptance Tests"]
     params:
@@ -481,12 +473,12 @@ jobs:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((sit-gcp-project-name))
       KUBERNETES_CLUSTER: ((sit-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: actionexportersvc
-      KUBERNETES_SELECTOR: app=actionexportersvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/handlers
-      KUBERNETES_FILE_PREFIX: actionexporter
+      KUBERNETES_DEPLOYMENT_NAME: printfilesvc
+      KUBERNETES_SELECTOR: app=printfilesvc
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: print-file-service
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-handlers-repo}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
 - name: "SIT Deploy Case-API"
   serial: true

--- a/pipelines/dev-kubernetes-pipeline.yml
+++ b/pipelines/dev-kubernetes-pipeline.yml
@@ -32,13 +32,6 @@ resources:
     private_key: ((github.service_account_private_key))
     paths: [microservices/*]
 
-- name: census-rm-kubernetes-handlers-repo
-  type: git
-  source:
-    uri: git@github.com:ONSdigital/census-rm-kubernetes.git
-    private_key: ((github.service_account_private_key))
-    paths: [handlers/*]
-
 - name: census-rm-kubernetes-ops-repo
   type: git
   source:
@@ -64,13 +57,6 @@ resources:
   type: docker-image
   source:
     repository: eu.gcr.io/census-rm-ci/rm/census-rm-action-scheduler
-    username: _json_key
-    password: ((gcp.service_account_json))
-
-- name: actionexportersvc-docker-latest
-  type: docker-image
-  source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-actionexportersvc
     username: _json_key
     password: ((gcp.service_account_json))
 
@@ -116,12 +102,20 @@ resources:
     username: _json_key
     password: ((gcp.service_account_json))
 
+- name: print-file-service-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-print-file-service
+    username: _json_key
+    password: ((gcp.service_account_json))
+
+
 jobs:
 
 
 - name: deploy-infrastructure
   serial: true
-  serial_groups: [action-scheduler, actionexportersvc, case-api, case-processor, uac-qid-service, ops, pubsubsvc]
+  serial_groups: [action-scheduler, case-api, case-processor, uac-qid-service, ops, pubsubsvc, print-file-service]
   max_in_flight: 1
   plan:
   - get: census-rm-terraform
@@ -196,33 +190,6 @@ jobs:
       KUBERNETES_FILE_PREFIX: action-scheduler
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
-
-- name: actionexportersvc
-  serial: true
-  serial_groups: [actionexportersvc]
-  plan:
-  - get: census-rm-terraform
-    trigger: true
-    passed: [deploy-infrastructure]
-  - get: census-rm-kubernetes-handlers-repo
-    trigger: true
-  - get: actionexportersvc-docker-latest
-    trigger: true
-    params:
-      skip_download: true
-  - get: census-rm-deploy
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: actionexportersvc
-      KUBERNETES_SELECTOR: app=actionexportersvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/handlers
-      KUBERNETES_FILE_PREFIX: actionexporter
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-handlers-repo}
 
 - name: case-api
   serial: true
@@ -332,6 +299,33 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
+- name: print-file-service
+  serial: true
+  serial_groups: [print-file-service]
+  plan:
+  - get: census-rm-terraform
+    trigger: true
+    passed: [deploy-infrastructure]
+  - get: census-rm-kubernetes-microservices-repo
+    trigger: true
+  - get: print-file-service-docker-latest
+    trigger: true
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((ci-gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: printfilesvc
+      KUBERNETES_SELECTOR: app=printfilesvc
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: print-file-service
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+
 - name: ops
   serial: true
   serial_groups: [ops]
@@ -361,31 +355,23 @@ jobs:
 
 - name: "Acceptance Tests"
   serial: true
-  serial_groups: [action-scheduler, actionexportersvc, case-api, case-processor, uac-qid-service, pubsubsvc]
+  serial_groups: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service]
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: [action-scheduler, actionexportersvc, case-api, case-processor, uac-qid-service, pubsubsvc]
+    passed: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service]
   - get: acceptance-tests-repo
   - get: batch-runner-repo
   - get: acceptance-tests-docker-image
     trigger: true
     params:
       skip_download: true
-  - get: census-rm-kubernetes-handlers-repo
-    trigger: true
-    passed: [actionexportersvc]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
-    passed: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc]
+    passed: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service]
   - get: action-scheduler-docker-latest
     trigger: true
     passed: [action-scheduler]
-    params:
-      skip_download: true
-  - get: actionexportersvc-docker-latest
-    trigger: true
-    passed: [actionexportersvc]
     params:
       skip_download: true
   - get: case-api-docker-latest
@@ -409,6 +395,10 @@ jobs:
     params:
       skip_download: true
   - get: qid-batch-runner-docker-latest
+    trigger: true
+    params:
+      skip_download: true
+  - get: print-file-service-docker-latest
     trigger: true
     params:
       skip_download: true

--- a/pipelines/docker-build-pipeline.yml
+++ b/pipelines/docker-build-pipeline.yml
@@ -1,11 +1,5 @@
 resources:
 
-  - name: actionexporter-master
-    type: git
-    source:
-      uri: git@github.com:ONSdigital/census-rm-actionexporter-service.git
-      private_key: ((github.service_account_private_key))
-
   - name: action-scheduler-master
     type: git
     source:
@@ -66,20 +60,6 @@ resources:
       uri: git@github.com:ONSdigital/census-rm-acceptance-tests.git
       private_key: ((github.service_account_private_key))
 
-
-  - name: actionexporter-docker-image-ci
-    type: docker-image
-    source:
-      repository: ((docker-registry-ci))/rm/census-rm-actionexporter
-      username: _json_key
-      password: ((gcp.service_account_json))
-
-  - name: actionexporter-docker-image-gcr
-    type: docker-image
-    source:
-      repository: ((docker-registry-gcr))/rm/census-rm-actionexporter
-      username: _json_key
-      password: ((gcp.service_account_json))
 
   - name: action-scheduler-docker-image-ci
     type: docker-image
@@ -222,48 +202,6 @@ resources:
       password: ((gcp.service_account_json))
 
 jobs:
-
-  - name: build-actionexporter-master
-    plan:
-    - get: actionexporter-master
-      trigger: true
-    - task: Build Action Exporter Image (master)
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: adoptopenjdk/maven-openjdk8
-        inputs:
-          - name: actionexporter-master
-        outputs:
-          - name: build
-        run:
-          path: sh
-          args:
-            - -exc
-            - |
-              mkdir -p build/target
-              cd actionexporter-master
-              mvn package -DskipITs -Ddockerfile.skip
-              cp target/census-rm-*.jar ../build/target
-              cp Dockerfile ../build
-    - put: actionexporter-docker-image-ci
-      params:
-        build: build
-        tag_file: actionexporter-master/.git/ref
-        tag_as_latest: true
-      get_params:
-        save: true
-    - put: actionexporter-docker-image-gcr
-      params:
-        build: build
-        cache_from: 
-          - actionexporter-docker-image-ci
-        tag_file: actionexporter-master/.git/ref
-        tag_as_latest: true
-      get_params:
-        skip_download: true
 
   - name: build-action-scheduler-master
     plan:

--- a/pipelines/docker-release-pipeline.yml
+++ b/pipelines/docker-release-pipeline.yml
@@ -8,14 +8,6 @@ resource_types:
 
 resources:
 
-  - name: actionexporter-release
-    type: github-release-latest
-    source:
-      owner: ONSdigital
-      repository: census-rm-actionexporter-service
-      access_token: ((github.access_token))
-      order_by: time
-
   - name: action-scheduler-release
     type: github-release-latest
     source:
@@ -88,20 +80,6 @@ resources:
       access_token: ((github.access_token))
       order_by: time
 
-
-  - name: actionexporter-docker-image-ci
-    type: docker-image
-    source:
-      repository: ((docker-registry-ci))/rm/census-rm-actionexporter
-      username: _json_key
-      password: ((gcp.service_account_json))
-
-  - name: actionexporter-docker-image-gcr
-    type: docker-image
-    source:
-      repository: ((docker-registry-gcr))/rm/census-rm-actionexporter
-      username: _json_key
-      password: ((gcp.service_account_json))
 
   - name: action-scheduler-docker-image-ci
     type: docker-image
@@ -231,52 +209,6 @@ resources:
 
 
 jobs:
-
-  - name: build-actionexporter-release
-    plan:
-    - get: actionexporter-release
-      trigger: true
-    - task: Build Action Exporter Image (release)
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: adoptopenjdk/maven-openjdk8
-        inputs:
-          - name: actionexporter-release
-        outputs:
-          - name: build
-          - name: extracted-actionexporter
-        run:
-          path: sh
-          args:
-            - -exc
-            - |
-              mkdir -p build/target
-              cd actionexporter-release
-              tar -xzf source.tar.gz -C ../extracted-actionexporter --strip-components=1
-              cd ../extracted-actionexporter
-              mvn package -DskipITs -Ddockerfile.skip
-              cp target/census-rm-*.jar ../build/target
-              cp Dockerfile ../build
-              cp healthcheck.sh ../build
-    - put: actionexporter-docker-image-ci
-      params:
-        build: build
-        tag_file: actionexporter-release/tag
-        tag_as_latest: false
-      get_params:
-        save: true
-    - put: actionexporter-docker-image-gcr
-      params:
-        build: build
-        cache_from:
-          - actionexporter-docker-image-ci
-        tag_file: actionexporter-release/tag
-        tag_as_latest: false
-      get_params:
-        skip_download: true
 
   - name: build-action-scheduler-release
     plan:

--- a/pipelines/manual-ci-kubernetes-pipeline.yml
+++ b/pipelines/manual-ci-kubernetes-pipeline.yml
@@ -19,13 +19,6 @@ resources:
     uri: git@github.com:ONSdigital/census-rm-qid-batch-runner.git
     private_key: ((github.service_account_private_key))
 
-- name: census-rm-kubernetes-handlers-repo
-  type: git
-  source:
-    uri: git@github.com:ONSdigital/census-rm-kubernetes.git
-    private_key: ((github.service_account_private_key))
-    paths: [handlers/*]
-
 - name: census-rm-kubernetes-ops-repo
   type: git
   source:
@@ -51,13 +44,6 @@ resources:
   type: docker-image
   source:
     repository: eu.gcr.io/census-rm-ci/rm/census-rm-action-scheduler
-    username: _json_key
-    password: ((gcp.service_account_json))
-
-- name: actionexportersvc-docker-latest
-  type: docker-image
-  source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-actionexportersvc
     username: _json_key
     password: ((gcp.service_account_json))
 
@@ -103,6 +89,14 @@ resources:
     username: _json_key
     password: ((gcp.service_account_json))
 
+- name: print-file-service-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-rm-ci/rm/census-rm-print-file-service
+    username: _json_key
+    password: ((gcp.service_account_json))
+
+
 jobs:
 
 # Kubernetes Config
@@ -129,28 +123,6 @@ jobs:
       KUBERNETES_FILE_PREFIX: action-scheduler
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
-
-- name: actionexportersvc
-  serial: true
-  serial_groups: [actionexportersvc]
-  plan:
-  - get: census-rm-kubernetes-handlers-repo
-  - get: actionexportersvc-docker-latest
-    params:
-      skip_download: true
-  - get: census-rm-deploy
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: actionexportersvc
-      KUBERNETES_SELECTOR: app=actionexportersvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/handlers
-      KUBERNETES_FILE_PREFIX: actionexporter
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-handlers-repo}
 
 - name: case-api
   serial: true
@@ -262,25 +234,42 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-ops-repo}
 
+- name: print-file-service
+  serial: true
+  serial_groups: [print-file-service]
+  plan:
+  - get: census-rm-kubernetes-microservices-repo
+  - get: print-file-service-docker-latest
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: printfilesvc
+      KUBERNETES_SELECTOR: app=printfilesvc
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: print-file-service
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+
+
 - name: "Acceptance Tests"
   serial: true
-  serial_groups: [action-scheduler, actionexportersvc, case-api, case-processor, uac-qid-service, pubsubsvc]
+  serial_groups: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service]
   plan:
   - get: acceptance-tests-repo
   - get: batch-runner-repo
   - get: acceptance-tests-docker-image
     params:
       skip_download: true
-  - get: census-rm-kubernetes-handlers-repo
-    passed: [actionexportersvc]
   - get: census-rm-kubernetes-microservices-repo
-    passed: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc]
+    passed: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service]
   - get: action-scheduler-docker-latest
     passed: [action-scheduler]
-    params:
-      skip_download: true
-  - get: actionexportersvc-docker-latest
-    passed: [actionexportersvc]
     params:
       skip_download: true
   - get: case-api-docker-latest
@@ -300,6 +289,9 @@ jobs:
     params:
       skip_download: true
   - get: qid-batch-runner-docker-latest
+    params:
+      skip_download: true
+  - get: print-file-service-docker-latest
     params:
       skip_download: true
   - task: "Run Acceptance Tests (in K8s)"


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It's high time to kill the action exporter service dead.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added print file service to dev, CI, and manual deployment pipelines
- Removed action exporter references
