### PR TITLE
update blacklodge pipeline to point to RM v1.2.0

### DIFF
--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -96,7 +96,7 @@ jobs:
             gcp-project-name: census-rm-blacklodge
             kubernetes-cluster-name: rm-k8s-cluster
             acceptance-tests-image: eu.gcr.io/census-gcr-rm/rm/census-rm-acceptance-tests:v1.0.0
-            kubernetes-release: v1.0.0
+            kubernetes-release: v1.2.0
 
         - name: build-images
           team: rm


### PR DESCRIPTION
# Motivation and Context
release RM v1.2.0 to blacklodge

# What has changed
Change blacklodge pipeline use kubernetes-release v1.2.0