### PR TITLE
Add performance tests pipeline

### DIFF
--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -78,3 +78,13 @@ jobs:
           vars:
             docker-registry-ci: eu.gcr.io/census-rm-ci
             docker-registry-gcr: eu.gcr.io/census-gcr-rm
+
+        - name: test-performance
+          team: rm
+          config_file: census-rm-deploy/pipelines/performance-tests-pipeline.yml
+          unpaused: true
+          vars:
+            performance-gcp-environment-name: census-rm-performance
+            performance-kubernetes-cluster-name: rm-k8s-cluster
+            performance-tests-image: eu.gcr.io/census-gcr-rm/rm/census-rm-performance-tests:latest
+            terraform-branch: master

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -119,7 +119,8 @@ jobs:
           config_file: census-rm-deploy/pipelines/performance-tests-pipeline.yml
           unpaused: true
           vars:
-            performance-gcp-environment-name: census-rm-performance
+            performance-gcp-environment-name: performance
+            performance-gcp-project-name: census-rm-performance
             performance-kubernetes-cluster-name: rm-k8s-cluster
             performance-tests-image: eu.gcr.io/census-gcr-rm/rm/census-rm-performance-tests:latest
             terraform-branch: master

--- a/pipelines/docker-build-pipeline.yml
+++ b/pipelines/docker-build-pipeline.yml
@@ -60,6 +60,12 @@ resources:
       uri: git@github.com:ONSdigital/census-rm-acceptance-tests.git
       private_key: ((github.service_account_private_key))
 
+  - name: performance-tests-master
+    type: git
+    source:
+      uri: git@github.com:ONSdigital/census-rm-performance-tests.git
+      private_key: ((github.service_account_private_key))
+
   - name: fieldwork-adapter-master
     type: git
     source:
@@ -217,6 +223,20 @@ resources:
     type: docker-image
     source:
       repository: ((docker-registry-gcr))/rm/census-rm-fieldwork-adapter
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: performance-tests-docker-image-ci
+    type: docker-image
+    source:
+      repository: ((docker-registry-ci))/rm/census-rm-performance-tests
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: performance-tests-docker-image-gcr
+    type: docker-image
+    source:
+      repository: ((docker-registry-gcr))/rm/census-rm-performance-tests
       username: _json_key
       password: ((gcp.service_account_json))
 
@@ -514,6 +534,27 @@ jobs:
         cache_from:
           - acceptance-tests-docker-image-ci
         tag_file: acceptance-tests-master/.git/ref
+        tag_as_latest: true
+      get_params:
+        skip_download: true
+
+  - name: build-performance-tests-master
+    plan:
+    - get: performance-tests-master
+      trigger: true
+    - put: performance-tests-docker-image-ci
+      params:
+        build: performance-tests-master
+        tag_file: performance-tests-master/.git/ref
+        tag_as_latest: true
+      get_params:
+        save: true
+    - put: performance-tests-docker-image-gcr
+      params:
+        build: performance-tests-master
+        cache_from:
+          - performance-tests-docker-image-ci
+        tag_file: performance-tests-master/.git/ref
         tag_as_latest: true
       get_params:
         skip_download: true

--- a/pipelines/performance-tests-pipeline.yaml
+++ b/pipelines/performance-tests-pipeline.yaml
@@ -37,8 +37,6 @@ resources:
 
 jobs:
 
-
-# CI
 - name: "Deploy Performance Infrastructure"
   serial: true
   serial_groups: ["Performance Tests"]

--- a/pipelines/performance-tests-pipeline.yaml
+++ b/pipelines/performance-tests-pipeline.yaml
@@ -30,7 +30,7 @@ resources:
 - name: performance-tests-docker-image
   type: docker-image
   source:
-    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-performance-tests
+    repository: ((performance-tests-image))
     username: _json_key
     password: ((gcp.service_account_json))
 
@@ -56,8 +56,8 @@ jobs:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         AUTO_APPLY: true
         DEV_DUMMY_PGP: true
+        DEV_LOCAL_SFTP: true
         DEV_PUBSUB: true
-        DISABLE_CI_BINDING: true
         ENV: ((performance-gcp-environment-name))
         GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json
         KEEP_TMP_K8S: true

