### PR TITLE
Point blacklodge pipeline at version-1 config

### DIFF
--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
             gcp-project-name: census-rm-blacklodge
             kubernetes-cluster-name: rm-k8s-cluster
             acceptance-tests-image: eu.gcr.io/census-gcr-rm/rm/census-rm-acceptance-tests:latest
-            release-directory: releases/version-0
+            release-directory: releases/version-1
 
         - name: build-images
           team: rm

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
             gcp-project-name: census-rm-blacklodge
             kubernetes-cluster-name: rm-k8s-cluster
             acceptance-tests-image: eu.gcr.io/census-gcr-rm/rm/census-rm-acceptance-tests:latest
-            release-directory: releases/version-1
+            kubernetes-release: v1.0.0
 
         - name: build-images
           team: rm

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -61,6 +61,7 @@ jobs:
             gcp-project-name: census-rm-blacklodge
             kubernetes-cluster-name: rm-k8s-cluster
             acceptance-tests-image: eu.gcr.io/census-gcr-rm/rm/census-rm-acceptance-tests:latest
+            kubernetes-environment-directory: blacklodge
 
         - name: build-images
           team: rm

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
             gcp-project-name: census-rm-blacklodge
             kubernetes-cluster-name: rm-k8s-cluster
             acceptance-tests-image: eu.gcr.io/census-gcr-rm/rm/census-rm-acceptance-tests:latest
-            kubernetes-environment-directory: blacklodge
+            release-directory: releases/version-0
 
         - name: build-images
           team: rm

--- a/pipelines/manual-ci-kubernetes-pipeline.yml
+++ b/pipelines/manual-ci-kubernetes-pipeline.yml
@@ -186,7 +186,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: uacqidservice
       KUBERNETES_SELECTOR: app=uacqidservice
-      KUBERNETES_FILE_PATH: kubernetes-repo/((kubernetes-releases-directory))
+      KUBERNETES_FILE_PATH: kubernetes-repo/((release-directory))/microservices
       KUBERNETES_FILE_PREFIX: uac-qid-service
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s

--- a/pipelines/manual-ci-kubernetes-pipeline.yml
+++ b/pipelines/manual-ci-kubernetes-pipeline.yml
@@ -117,7 +117,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: action-scheduler
       KUBERNETES_SELECTOR: app=action-scheduler
-      KUBERNETES_FILE_PATH: kubernetes-repo/prod
+      KUBERNETES_FILE_PATH: kubernetes-repo/((kubernetes-environment-directory))
       KUBERNETES_FILE_PREFIX: action-scheduler
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -140,7 +140,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: case-api
       KUBERNETES_SELECTOR: app=case-api
-      KUBERNETES_FILE_PATH: kubernetes-repo/prod
+      KUBERNETES_FILE_PATH: kubernetes-repo/((kubernetes-environment-directory))
       KUBERNETES_FILE_PREFIX: case-api
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -163,7 +163,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: case-processor
       KUBERNETES_SELECTOR: app=case-processor
-      KUBERNETES_FILE_PATH: kubernetes-repo/prod
+      KUBERNETES_FILE_PATH: kubernetes-repo/((kubernetes-environment-directory))
       KUBERNETES_FILE_PREFIX: case-processor
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -186,7 +186,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: uacqidservice
       KUBERNETES_SELECTOR: app=uacqidservice
-      KUBERNETES_FILE_PATH: kubernetes-repo/prod
+      KUBERNETES_FILE_PATH: kubernetes-repo/((kubernetes-environment-directory))
       KUBERNETES_FILE_PREFIX: uac-qid-service
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -209,7 +209,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: pubsubsvc
       KUBERNETES_SELECTOR: app=pubsubsvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/prod
+      KUBERNETES_FILE_PATH: kubernetes-repo/((kubernetes-environment-directory))
       KUBERNETES_FILE_PREFIX: pubsub
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -254,7 +254,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_STATEFULSET_NAME: printfilesvc
       KUBERNETES_SELECTOR: app=printfilesvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/prod
