### PR TITLE
Remove ATs and bump to k8s v1.4.0

### DIFF
--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -92,12 +92,10 @@ jobs:
           team: rm
           config_file: census-rm-deploy/pipelines/manual-release-pipeline.yml
           vars:
-            acceptance-tests-image: eu.gcr.io/census-gcr-rm/rm/census-rm-acceptance-tests:v1.0.0
-            acceptance-tests-release: v1.0.0
             gcp-environment-name: blacklodge
             gcp-project-name: census-rm-blacklodge
             kubernetes-cluster-name: rm-k8s-cluster
-            kubernetes-release: v1.3.0
+            kubernetes-release: v1.4.0
 
         - name: build-images
           team: rm

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -38,16 +38,6 @@ resources:
   version:
     ref: ((kubernetes-release))
 
-- name: acceptance-tests-repo
-  type: git
-  source:
-    uri: git@github.com:ONSdigital/census-rm-acceptance-tests.git
-    private_key: ((github.service_account_private_key))
-    paths: [kubernetes.env, tasks/*]
-    tag_filter: v*
-  version:
-    ref: ((acceptance-tests-release))
-
 templating:
 
 slack_failure_alert: &slack_failure_alert
@@ -268,21 +258,3 @@ jobs:
       KUBERNETES_FILE_PREFIX: notify-processor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
-
-- name: "Acceptance Tests"
-  serial: true
-  serial_groups: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service, fieldwork-adapter, notify-processor]
-  plan:
-  - get: acceptance-tests-repo
-  - get: census-rm-kubernetes-microservices-repo
-    passed: [action-scheduler, case-api, case-processor, uac-qid-service, pubsubsvc, print-file-service, fieldwork-adapter, notify-processor]
-  - task: "Run Acceptance Tests (in K8s)"
-    file: acceptance-tests-repo/tasks/kubectl-run-acceptance-tests.yml
-    on_failure: *slack_failure_alert
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
-      ACCEPTANCE_TESTS_IMAGE: ((acceptance-tests-image))
-      BATCH_RUNNER_CONFIG: census-rm-kubernetes-microservices-repo/release/microservices/qid-batch-runner-deployment.yml
-    input_mapping: {acceptance-tests-repo: acceptance-tests-repo}


### PR DESCRIPTION
Acceptance tests should not be ran in Blacklodge currently.

Bumping to use latest (v1.4.0) version of RM.