--- a/pipelines/performance-tests-pipeline.yaml
+++ b/pipelines/performance-tests-pipeline.yaml
@@ -1,0 +1,110 @@
+---
+resources:
+
+- name: 24h
+  type: time
+  source:
+    interval: 24h
+    days: [Monday, Tuesday, Wednesday, Thursday, Friday]
+
+- name: census-rm-kubernetes-repo
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-kubernetes.git
+    private_key: ((github.service_account_private_key))
+
+- name: census-rm-terraform-repo
+  type: git
+  source:
+    branch: ((terraform-branch))
+    uri: git@github.com:ONSdigital/census-rm-terraform.git
+    private_key: ((github.service_account_private_key))
+
+- name: performance-tests-repo
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-performance-tests.git
+    private_key: ((github.service_account_private_key))
+    paths: [kubernetes.env, tasks/*]
+
+- name: performance-tests-docker-image
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-performance-tests
+    username: _json_key
+    password: ((gcp.service_account_json))
+
+
+jobs:
+
+
+# CI
+- name: "Deploy Performance Infrastructure"
+  serial: true
+  serial_groups: ["Performance Tests"]
+  max_in_flight: 1
+  plan:
+  - get: census-rm-terraform-repo
+    trigger: true
+  - get: census-rm-kubernetes-repo
+  - task: "Build & Deploy Performance Infrastructure"
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: google/cloud-sdk
+      params:
+        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+        AUTO_APPLY: true
+        DEV_DUMMY_PGP: true
+        DEV_PUBSUB: true
+        DISABLE_CI_BINDING: true
+        ENV: ((performance-gcp-environment-name))
+        GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json
+        KEEP_TMP_K8S: true
+      inputs:
+        - name: census-rm-terraform
+        - name: census-rm-kubernetes-repo
+      run:
+        path: bash
+        args:
+          - -exc
+          - |
+            apt-get install -y unzip procps  # NB: procps is used by Helm
+            git clone https://github.com/kamatama41/tfenv.git ~/.tfenv && \
+            ln -s /root/.tfenv/bin/* /usr/local/bin
+            cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
+            $ADMIN_SERVICE_ACCOUNT_JSON
+            EOL
+            gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+            cp -R census-rm-kubernetes-repo/ census-rm-terraform/tmp_rm_kube
+            cd census-rm-terraform
+            tfenv install
+            curl -L https://git.io/get_helm.sh | bash && \
+            helm init --client-only && \
+            helm plugin install https://github.com/rimusz/helm-tiller
+            ./apply.sh
+
+- name: "Performance Tests"
+  serial: true
+  serial_groups: ["Performance Tests"]
+  plan:
+  - get: 24h
+    trigger: true
+  - get: census-rm-terraform-repo
+    trigger: true
+    passed: ["Deploy Performance Infrastructure"]
+  - get: performance-tests-repo
+  - get: performance-tests-docker-image
+    trigger: true
+    params:
+      skip_download: true
+  - task: "Run Performance Tests (in K8s)"  # TODO: what is deemed a failure?
+    file: performance-tests-repo/tasks/kubectl-run-performance-tests.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      PERFORMANCE_TESTS_IMAGE: ((performance-tests-image))
+    input_mapping: {performance-tests-repo: performance-tests-repo}

--- a/pipelines/performance-tests-pipeline.yaml
+++ b/pipelines/performance-tests-pipeline.yaml
@@ -62,7 +62,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json
         KEEP_TMP_K8S: true
       inputs:
-        - name: census-rm-terraform
+        - name: census-rm-terraform-repo
         - name: census-rm-kubernetes-repo
       run:
         path: bash
@@ -76,8 +76,8 @@ jobs:
             $ADMIN_SERVICE_ACCOUNT_JSON
             EOL
             gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
-            cp -R census-rm-kubernetes-repo/ census-rm-terraform/tmp_rm_kube
-            cd census-rm-terraform
+            cp -R census-rm-kubernetes-repo/ census-rm-terraform-repo/tmp_rm_kube
+            cd census-rm-terraform-repo
             tfenv install
             curl -L https://git.io/get_helm.sh | bash && \
             helm init --client-only && \


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
New pipeline required to trigger performance tests every 24 hours (weekdays).

TODO: this will add the functionality but we'd like to set thresholds of failure

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- New performance pipeline which builds infrastructure (when changes have been made to terraform) and triggers performance tests every 24hrs
- Added new pipeline to pipeline of pipelines

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://github.com/ONSdigital/census-rm-performance-tests/pull/3
