### PR TITLE
Use dev deployments of toolbox apps

### DIFF
--- a/pipelines/ci-sit-kubernetes-pipeline.yml
+++ b/pipelines/ci-sit-kubernetes-pipeline.yml
@@ -1379,7 +1379,7 @@ jobs:
       KUBERNETES_DEPLOYMENT_NAME: rabbitmonitor
       KUBERNETES_SELECTOR: app=rabbitmonitor
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
-      KUBERNETES_FILE_PREFIX: census-rm-toolbox
+      KUBERNETES_FILE_PREFIX: rabbitmonitor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
       docker-image-resource: toolbox-docker-latest,
@@ -1411,7 +1411,7 @@ jobs:
       KUBERNETES_DEPLOYMENT_NAME: regionalcounts
       KUBERNETES_SELECTOR: app=regionalcounts
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
-      KUBERNETES_FILE_PREFIX: census-rm-toolbox
+      KUBERNETES_FILE_PREFIX: regionalcounts
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
       docker-image-resource: toolbox-docker-latest,

--- a/pipelines/ci-sit-kubernetes-pipeline.yml
+++ b/pipelines/ci-sit-kubernetes-pipeline.yml
@@ -740,10 +740,10 @@ jobs:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
       KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: toolbox
-      KUBERNETES_SELECTOR: app=toolbox
+      KUBERNETES_DEPLOYMENT_NAME: census-rm-toolbox
+      KUBERNETES_SELECTOR: app=census-rm-toolbox
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
-      KUBERNETES_FILE_PREFIX: census-rm-toolbox
+      KUBERNETES_FILE_PREFIX: census-rm-toolbox-dev
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
       docker-image-resource: toolbox-docker-latest,
@@ -773,7 +773,7 @@ jobs:
       KUBERNETES_DEPLOYMENT_NAME: eventlatencymonitor
       KUBERNETES_SELECTOR: app=eventlatencymonitor
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
-      KUBERNETES_FILE_PREFIX: eventlatencymonitor
+      KUBERNETES_FILE_PREFIX: eventlatencymonitor-dev
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
       docker-image-resource: toolbox-docker-latest,
@@ -833,7 +833,7 @@ jobs:
       KUBERNETES_DEPLOYMENT_NAME: regionalcounts
       KUBERNETES_SELECTOR: app=regionalcounts
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
-      KUBERNETES_FILE_PREFIX: census-rm-toolbox
+      KUBERNETES_FILE_PREFIX: regional-counts-dev
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
       docker-image-resource: toolbox-docker-latest,


### PR DESCRIPTION
# Motivation and Context
Dev versions of the deployments for toolbox need to be used in CI as the prod version expect a read replica DB

# What has changed
* Fixed incorrect deployment file prefixes
* Use dev versions for CI which don't use read replicas

# Links
https://trello.com/c/rwDgOIUh/1360-deploy-toolbox-in-ci-wl-pipeline-3
https://github.com/ONSdigital/census-rm-kubernetes/pull/159