### PR TITLE
Add Fieldwork Adapter microservice

### DIFF
--- a/pipelines/ci-sit-kubernetes-pipeline.yml
+++ b/pipelines/ci-sit-kubernetes-pipeline.yml
@@ -366,9 +366,38 @@ jobs:
       docker-image-resource: print-file-service-docker-latest,
       kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
+- name: "CI Deploy Fieldwork Adapter"
+  serial: true
+  serial_groups: [ci-fieldwork-adapter]
+  plan:
+  - get: census-rm-terraform
+    trigger: true
+    passed: ["CI Deploy Infrastructure"]
+  - get: census-rm-kubernetes-microservices-repo
+    trigger: true
+  - get: fieldwork-adapter-docker-latest
+    trigger: true
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((ci-gcp-project-name))
+      KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: fieldwork-adapter
+      KUBERNETES_SELECTOR: app=fieldwork-adapter
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: fieldwork-adapter
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {
+      docker-image-resource: fieldwork-adapter-docker-latest,
+      kubernetes-repo: census-rm-kubernetes-microservices-repo}
+
 - name: "CI Acceptance Tests"
   serial: true
-  serial_groups: [ci-action-scheduler, ci-case-api, ci-case-processor, ci-uac-qid-service, ci-pubsubsvc, ci-print-file-service]
+  serial_groups: [ci-action-scheduler, ci-case-api, ci-case-processor, ci-uac-qid-service, ci-pubsubsvc, ci-print-file-service, ci-fieldwork-adapter]
   plan:
   - get: census-rm-terraform
     trigger: true
@@ -377,7 +406,8 @@ jobs:
              "CI Deploy Case-Processor", 
              "CI Deploy UAC QID Service", 
              "CI Deploy PubSub Service",
-             "CI Deploy Print File Service"]
+             "CI Deploy Print File Service",
+             "CI Deploy Fieldwork Adapter"]
   - get: acceptance-tests-repo
   - get: batch-runner-repo
   - get: acceptance-tests-docker-image
@@ -391,7 +421,8 @@ jobs:
              "CI Deploy Case-Processor", 
              "CI Deploy UAC QID Service", 
              "CI Deploy PubSub Service",
-             "CI Deploy Print File Service"]
+             "CI Deploy Print File Service",
+             "CI Deploy Fieldwork Adapter"]
   - get: action-scheduler-docker-latest
     trigger: true
     passed: ["CI Deploy Action-Scheduler"]
@@ -424,6 +455,11 @@ jobs:
   - get: print-file-service-docker-latest
     trigger: true
     passed: ["CI Deploy Print File Service"]
+    params:
+      skip_download: true
+  - get: fieldwork-adapter-docker-latest
+    trigger: true
+    passed: ["CI Deploy Fieldwork Adaapter"]
     params:
       skip_download: true
   - task: "Run Acceptance Tests (in K8s)"
@@ -651,3 +687,34 @@ jobs:
     input_mapping: {
       docker-image-resource: ops-docker-latest,
       kubernetes-repo: census-rm-kubernetes-ops-repo}
+
+- name: "SIT Deploy Fieldwork Adapter"
+  serial: true
+  serial_groups: [sit-fieldwork-adapter]
+  plan:
+  - get: census-rm-terraform
+    trigger: true
+    passed: ["CI Acceptance Tests"]
+  - get: census-rm-kubernetes-microservices-repo
+    trigger: true
+    passed: ["CI Acceptance Tests"]
+  - get: fieldwork-adapter-docker-latest
+    trigger: true
+    passed: ["CI Acceptance Tests"]
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((sit-gcp-project-name))
+      KUBERNETES_CLUSTER: ((sit-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: fieldwork-adapter
+      KUBERNETES_SELECTOR: app=fieldwork-adapter
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: fieldwork-adapter
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {
+      docker-image-resource: fieldwork-adapter-docker-latest,
+      kubernetes-repo: census-rm-kubernetes-microservices-repo}

--- a/pipelines/dev-kubernetes-pipeline.yml
+++ b/pipelines/dev-kubernetes-pipeline.yml
@@ -326,6 +326,33 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
+- name: fieldwork-adapter
+  serial: true
+  serial_groups: [fieldwork-adapter]
+  plan:
+  - get: census-rm-terraform
+    trigger: true
+    passed: [deploy-infrastructure]
+  - get: census-rm-kubernetes-microservices-repo
+    trigger: true
+  - get: fieldwork-adapter-docker-latest
+    trigger: true
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: fieldwork-adapter
+      KUBERNETES_SELECTOR: app=fieldwork-adapter
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: fieldwork-adapter
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+
 - name: ops
   serial: true
   serial_groups: [ops]
@@ -355,11 +382,11 @@ jobs:
 
 - name: "Acceptance Tests"
   serial: true
-  serial_groups: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service]
+  serial_groups: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service, fieldwork-adapter]
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service]
+    passed: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service, fieldwork-adapter]
   - get: acceptance-tests-repo
   - get: batch-runner-repo
   - get: acceptance-tests-docker-image
