### PR TITLE
RMC-163 Build and Push RM Data Exporter

### DIFF
--- a/pipelines/docker-build-pipeline.yml
+++ b/pipelines/docker-build-pipeline.yml
@@ -90,6 +90,12 @@ resources:
       uri: git@github.com:ONSdigital/census-rm-notify-stub.git
       private_key: ((github.service_account_private_key))
 
+  - name: data-exporter-master
+    type: git
+    source:
+      uri: git@github.com:ONSdigital/census-rm-dataexporter.git
+      private_key: ((github.service_account_private_key))
+
   - name: action-scheduler-docker-image-ci
     type: docker-image
     source:
@@ -269,6 +275,20 @@ resources:
     type: docker-image
     source:
       repository: ((docker-registry-gcr))/rm/census-rm-notify-stub
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: data-exporter-docker-image-ci
+    type: docker-image
+    source:
+      repository: ((docker-registry-ci))/rm/census-rm-data-exporter
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: data-exporter-docker-image-gcr
+    type: docker-image
+    source:
+      repository: ((docker-registry-gcr))/rm/census-rm-data-exporter
       username: _json_key
       password: ((gcp.service_account_json))
 
@@ -800,3 +820,25 @@ jobs:
       get_params:
         skip_download: true
 
+  - name: build-data-exporter-master
+    plan:
+    - get: data-exporter-master
+      trigger: true
+    - put: data-exporter-docker-image-ci
+      on_failure: *slack_failure_alert_ci
+      params:
+        build: data-exporter-master/docker
+        tag_file: data-exporter-master/.git/ref
+        tag_as_latest: true
+      get_params:
+        save: true
+    - put: data-exporter-docker-image-gcr
+      on_failure: *slack_failure_alert_gcr
+      params:
+        build: data-exporter-master/docker
+        cache_from:
+          - data-exporter-docker-image-ci
+        tag_file: data-exporter-master/.git/ref
+        tag_as_latest: true
+      get_params:
+        skip_download: true

--- a/pipelines/docker-release-pipeline.yml
+++ b/pipelines/docker-release-pipeline.yml
@@ -162,7 +162,7 @@ resources:
       repository: ((docker-registry-ci))/rm/census-rm-case-processor
       username: _json_key
       password: ((gcp.service_account_json))
-  
+
   - name: case-processor-docker-image-gcr
     type: docker-image
     source:
@@ -260,7 +260,7 @@ resources:
       repository: ((docker-registry-ci))/rm/census-rm-fieldwork-adapter
       username: _json_key
       password: ((gcp.service_account_json))
-  
+
   - name: fieldwork-adapter-docker-image-gcr
     type: docker-image
     source:
@@ -274,7 +274,7 @@ resources:
       repository: ((docker-registry-ci))/rm/census-rm-notify-processor
       username: _json_key
       password: ((gcp.service_account_json))
-  
+
   - name: notify-processor-docker-image-gcr
     type: docker-image
     source:

--- a/pipelines/docker-release-pipeline.yml
+++ b/pipelines/docker-release-pipeline.yml
@@ -114,6 +114,14 @@ resources:
       access_token: ((github.access_token))
       order_by: time
 
+  - name: data-exporter-release
+    type: github-release-latest
+    source:
+      owner: ONSdigital
+      repository: census-rm-dataexporter
+      access_token: ((github.access_token))
+      order_by: time
+
   - name: acceptance-tests-docker-image-ci
     type: docker-image
     source:
@@ -279,6 +287,20 @@ resources:
     type: docker-image
     source:
       repository: ((docker-registry-gcr))/rm/census-rm-notify-processor
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: data-exporter-docker-image-ci
+    type: docker-image
+    source:
+      repository: ((docker-registry-ci))/rm/census-rm-data-exporter
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: data-exporter-docker-image-gcr
+    type: docker-image
+    source:
+      repository: ((docker-registry-gcr))/rm/census-rm-data-exporter
       username: _json_key
       password: ((gcp.service_account_json))
 
@@ -939,6 +961,50 @@ jobs:
         cache_from:
           - acceptance-tests-docker-image-ci
         tag_file: acceptance-tests-release/tag
+        tag_as_latest: false
+      get_params:
+        skip_download: true
+
+  - name: build-data-exporter-release
+    plan:
+    - get: data-exporter-release
+      params:
+        include_source_tarball: true
+      trigger: true
+    - task: Build Data Exporter Image (release)
+      on_failure: *slack_failure_alert_prebuild
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: alpine
+        inputs:
+          - name: data-exporter-release
+        outputs:
+          - name: extracted-data-exporter
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              cd data-exporter-release
+              tar -xzf source.tar.gz -C ../extracted-data-exporter --strip-components=1
+    - put: data-exporter-docker-image-ci
+      on_failure: *slack_failure_alert_ci
+      params:
+        build: extracted-data-exporter
+        tag_file: data-exporter-release/tag
+        tag_as_latest: false
+      get_params:
+        save: true
+    - put: data-exporter-docker-image-gcr
+      on_failure: *slack_failure_alert_gcr
+      params:
+        build: extracted-data-exporter
+        cache_from:
+          - data-exporter-docker-image-ci
+        tag_file: data-exporter-release/tag
         tag_as_latest: false
       get_params:
         skip_download: true


### PR DESCRIPTION
# Motivation and Context
We need to build and push the [census-rm-dataexporter](https://github.com/ONSdigital/census-rm-dataexporter).

# What has changed
* Build and push latest tagged images of data exporter from commits to master
* Build and push release tagged images of data exporter from github release tags

# Links
https://trello.com/c/F80WMX7r/978-rmc-163-mi-to-dap-for-rca-fca
https://github.com/ONSdigital/census-rm-dataexporter