### PR TITLE
Remove rogue c character

### DIFF
--- a/pipelines/docker-build-pipeline.yml
+++ b/pipelines/docker-build-pipeline.yml
@@ -928,7 +928,7 @@ jobs:
             - -exc
             - |
               mkdir -p build/target
-              cd cexception-manager-master
+              cd exception-manager-master
               mvn package -DskipITs -Ddockerfile.skip
               cp target/census-rm-*.jar ../build/target
               cp Dockerfile ../build


### PR DESCRIPTION
# Motivation and Context
Exception manager Concourse build still broken.

# What has changed
Removed rogue 'c'.

# How to test?
Fly. Run the build job.

# Links
Trello: https://trello.com/c/2rkYNAMa