### PR TITLE
Update manual release pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Create a secrets YAML file containing the required configuration:
 
 
 ### [Manual Release Pipeline](pipelines/manual-release-pipeline.yml)
-This pipeline is designed for deploying release tagged versions of the docker images, but not necessarily as soon as they're built. It fetches only commits with tags matching `v*.*.*`. The job `Trigger All` acts as a gate for deploying all the apps on the currently selected release version. To deploy a specific version, disable all versions above it on the resource UI, then trigger the `Trigger All` job.
+This pipeline is designed for deploying release tagged versions of the docker images, but not necessarily as soon as they're built. It fetches only commits with tags matching `v*.*.*`. The `Deploy` job is what should be triggered manually by the user to deploy the active version. This works by acting as a gate on the `every-minute` resource. All the individual service deploy jobs are set to trigger off the `every-minute` resource but require the `Deploy` job to have passed, which is only triggered manually. This allows all the services to be deployed with one manual trigger of the `Deploy` job, once every minute. The version to be deployed can be changed by selectively enabling only the desired version ref in the resource UI.
+ To deploy a specific version, disable all versions above it on the resource UI, then trigger the `Deploy` job.
 
 #### How to fly
 Create a secrets YAML file containing the required configuration:

--- a/README.md
+++ b/README.md
@@ -68,3 +68,12 @@ Create a secrets YAML file containing the required configuration:
 | acceptance-tests-image   | String                                                                              | The name of the acceptance tests image to run                                            |
 | gcp-environment-name     | String                                                                              | The name of the GCP project suffix the targeted cluster belongs to                       |
 | gcp-project-name         | String                                                                              | The name of the GCP project targeted cluster belongs to                                                       |