@@ -368,7 +395,7 @@ jobs:
       skip_download: true
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
-    passed: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service]
+    passed: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service, fieldwork-adapter]
   - get: action-scheduler-docker-latest
     trigger: true
     passed: [action-scheduler]
@@ -400,6 +427,11 @@ jobs:
       skip_download: true
   - get: print-file-service-docker-latest
     trigger: true
+    params:
+      skip_download: true
+  - get: fieldwork-adapter-docker-latest
+    trigger: true
+    passed: [fieldwork-adapter]
     params:
       skip_download: true
   - task: "Run Acceptance Tests (in K8s)"

--- a/pipelines/docker-build-pipeline.yml
+++ b/pipelines/docker-build-pipeline.yml
@@ -60,6 +60,11 @@ resources:
       uri: git@github.com:ONSdigital/census-rm-acceptance-tests.git
       private_key: ((github.service_account_private_key))
 
+  - name: fieldwork-adapter-master
+    type: git
+    source:
+      uri: git@github.com:ONSdigital/census-rm-fieldwork-adapter.git
+      private_key: ((github.service_account_private_key))
 
   - name: action-scheduler-docker-image-ci
     type: docker-image
@@ -198,6 +203,20 @@ resources:
     type: docker-image
     source:
       repository: ((docker-registry-gcr))/rm/census-rm-acceptance-tests
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: fieldwork-adapter-docker-image-ci
+    type: docker-image
+    source:
+      repository: ((docker-registry-ci))/rm/census-rm-fieldwork-adapter
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: fieldwork-adapter-docker-image-gcr
+    type: docker-image
+    source:
+      repository: ((docker-registry-gcr))/rm/census-rm-fieldwork-adapter
       username: _json_key
       password: ((gcp.service_account_json))
 
@@ -495,6 +514,48 @@ jobs:
         cache_from:
           - acceptance-tests-docker-image-ci
         tag_file: acceptance-tests-master/.git/ref