+      KUBERNETES_FILE_PATH: kubernetes-repo/((kubernetes-environment-directory))
       KUBERNETES_FILE_PREFIX: print-file-service
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s

--- a/pipelines/manual-ci-kubernetes-pipeline.yml
+++ b/pipelines/manual-ci-kubernetes-pipeline.yml
@@ -11,7 +11,8 @@ resources:
   source:
     uri: git@github.com:ONSdigital/census-rm-kubernetes.git
     private_key: ((github.service_account_private_key))
-    paths: [((release-directory))/microservices/*]
+    paths: [release/microservices/*]
+    tag_filter: ((kubernetes-release))
 
 - name: batch-runner-repo
   type: git
@@ -24,7 +25,8 @@ resources:
   source:
     uri: git@github.com:ONSdigital/census-rm-kubernetes.git
     private_key: ((github.service_account_private_key))
-    paths: [optional/ops-*]
+    paths: [release/optional/ops-*]
+    tag_filter: ((kubernetes-release))
 
 - name: acceptance-tests-repo
   type: git
@@ -117,7 +119,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: action-scheduler
       KUBERNETES_SELECTOR: app=action-scheduler
-      KUBERNETES_FILE_PATH: kubernetes-repo/((release-directory))/microservices
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: action-scheduler
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -140,7 +142,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: case-api
       KUBERNETES_SELECTOR: app=case-api
-      KUBERNETES_FILE_PATH: kubernetes-repo/((release-directory))/microservices
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: case-api
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -163,7 +165,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: case-processor
       KUBERNETES_SELECTOR: app=case-processor
-      KUBERNETES_FILE_PATH: kubernetes-repo/((release-directory))/microservices
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: case-processor
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -186,7 +188,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: uacqidservice
       KUBERNETES_SELECTOR: app=uacqidservice
-      KUBERNETES_FILE_PATH: kubernetes-repo/((release-directory))/microservices
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: uac-qid-service
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -209,7 +211,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: pubsubsvc
       KUBERNETES_SELECTOR: app=pubsubsvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/((release-directory))/microservices
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: pubsub
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -232,7 +234,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: ops
       KUBERNETES_SELECTOR: app=ops
-      KUBERNETES_FILE_PATH: kubernetes-repo/optional
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       KUBERNETES_FILE_PREFIX: ops
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-ops-repo}
@@ -254,7 +256,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_STATEFULSET_NAME: printfilesvc
       KUBERNETES_SELECTOR: app=printfilesvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/((release-directory))/microservices
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: print-file-service
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s

--- a/pipelines/manual-ci-kubernetes-pipeline.yml
+++ b/pipelines/manual-ci-kubernetes-pipeline.yml
@@ -11,7 +11,7 @@ resources:
   source:
     uri: git@github.com:ONSdigital/census-rm-kubernetes.git
     private_key: ((github.service_account_private_key))
-    paths: [microservices/*]
+    paths: [((release-directory))/microservices/*]
 
 - name: batch-runner-repo
   type: git
@@ -117,7 +117,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: action-scheduler
       KUBERNETES_SELECTOR: app=action-scheduler
-      KUBERNETES_FILE_PATH: kubernetes-repo/((kubernetes-environment-directory))
+      KUBERNETES_FILE_PATH: kubernetes-repo/((release-directory))/microservices
       KUBERNETES_FILE_PREFIX: action-scheduler
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -140,7 +140,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: case-api
       KUBERNETES_SELECTOR: app=case-api
-      KUBERNETES_FILE_PATH: kubernetes-repo/((kubernetes-environment-directory))
+      KUBERNETES_FILE_PATH: kubernetes-repo/((release-directory))/microservices
       KUBERNETES_FILE_PREFIX: case-api
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -163,7 +163,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: case-processor
       KUBERNETES_SELECTOR: app=case-processor
-      KUBERNETES_FILE_PATH: kubernetes-repo/((kubernetes-environment-directory))
+      KUBERNETES_FILE_PATH: kubernetes-repo/((release-directory))/microservices
       KUBERNETES_FILE_PREFIX: case-processor
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -186,7 +186,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: uacqidservice
       KUBERNETES_SELECTOR: app=uacqidservice
-      KUBERNETES_FILE_PATH: kubernetes-repo/((kubernetes-environment-directory))
+      KUBERNETES_FILE_PATH: kubernetes-repo/((kubernetes-releases-directory))
       KUBERNETES_FILE_PREFIX: uac-qid-service
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -209,7 +209,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: pubsubsvc
       KUBERNETES_SELECTOR: app=pubsubsvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/((kubernetes-environment-directory))
+      KUBERNETES_FILE_PATH: kubernetes-repo/((release-directory))/microservices
       KUBERNETES_FILE_PREFIX: pubsub
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -254,7 +254,7 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_STATEFULSET_NAME: printfilesvc
       KUBERNETES_SELECTOR: app=printfilesvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/((kubernetes-environment-directory))
+      KUBERNETES_FILE_PATH: kubernetes-repo/((release-directory))/microservices
       KUBERNETES_FILE_PREFIX: print-file-service
       SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s

--- a/pipelines/manual-ci-kubernetes-pipeline.yml
+++ b/pipelines/manual-ci-kubernetes-pipeline.yml
@@ -105,9 +105,7 @@ jobs:
   serial_groups: [action-scheduler]
   plan:
   - get: census-rm-kubernetes-microservices-repo
-    
   - get: action-scheduler-docker-latest
-    
     params:
       skip_download: true
   - get: census-rm-deploy
@@ -119,8 +117,9 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: action-scheduler
       KUBERNETES_SELECTOR: app=action-scheduler
-      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PATH: kubernetes-repo/prod
       KUBERNETES_FILE_PREFIX: action-scheduler
+      SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
@@ -141,8 +140,9 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: case-api
       KUBERNETES_SELECTOR: app=case-api
-      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PATH: kubernetes-repo/prod
       KUBERNETES_FILE_PREFIX: case-api
+      SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
@@ -163,8 +163,9 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: case-processor
       KUBERNETES_SELECTOR: app=case-processor
-      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PATH: kubernetes-repo/prod
       KUBERNETES_FILE_PREFIX: case-processor
+      SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
@@ -185,8 +186,9 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: uacqidservice
       KUBERNETES_SELECTOR: app=uacqidservice
-      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PATH: kubernetes-repo/prod
       KUBERNETES_FILE_PREFIX: uac-qid-service
+      SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
@@ -207,8 +209,9 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: pubsubsvc
       KUBERNETES_SELECTOR: app=pubsubsvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PATH: kubernetes-repo/prod
       KUBERNETES_FILE_PREFIX: pubsub
+      SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
@@ -251,8 +254,9 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_STATEFULSET_NAME: printfilesvc
       KUBERNETES_SELECTOR: app=printfilesvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PATH: kubernetes-repo/prod
       KUBERNETES_FILE_PREFIX: print-file-service
+      SKIP_IMAGE_PATCH: true
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 

--- a/tasks/kubectl-apply-deployment.yml
+++ b/tasks/kubectl-apply-deployment.yml
@@ -13,6 +13,7 @@ params:
   KUBERNETES_FILE_PREFIX:
   KUBERNETES_SELECTOR:
   SERVICE_ACCOUNT_JSON:
+  SKIP_IMAGE_PATCH:
   WAIT_UNTIL_AVAILABLE_TIMEOUT:
 
 inputs:
@@ -34,8 +35,10 @@ run:
       # Apply deployment config
       kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-deployment.yml --record
 
-      # Patch deployment to use docker image specified in pipeline rather than deployment script
-      kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} --type='json' -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/image\",\"value\":\"$(cat docker-image-resource/repository)\"}]" --record
+      if [ -z "$SKIP_IMAGE_PATCH" ]; then
+        # Patch deployment to use docker image specified in pipeline rather than deployment script
+        kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} --type='json' -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/image\",\"value\":\"$(cat docker-image-resource/repository)\"}]" --record
+      fi
 
       # Patch deployment with timestamp/image digest to force pod recreation
       kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"timestamp\":\"`date +'%s'`\",\"image-digest\":\"$(cat docker-image-resource/digest | cut -d':' -f2 | cut -c1-60)\"}}}}}" --record

--- a/tasks/kubectl-apply-service-and-deploy.yml
+++ b/tasks/kubectl-apply-service-and-deploy.yml
@@ -13,6 +13,7 @@ params:
   KUBERNETES_FILE_PREFIX:
   KUBERNETES_SELECTOR:
   SERVICE_ACCOUNT_JSON:
+  SKIP_IMAGE_PATCH:
   WAIT_UNTIL_AVAILABLE_TIMEOUT:
 
 inputs:
@@ -37,8 +38,10 @@ run:
       # Apply deployment config
       kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-deployment.yml --record
 
-      # Patch deployment to use docker image specified in pipeline rather than deployment script
-      kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} --type='json' -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/image\",\"value\":\"$(cat docker-image-resource/repository)\"}]" --record
+      if [ -z "$SKIP_IMAGE_PATCH" ]; then
+        # Patch deployment to use docker image specified in pipeline rather than deployment script
+        kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} --type='json' -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/image\",\"value\":\"$(cat docker-image-resource/repository)\"}]" --record
+      fi
 
       # Patch deployment with timestamp/image digest to force pod recreation
       kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"timestamp\":\"`date +'%s'`\",\"image-digest\":\"$(cat docker-image-resource/digest | cut -d':' -f2 | cut -c1-60)\"}}}}}" --record

--- a/tasks/kubectl-apply-statefulset.yml
+++ b/tasks/kubectl-apply-statefulset.yml
@@ -13,6 +13,7 @@ params:
   KUBERNETES_FILE_PREFIX:
   KUBERNETES_SELECTOR:
   SERVICE_ACCOUNT_JSON:
+  SKIP_IMAGE_PATCH:
   WAIT_UNTIL_AVAILABLE_TIMEOUT:
 
 inputs:
@@ -34,8 +35,10 @@ run:
       # Apply statefulset config
       kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-statefulset.yml --record
 
-      # Patch statefulset to use docker image specified in pipeline rather than statefulset script
-      kubectl patch sts ${KUBERNETES_STATEFULSET_NAME} --type='json' -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/image\",\"value\":\"$(cat docker-image-resource/repository)\"}]" --record
+      if [ -z "$SKIP_IMAGE_PATCH" ]; then
+        # Patch statefulset to use docker image specified in pipeline rather than statefulset script
+        kubectl patch sts ${KUBERNETES_STATEFULSET_NAME} --type='json' -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/image\",\"value\":\"$(cat docker-image-resource/repository)\"}]" --record
+      fi
 
       # Patch statefulset with timestamp/image digest to force pod recreation
       kubectl patch sts ${KUBERNETES_STATEFULSET_NAME} -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"timestamp\":\"`date +'%s'`\",\"image-digest\":\"$(cat docker-image-resource/digest | cut -d':' -f2 | cut -c1-60)\"}}}}}" --record


### PR DESCRIPTION
# Overview

As part of the release process we want to pin images used in "prod-like" environments to tagged releases.

# What has changed

These changes point the manual (blacklodge) pipeline to use the "release" subdirectory for the k8s microservice deployment configurations, which contain the pinned image versions (vA.B.C).

As the image for each service is pinned in the k8s configuration files there is no need to patch the images inside the task and so can be skipped in the manual pipeline.

# Links

- Dependent on changes from https://github.com/ONSdigital/census-rm-kubernetes/pull/83
- [Trello card](https://trello.com/c/CQDFbzS8)