+
+#### Force checking for older versions
+By default the github resource will only pick tags from the newest since the pipeline was first flown. If you need to use an older tag you can force it to check older resources versions with the [`check-resource` fly command](https://concourse-ci.org/managing-resources.html#fly-check-resource) with an appropraite `from`, e.g.
+
+```shell-script
+fly -t <target> check-resource -r <pipeline>/census-rm-kubernetes-release -f ref:v1.0.0
+```
+
+This would bring in all versions from `v1.0.0` chronologically.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Create a secrets YAML file containing the required configuration:
 
 ### [Manual Release Pipeline](pipelines/manual-release-pipeline.yml)
 This pipeline is designed for deploying release tagged versions of the docker images, but not necessarily as soon as they're built. It fetches only commits with tags matching `v*.*.*`. The `Deploy` job is what should be triggered manually by the user to deploy the active version. This works by acting as a gate on the `every-minute` resource. All the individual service deploy jobs are set to trigger off the `every-minute` resource but require the `Deploy` job to have passed, which is only triggered manually. This allows all the services to be deployed with one manual trigger of the `Deploy` job, once every minute. The version to be deployed can be changed by selectively enabling only the desired version ref in the resource UI.
- To deploy a specific version, disable all versions above it on the resource UI, then trigger the `Deploy` job.
+ To deploy a specific version, disable all versions above it on the resource UI, then trigger the `Deploy` job. See https://concourse-ci.org/manual-trigger-example.html
 
 #### How to fly
 Create a secrets YAML file containing the required configuration:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Create a secrets YAML file containing the required configuration:
 
 
 ### [Manual Release Pipeline](pipelines/manual-release-pipeline.yml)
-This pipeline targets release/prod-like environments with all the automatic triggers removed. This is useful for any environment where we want to be deploying release tagged versions of the docker images, but not necessarily as soon as they're built.
+This pipeline is designed for deploying release tagged versions of the docker images, but not necessarily as soon as they're built. It fetches only commits with tags matching `v*.*.*`. The job `Trigger All` acts as a gate for deploying all the apps on the currently selected release version. To deploy a specific version, disable all versions above it on the resource UI, then trigger the `Trigger All` job.
 
 #### How to fly
 Create a secrets YAML file containing the required configuration:
@@ -67,4 +67,3 @@ Create a secrets YAML file containing the required configuration:
 | acceptance-tests-image   | String                                                                              | The name of the acceptance tests image to run                                            |
 | gcp-environment-name     | String                                                                              | The name of the GCP project suffix the targeted cluster belongs to                       |
 | gcp-project-name         | String                                                                              | The name of the GCP project targeted cluster belongs to                                                       |
-| kubernetes-release       | String                                                                              | The semantic version string of the tagged [kubernetes repository](https://github.com/ONSdigital/census-rm-kubernetes)                                                       |

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -95,7 +95,6 @@ jobs:
             gcp-environment-name: blacklodge
             gcp-project-name: census-rm-blacklodge
             kubernetes-cluster-name: rm-k8s-cluster
-            kubernetes-release: v1.4.0
 
         - name: build-images
           team: rm

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -510,7 +510,6 @@ jobs:
   disable_manual_trigger: true
   serial: true
   plan:
-  - get: census-rm-kubernetes-release
   - get: every-minute
     trigger: true
     passed: ["Action Scheduler", 

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -101,6 +101,37 @@ slack_success_alert: &slack_success_alert
           }
       ]
 
+slack_in_progress_alert: &slack_in_progress_alert
+  put: slack-alert
+  params:
+    icon_emoji: ":concourse:"
+    username: Concourse
+    attachments: [
+          {
+              "fallback": "((gcp-environment-name)) release started. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+              "title": "((gcp-environment-name)) Release Started",
+              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+              "fields": [
+                  {
+                      "title": "Pipeline",
+                      "value": "$BUILD_PIPELINE_NAME",
+                      "short": true
+                  },
+                  {
+                      "title": "Environment",
+                      "value": "((gcp-environment-name))",
+                      "short": true
+                  },
+                  {
+                      "title": "Project",
+                      "value": "((gcp-project-name))",
+                      "short": true
+                  }
+              ],
+              "color": "#ffe100"
+          }
+      ]
+
 
 jobs:
 
@@ -109,6 +140,7 @@ jobs:
   plan:
     - get: every-minute
     - get: census-rm-kubernetes-release
+  on_success: *slack_in_progress_alert
 
 - name: "Action Scheduler"
   disable_manual_trigger: true

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -73,13 +73,12 @@ slack_failure_alert: &slack_failure_alert
 slack_success_alert: &slack_success_alert
   put: slack-alert
   params:
-    release-ref: census-rm-kuberenetes-release/.git/ref
     icon_emoji: ":concourse:"
     username: Concourse
     attachments: [
           {
-              "fallback": "$BUILD_PIPELINE_NAME release succeeded. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
-              "title": "$BUILD_PIPELINE_NAME Release Succeeded",
+              "fallback": "((gcp-environment-name)) release succeeded. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+              "title": "((gcp-environment-name)) Release Succeeded",
               "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
               "fields": [
                   {
@@ -95,11 +94,6 @@ slack_success_alert: &slack_success_alert
                   {
                       "title": "Project",
                       "value": "((gcp-project-name))",
-                      "short": true
-                  },
-                  {
-                      "title": "Version",
-                      "value": "${cat release-ref}",
                       "short": true
                   }
               ],
@@ -117,6 +111,7 @@ jobs:
     - get: census-rm-kubernetes-release
 
 - name: "Action Scheduler"
+  disable_manual_trigger: true
   serial: true
   serial_groups: [action-scheduler]
   plan:
@@ -142,6 +137,7 @@ jobs:
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
 - name: "Case API"
+  disable_manual_trigger: true
   serial: true
   serial_groups: [case-api]
   plan:
@@ -167,6 +163,7 @@ jobs:
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
 - name: "Case Processor"
+  disable_manual_trigger: true
   serial: true
   serial_groups: [case-processor]
   plan:
@@ -192,6 +189,7 @@ jobs:
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
 - name: "UAC QID Service"
+  disable_manual_trigger: true
   serial: true
   serial_groups: [uac-qid-service]
   plan:
@@ -217,6 +215,7 @@ jobs:
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
 - name: "PubSub Service"
+  disable_manual_trigger: true
   serial: true
   serial_groups: [pubsubsvc]
   plan:
@@ -242,6 +241,7 @@ jobs:
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
 - name: "Ops Tool"
+  disable_manual_trigger: true
   serial: true
   serial_groups: [ops]
   plan:
@@ -267,6 +267,7 @@ jobs:
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
 - name: "Print File Service"
+  disable_manual_trigger: true
   serial: true
   serial_groups: [print-file-service]
   plan:
@@ -292,6 +293,7 @@ jobs:
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
 - name: "Fieldwork Adapter"
+  disable_manual_trigger: true
   serial: true
   serial_groups: [fieldwork-adapter]
   plan:
@@ -317,6 +319,7 @@ jobs:
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
 - name: "Notify Processor"
+  disable_manual_trigger: true
   serial: true
   serial_groups: [notify-processor]
   plan:
@@ -342,6 +345,7 @@ jobs:
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
 - name: "Exception Manager"
+  disable_manual_trigger: true
   serial: true
   serial_groups: [exception-manager]
   plan:
@@ -367,6 +371,7 @@ jobs:
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
 - name: "Toolbox"
+  disable_manual_trigger: true
   serial: true
   serial_groups: [toolbox]
   plan:
@@ -392,6 +397,7 @@ jobs:
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
 - name: "Event Latency Monitor"
+  disable_manual_trigger: true
   serial: true
   serial_groups: [event-latency-monitor]
   plan:
@@ -417,6 +423,7 @@ jobs:
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
 - name: "Rabbit Monitor"
+  disable_manual_trigger: true
   serial: true
   serial_groups: [rabbitmonitor]
   plan:
@@ -442,6 +449,7 @@ jobs:
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
 - name: "Regional Counts"
+  disable_manual_trigger: true
   serial: true
   serial_groups: [regionalcounts]
   plan:
@@ -466,7 +474,8 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
-- name: "Report Success"  
+- name: "Report Success"
+  disable_manual_trigger: true
   serial: true
   plan:
   - get: census-rm-kubernetes-release

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -70,9 +70,47 @@ slack_failure_alert: &slack_failure_alert
           }
       ]
 
+slack_success_alert: &slack_success_alert
+  put: slack-alert
+  params:
+    release-ref: census-rm-kuberenetes-release/.git/ref
+    icon_emoji: ":concourse:"
+    username: Concourse
+    attachments: [
+          {
+              "fallback": "$BUILD_PIPELINE_NAME release succeeded. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+              "title": "$BUILD_PIPELINE_NAME Release Succeeded",
+              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+              "fields": [
+                  {
+                      "title": "Pipeline",
+                      "value": "$BUILD_PIPELINE_NAME",
+                      "short": true
+                  },
+                  {
+                      "title": "Environment",
+                      "value": "((gcp-environment-name))",
+                      "short": true
+                  },
+                  {
+                      "title": "Project",
+                      "value": "((gcp-project-name))",
+                      "short": true
+                  },
+                  {
+                      "title": "Version",
+                      "value": "${cat release-ref}",
+                      "short": true
+                  }
+              ],
+              "color": "#36a64f"
+          }
+      ]
+
+
 jobs:
 
-- name: "Trigger All"
+- name: "Deploy"
   serial: true
   plan:
     - get: every-minute
@@ -84,11 +122,11 @@ jobs:
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -109,11 +147,11 @@ jobs:
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -134,11 +172,11 @@ jobs:
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -159,11 +197,11 @@ jobs:
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -184,11 +222,11 @@ jobs:
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -209,11 +247,11 @@ jobs:
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -234,11 +272,11 @@ jobs:
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
     on_failure: *slack_failure_alert
@@ -259,11 +297,11 @@ jobs:
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -284,11 +322,11 @@ jobs:
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -305,22 +343,22 @@ jobs:
 
 - name: "Exception Manager"
   serial: true
-  serial_groups: [sit-exception-manager]
+  serial_groups: [exception-manager]
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((sit-gcp-project-name))
-      KUBERNETES_CLUSTER: ((sit-kubernetes-cluster-name))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: exception-manager
       KUBERNETES_SELECTOR: app=exception-manager
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
@@ -330,22 +368,22 @@ jobs:
 
 - name: "Toolbox"
   serial: true
-  serial_groups: [sit-toolbox]
+  serial_groups: [toolbox]
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((sit-gcp-project-name))
-      KUBERNETES_CLUSTER: ((sit-kubernetes-cluster-name))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: census-rm-toolbox
       KUBERNETES_SELECTOR: app=census-rm-toolbox
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
@@ -359,18 +397,18 @@ jobs:
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((sit-gcp-project-name))
-      KUBERNETES_CLUSTER: ((sit-kubernetes-cluster-name))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: eventlatencymonitor
       KUBERNETES_SELECTOR: app=eventlatencymonitor
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
@@ -384,18 +422,18 @@ jobs:
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((sit-gcp-project-name))
-      KUBERNETES_CLUSTER: ((sit-kubernetes-cluster-name))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: rabbitmonitor
       KUBERNETES_SELECTOR: app=rabbitmonitor
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
@@ -409,21 +447,43 @@ jobs:
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger All"]
+    passed: ["Deploy"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((sit-gcp-project-name))
-      KUBERNETES_CLUSTER: ((sit-kubernetes-cluster-name))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: regionalcounts
       KUBERNETES_SELECTOR: app=regionalcounts
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       KUBERNETES_FILE_PREFIX: regional-counts
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "Report Success"  
+  serial: true
+  plan:
+  - get: census-rm-kubernetes-release
+  - get: every-minute
+    trigger: true
+    passed: ["Action Scheduler", 
+    "Case API", 
+    "Case Processor", 
+    "UAC QID Service", 
+    "PubSub Service",
+    "Print File Service", 
+    "Ops Tool",
+     "Fieldwork Adapter", 
+     "Notify Processor", 
+     "Exception Manager", 
+     "Toolbox", 
+     "Event Latency Monitor", 
+     "Rabbit Monitor", 
+     "Regional Counts"]
+  - *slack_success_alert

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -18,25 +18,19 @@ resources:
     uri: git@github.com:ONSdigital/census-rm-deploy.git
     private_key: ((github.service_account_private_key))
 
-- name: census-rm-kubernetes-microservices-repo
+- name: census-rm-kubernetes-release
   type: git
   source:
     uri: git@github.com:ONSdigital/census-rm-kubernetes.git
     private_key: ((github.service_account_private_key))
-    paths: [release/microservices/*]
-    tag_filter: v*
-  version: 
-    ref: ((kubernetes-release))
+    paths: [release/*]
+    tag_filter: v*.*.*
+    branch: master
 
-- name: census-rm-kubernetes-ops-repo
-  type: git
+- name: every-minute
+  type: time
   source:
-    uri: git@github.com:ONSdigital/census-rm-kubernetes.git
-    private_key: ((github.service_account_private_key))
-    paths: [release/optional/ops-*]
-    tag_filter: v*
-  version:
-    ref: ((kubernetes-release))
+    interval: 1m
 
 templating:
 
@@ -78,13 +72,23 @@ slack_failure_alert: &slack_failure_alert
 
 jobs:
 
-# Kubernetes Config
-- name: action-scheduler
+- name: "Trigger All"
+  serial: true
+  plan:
+    - get: every-minute
+    - get: census-rm-kubernetes-release
+
+- name: "Action Scheduler"
   serial: true
   serial_groups: [action-scheduler]
   plan:
-  - get: census-rm-kubernetes-microservices-repo
+  - get: census-rm-kubernetes-release
+    trigger: true
+    passed: ["Trigger All"]
   - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger All"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -97,14 +101,19 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: action-scheduler
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
-- name: case-api
+- name: "Case API"
   serial: true
   serial_groups: [case-api]
   plan:
-  - get: census-rm-kubernetes-microservices-repo
+  - get: census-rm-kubernetes-release
+    trigger: true
+    passed: ["Trigger All"]
   - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger All"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -117,14 +126,19 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: case-api
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
-- name: case-processor
+- name: "Case Processor"
   serial: true
   serial_groups: [case-processor]
   plan:
-  - get: census-rm-kubernetes-microservices-repo
+  - get: census-rm-kubernetes-release
+    trigger: true
+    passed: ["Trigger All"]
   - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger All"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -137,14 +151,19 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: case-processor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
-- name: uac-qid-service
+- name: "UAC QID Service"
   serial: true
   serial_groups: [uac-qid-service]
   plan:
-  - get: census-rm-kubernetes-microservices-repo
+  - get: census-rm-kubernetes-release
+    trigger: true
+    passed: ["Trigger All"]
   - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger All"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -157,14 +176,19 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: uac-qid-service
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
-- name: pubsubsvc
+- name: "PubSub Service"
   serial: true
   serial_groups: [pubsubsvc]
   plan:
-  - get: census-rm-kubernetes-microservices-repo
+  - get: census-rm-kubernetes-release
+    trigger: true
+    passed: ["Trigger All"]
   - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger All"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -177,14 +201,19 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: pubsub
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
-- name: ops
+- name: "Ops Tool"
   serial: true
   serial_groups: [ops]
   plan:
-  - get: census-rm-kubernetes-ops-repo
+  - get: census-rm-kubernetes-release
+    trigger: true
+    passed: ["Trigger All"]
   - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger All"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -197,14 +226,19 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       KUBERNETES_FILE_PREFIX: ops
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-ops-repo}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
-- name: print-file-service
+- name: "Print File Service"
   serial: true
   serial_groups: [print-file-service]
   plan:
-  - get: census-rm-kubernetes-microservices-repo
+  - get: census-rm-kubernetes-release
+    trigger: true
+    passed: ["Trigger All"]
   - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger All"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
     on_failure: *slack_failure_alert
@@ -217,14 +251,19 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: print-file-service
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
-- name: fieldwork-adapter
+- name: "Fieldwork Adapter"
   serial: true
   serial_groups: [fieldwork-adapter]
   plan:
-  - get: census-rm-kubernetes-microservices-repo
+  - get: census-rm-kubernetes-release
+    trigger: true
+    passed: ["Trigger All"]
   - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger All"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -234,17 +273,22 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: fieldwork-adapter
       KUBERNETES_SELECTOR: app=fieldwork-adapter
-      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: fieldwork-adapter
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
-- name: notify-processor
+- name: "Notify Processor"
   serial: true
   serial_groups: [notify-processor]
   plan:
-  - get: census-rm-kubernetes-microservices-repo
+  - get: census-rm-kubernetes-release
+    trigger: true
+    passed: ["Trigger All"]
   - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger All"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -254,7 +298,132 @@ jobs:
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_DEPLOYMENT_NAME: notify-processor
       KUBERNETES_SELECTOR: app=notify-processor
-      KUBERNETES_FILE_PATH: kubernetes-repo/microservices
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: notify-processor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-microservices-repo}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "Exception Manager"
+  serial: true
+  serial_groups: [sit-exception-manager]
+  plan:
+  - get: census-rm-kubernetes-release
+    trigger: true
+    passed: ["Trigger All"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger All"]
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((sit-gcp-project-name))
+      KUBERNETES_CLUSTER: ((sit-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: exception-manager
+      KUBERNETES_SELECTOR: app=exception-manager
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: exception-manager
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "Toolbox"
+  serial: true
+  serial_groups: [sit-toolbox]
+  plan:
+  - get: census-rm-kubernetes-release
+    trigger: true
+    passed: ["Trigger All"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger All"]
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((sit-gcp-project-name))
+      KUBERNETES_CLUSTER: ((sit-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: census-rm-toolbox
+      KUBERNETES_SELECTOR: app=census-rm-toolbox
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
+      KUBERNETES_FILE_PREFIX: census-rm-toolbox
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "Event Latency Monitor"
+  serial: true
+  serial_groups: [event-latency-monitor]
+  plan:
+  - get: census-rm-kubernetes-release
+    trigger: true
+    passed: ["Trigger All"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger All"]
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((sit-gcp-project-name))
+      KUBERNETES_CLUSTER: ((sit-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: eventlatencymonitor
+      KUBERNETES_SELECTOR: app=eventlatencymonitor
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
+      KUBERNETES_FILE_PREFIX: eventlatencymonitor
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "Rabbit Monitor"
+  serial: true
+  serial_groups: [rabbitmonitor]
+  plan:
+  - get: census-rm-kubernetes-release
+    trigger: true
+    passed: ["Trigger All"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger All"]
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((sit-gcp-project-name))
+      KUBERNETES_CLUSTER: ((sit-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: rabbitmonitor
+      KUBERNETES_SELECTOR: app=rabbitmonitor
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
+      KUBERNETES_FILE_PREFIX: rabbitmonitor
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "Regional Counts"
+  serial: true
+  serial_groups: [regionalcounts]
+  plan:
+  - get: census-rm-kubernetes-release
+    trigger: true
+    passed: ["Trigger All"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger All"]
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((sit-gcp-project-name))
+      KUBERNETES_CLUSTER: ((sit-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: regionalcounts
+      KUBERNETES_SELECTOR: app=regionalcounts
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
+      KUBERNETES_FILE_PREFIX: regional-counts
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}

--- a/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+++ b/tasks/kubectl-apply-service-and-deploy-no-patch.yml
@@ -36,9 +36,6 @@ run:
       # Apply deployment config
       kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-deployment.yml --record
 
-      # Patch deployment with timestamp to force pod recreation
-      kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"timestamp\":\"`date +'%s'`\"}}}}}" --record
-
       # Wait for rollout to finish
       kubectl rollout status deploy ${KUBERNETES_DEPLOYMENT_NAME} --watch=true --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT}
 


### PR DESCRIPTION
# Motivation and Context
The manual release pipeline has never worked for Blacklodge, this is an attempt to simplify it a bit to get it working, and add a single job as a gate to trigger all deployments at one for a given release tag.

It removes the configuration variable specifying the tag to deploy so that it just uses whatever tag the git resource has active.

The `Deploy` job is what should be triggered manually by the user to deploy the active version. This works by acting as a gate on the `every-minute` resource. All the individual service deploy jobs are set to trigger off the `every-minute` resource but require the `Deploy` job to have passed, which is only triggered manually. This allows all the services to be deployed with one manual trigger of the `Deploy` job, once every minute. The version to be deployed can be changed by selectively enabling only the desired version ref in the resource UI.
 To deploy a specific version, disable all versions above it on the resource UI, then trigger the `Deploy` job. See https://concourse-ci.org/manual-trigger-example.html

# What has changed
* Add new services
* Add trigger all job
* Remove tag configuration variable
* Remove patch from no patch deployment

# Links
https://trello.com/c/2SEfALQQ/1367-update-bl-pipeline