+        tag_as_latest: true
+      get_params:
+        skip_download: true
+
+  - name: build-fieldwork-adapter-master
+    plan:
+    - get: fieldwork-adapter-master
+      trigger: true
+    - task: Build Fieldwork Adapter Image (master)
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: adoptopenjdk/maven-openjdk11
+        inputs:
+          - name: fieldwork-adapter-master
+        outputs:
+          - name: build
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              mkdir -p build/target
+              cd fieldwork-adapter-master
+              mvn package -DskipITs -Ddockerfile.skip
+              cp target/*.jar ../build/target
+              cp Dockerfile ../build
+    - put: fieldwork-adapter-docker-image-ci
+      params:
+        build: build
+        tag_file: fieldwork-adapter-master/.git/ref
+        tag_as_latest: true
+      get_params:
+        save: true
+    - put: fieldwork-adapter-docker-image-gcr
+      params:
+        build: build
+        cache_from:
+          - fieldwork-adapter-docker-image-ci
+        tag_file: fieldwork-adapter-master/.git/ref
         tag_as_latest: true
       get_params:
         skip_download: true

--- a/pipelines/docker-release-pipeline.yml
+++ b/pipelines/docker-release-pipeline.yml
@@ -80,6 +80,13 @@ resources:
       access_token: ((github.access_token))
       order_by: time
 
+  - name: fieldwork-adapter-release
+    type: github-release-latest
+    source:
+      owner: ONSdigital
+      repository: census-rm-fieldwork-adapter
+      access_token: ((github.access_token))
+      order_by: time
 
   - name: action-scheduler-docker-image-ci
     type: docker-image
@@ -204,6 +211,20 @@ resources:
     type: docker-image
     source:
       repository: ((docker-registry-gcr))/rm/census-rm-sample-loader
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: fieldwork-adapter-docker-image-ci
+    type: docker-image
+    source:
+      repository: ((docker-registry-ci))/rm/census-rm-fieldwork-adapter
+      username: _json_key
+      password: ((gcp.service_account_json))
+  
+  - name: fieldwork-adapter-docker-image-gcr
+    type: docker-image
+    source:
+      repository: ((docker-registry-gcr))/rm/census-rm-fieldwork-adapter
       username: _json_key
       password: ((gcp.service_account_json))
 
@@ -600,6 +621,53 @@ jobs:
         cache_from:
           - sample-loader-docker-image-ci
         tag_file: sample-loader-release/tag
+        tag_as_latest: false
+      get_params:
+        skip_download: true
+
+  - name: build-fieldwork-adapter-release
+    plan:
+    - get: fieldwork-adapter-release
+      params:
+        include_source_tarball: true
+      trigger: true
+    - task: Build Fieldwork Adapter Image (release)
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: adoptopenjdk/maven-openjdk11
+        inputs:
+          - name: fieldwork-adapter-release
+        outputs:
+          - name: build
+          - name: extracted-fieldwork-adapter
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              mkdir -p build/target
+              cd fieldwork-adapter-release
+              tar -xzf source.tar.gz -C ../extracted-fieldwork-adapter --strip-components=1
+              cd ../extracted-fieldwork-adapter
+              mvn package -DskipITs -Ddockerfile.skip
+              cp target/census-rm-*.jar ../build/target
+              cp Dockerfile ../build
+    - put: fieldwork-adapter-docker-image-ci
+      params:
+        build: build
+        tag_file: fieldwork-adapter-release/tag
+        tag_as_latest: false
+      get_params:
+        save: true
+    - put: fieldwork-adapter-docker-image-gcr
+      params:
+        build: build
+        cache_from:
+          - fieldwork-adapter-docker-image-ci
+        tag_file: fieldwork-adapter-release/tag
         tag_as_latest: false
       get_params:
         skip_download: true

--- a/pipelines/manual-ci-kubernetes-pipeline.yml
+++ b/pipelines/manual-ci-kubernetes-pipeline.yml
@@ -96,6 +96,13 @@ resources:
     username: _json_key
     password: ((gcp.service_account_json))
 
+- name: fieldwork-adapter-docker-latest
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-fieldwork-adapter
+    username: _json_key
+    password: ((gcp.service_account_json))
+
 
 jobs:
 
@@ -256,10 +263,32 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
+- name: fieldwork-adapter
+  serial: true
+  serial_groups: [fieldwork-adapter]
+  plan:
+  - get: census-rm-kubernetes-microservices-repo
+  - get: fieldwork-adapter-docker-latest
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: fieldwork-adapter
+      KUBERNETES_SELECTOR: app=fieldwork-adapter
+      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PREFIX: fieldwork-adapter
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+
 
 - name: "Acceptance Tests"
   serial: true
-  serial_groups: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service]
+  serial_groups: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service, fieldwork-adapter]
   plan:
   - get: acceptance-tests-repo
   - get: batch-runner-repo
@@ -267,7 +296,7 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-kubernetes-microservices-repo
-    passed: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service]
+    passed: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service, fieldwork-adapter]
   - get: action-scheduler-docker-latest
     passed: [action-scheduler]
     params:
@@ -292,6 +321,9 @@ jobs:
     params:
       skip_download: true
   - get: print-file-service-docker-latest
+    params:
+      skip_download: true
+  - get: fieldwork-adapter-docker-latest
     params:
       skip_download: true
   - task: "Run Acceptance Tests (in K8s)"


### PR DESCRIPTION
# Motivation and Context
We need a new microservice called Fieldwork Adapter to convert from JSON to XML at the boundary of RM, for backwards compatibility with FWMT.

# What has changed
Added Fieldwork Adapter to all the concourse YAMLs.

# How to test?
Fly the pipeline(s). Ensure the things. Kindly do the needful.

# Links
Trello: https://trello.com/c/ZFtJpuaa
