### PR TITLE
add missing step to the case-procssor release build to copy healthcheck.sh

### DIFF
--- a/pipelines/docker-release-pipeline.yml
+++ b/pipelines/docker-release-pipeline.yml
@@ -335,6 +335,7 @@ jobs:
               mvn package -DskipITs -Ddockerfile.skip
               cp target/census-rm-*.jar ../build/target
               cp Dockerfile ../build
+              cp healthcheck.sh ../build
     - put: case-processor-docker-image-ci
       params:
         build: build


### PR DESCRIPTION
# Motivation and Context
there's a missing step in the case processor release step where it needs to copy over the healthcheck.sh file

# What has changed
updated the build-case-processor-release step to copy over healthcheck.sh

# How to test?
run the release job and the docker build should complete
