### PR TITLE
Patch CI and lodge environments to use images pushed to gcr-rm

### DIFF
--- a/pipelines/ci-sit-kubernetes-pipeline.yml
+++ b/pipelines/ci-sit-kubernetes-pipeline.yml
@@ -49,28 +49,28 @@ resources:
 - name: acceptance-tests-docker-image
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-acceptance-tests
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-acceptance-tests
     username: _json_key
     password: ((gcp.service_account_json))
 
 - name: action-scheduler-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-action-scheduler
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-action-scheduler
     username: _json_key
     password: ((gcp.service_account_json))
 
 - name: case-api-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-case-api
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-case-api
     username: _json_key
     password: ((gcp.service_account_json))
 
 - name: case-processor-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-case-processor
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-case-processor
     username: _json_key
     password: ((gcp.service_account_json))
 
@@ -84,28 +84,28 @@ resources:
 - name: pubsubsvc-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-pubsub
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-pubsub
     username: _json_key
     password: ((gcp.service_account_json))
 
 - name: ops-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-ops
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-ops
     username: _json_key
     password: ((gcp.service_account_json))
 
 - name: qid-batch-runner-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-qid-batch-runner
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-qid-batch-runner
     username: _json_key
     password: ((gcp.service_account_json))
 
 - name: print-file-service-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-print-file-service
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-print-file-service
     username: _json_key
     password: ((gcp.service_account_json))
 
@@ -130,6 +130,7 @@ jobs:
         source:
           repository: google/cloud-sdk
       params:
+        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         AUTO_APPLY: true
         DEV_DUMMY_PGP: true
         DEV_PUBSUB: true
@@ -137,7 +138,7 @@ jobs:
         ENV: ((ci-gcp-environment-name))
         GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json
         KEEP_TMP_K8S: true
-        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+        SKIP_DEPLOYMENTS: true
       inputs:
         - name: census-rm-terraform
         - name: census-rm-kubernetes-repo

--- a/pipelines/manual-ci-kubernetes-pipeline.yml
+++ b/pipelines/manual-ci-kubernetes-pipeline.yml
@@ -36,63 +36,63 @@ resources:
 - name: acceptance-tests-docker-image
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-acceptance-tests
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-acceptance-tests
     username: _json_key
     password: ((gcp.service_account_json))
 
 - name: action-scheduler-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-action-scheduler
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-action-scheduler
     username: _json_key
     password: ((gcp.service_account_json))
 
 - name: case-api-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-case-api
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-case-api
     username: _json_key
     password: ((gcp.service_account_json))
 
 - name: case-processor-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-case-processor
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-case-processor
     username: _json_key
     password: ((gcp.service_account_json))
 
 - name: uac-qid-service-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-uac-qid-service
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-uac-qid-service
     username: _json_key
     password: ((gcp.service_account_json))
 
 - name: pubsubsvc-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-pubsub
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-pubsub
     username: _json_key
     password: ((gcp.service_account_json))
 
 - name: ops-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-ops
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-ops
     username: _json_key
     password: ((gcp.service_account_json))
 
 - name: qid-batch-runner-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-qid-batch-runner
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-qid-batch-runner
     username: _json_key
     password: ((gcp.service_account_json))
 
 - name: print-file-service-docker-latest
   type: docker-image
   source:
-    repository: eu.gcr.io/census-rm-ci/rm/census-rm-print-file-service
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-print-file-service
     username: _json_key
     password: ((gcp.service_account_json))
 

--- a/tasks/kubectl-apply-deployment.yml
+++ b/tasks/kubectl-apply-deployment.yml
@@ -6,13 +6,13 @@ image_resource:
     repository: eu.gcr.io/census-gcr/gcloud-kubectl
 
 params:
-  SERVICE_ACCOUNT_JSON:
-  KUBERNETES_CLUSTER:
   GCP_PROJECT_NAME:
+  KUBERNETES_CLUSTER:
   KUBERNETES_DEPLOYMENT_NAME:
-  KUBERNETES_SELECTOR:
   KUBERNETES_FILE_PATH:
   KUBERNETES_FILE_PREFIX:
+  KUBERNETES_SELECTOR:
+  SERVICE_ACCOUNT_JSON:
   WAIT_UNTIL_AVAILABLE_TIMEOUT:
 
 inputs:
@@ -32,6 +32,9 @@ run:
 
       # Apply deployment config
       kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-deployment.yml --record
+
+      # Patch deployment to use docker image specified in pipeline rather than deployment script
+      kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "$(cat docker-image-resource/repository)"}]' --record
 
       # Patch deployment with timestamp/image digest to force pod recreation
       kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"timestamp\":\"`date +'%s'`\",\"image-digest\":\"$(cat docker-image-resource/digest | cut -d':' -f2 | cut -c1-60)\"}}}}}" --record

--- a/tasks/kubectl-apply-service-and-deploy.yml
+++ b/tasks/kubectl-apply-service-and-deploy.yml
@@ -6,13 +6,13 @@ image_resource:
     repository: eu.gcr.io/census-gcr/gcloud-kubectl
 
 params:
-  SERVICE_ACCOUNT_JSON:
-  KUBERNETES_CLUSTER:
   GCP_PROJECT_NAME:
+  KUBERNETES_CLUSTER:
   KUBERNETES_DEPLOYMENT_NAME:
-  KUBERNETES_SELECTOR:
   KUBERNETES_FILE_PATH:
   KUBERNETES_FILE_PREFIX:
+  KUBERNETES_SELECTOR:
+  SERVICE_ACCOUNT_JSON:
   WAIT_UNTIL_AVAILABLE_TIMEOUT:
 
 inputs:
@@ -35,6 +35,9 @@ run:
 
       # Apply deployment config
       kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-deployment.yml --record
+
+      # Patch deployment to use docker image specified in pipeline rather than deployment script
+      kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "$(cat docker-image-resource/repository)"}]' --record
 
       # Patch deployment with timestamp/image digest to force pod recreation
       kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"timestamp\":\"`date +'%s'`\",\"image-digest\":\"$(cat docker-image-resource/digest | cut -d':' -f2 | cut -c1-60)\"}}}}}" --record


### PR DESCRIPTION
The default for the deployment scripts in our [k8s repo](https://github.com/ONSdigital/census-rm-kubernetes) is to use images pushed to `eu.gcr.io/census-rm-ci/rm/`. There is a requirement to use  images pushed to `eu.gcr.io/census-gcr-rm/rm/` in CI and the lodges environments.