### PR TITLE
Fix missing file in fieldwork adapter release task

### DIFF
--- a/pipelines/docker-release-pipeline.yml
+++ b/pipelines/docker-release-pipeline.yml
@@ -806,6 +806,7 @@ jobs:
               mvn package -DskipITs -Ddockerfile.skip
               cp target/census-rm-*.jar ../build/target
               cp Dockerfile ../build
+              cp healthcheck.sh ../build
     - put: fieldwork-adapter-docker-image-ci
       on_failure: *slack_failure_alert_ci
       params:


### PR DESCRIPTION
From [release build #2](https://concourse.census-gcp.onsdigital.uk/teams/rm/pipelines/release-images/jobs/build-fieldwork-adapter-release/builds/2): `COPY failed: stat /scratch/docker/tmp/docker-builder158157775/healthcheck.sh: no such file or directory`