### PR TITLE
Add master and release builds of performance tests images

### DIFF
--- a/pipelines/docker-build-pipeline.yml
+++ b/pipelines/docker-build-pipeline.yml
@@ -12,6 +12,7 @@ resources:
     source:
       url: ((slack.webhook))
 
+  # Git repos
   - name: action-scheduler-master
     type: git
     source:
@@ -108,6 +109,13 @@ resources:
       uri: git@github.com:ONSdigital/census-rm-exception-manager.git
       private_key: ((github.service_account_private_key))
 
+  - name: performance-tests-master
+    type: git
+    source:
+      uri: git@github.com:ONSdigital/census-rm-performance-tests.git
+      private_key: ((github.service_account_private_key))
+
+  # Docker images
   - name: action-scheduler-docker-image-ci
     type: docker-image
     source:
@@ -329,6 +337,20 @@ resources:
     type: docker-image
     source:
       repository: ((docker-registry-gcr))/rm/census-rm-exception-manager
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: performance-tests-docker-image-ci
+    type: docker-image
+    source:
+      repository: ((docker-registry-ci))/rm/census-rm-performance-tests
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: performance-tests-docker-image-gcr
+    type: docker-image
+    source:
+      repository: ((docker-registry-gcr))/rm/census-rm-performance-tests
       username: _json_key
       password: ((gcp.service_account_json))
 
@@ -947,6 +969,29 @@ jobs:
         cache_from:
           - exception-manager-docker-image-ci
         tag_file: exception-manager-master/.git/ref
+        tag_as_latest: true
+      get_params:
+        skip_download: true
+
+  - name: build-performance-tests-master
+    plan:
+    - get: performance-tests-master
+      trigger: true
+    - put: performance-tests-docker-image-ci
+      on_failure: *slack_failure_alert_ci
+      params:
+        build: performance-tests-master/docker
+        tag_file: performance-tests-master/.git/ref
+        tag_as_latest: true
+      get_params:
+        save: true
+    - put: performance-tests-docker-image-gcr
+      on_failure: *slack_failure_alert_gcr
+      params:
+        build: performance-tests-master/docker
+        cache_from:
+          - performance-tests-docker-image-ci
+        tag_file: performance-tests-master/.git/ref
         tag_as_latest: true
       get_params:
         skip_download: true

--- a/pipelines/docker-release-pipeline.yml
+++ b/pipelines/docker-release-pipeline.yml
@@ -18,6 +18,7 @@ resources:
     source:
       url: ((slack.webhook))
 
+  # Github Releases
   - name: acceptance-tests-release
     type: github-release-latest
     source:
@@ -138,6 +139,15 @@ resources:
       access_token: ((github.access_token))
       order_by: time
 
+  - name: performance-tests-release
+    type: github-release-latest
+    source:
+      owner: ONSdigital
+      repository: census-rm-performance-tests
+      access_token: ((github.access_token))
+      order_by: time
+
+  # Docker Images
   - name: acceptance-tests-docker-image-ci
     type: docker-image
     source:
@@ -346,6 +356,20 @@ resources:
     type: docker-image
     source:
       repository: ((docker-registry-gcr))/rm/census-rm-exception-manager
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: performance-tests-docker-image-ci
+    type: docker-image
+    source:
+      repository: ((docker-registry-ci))/rm/census-rm-performance-tests
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: performance-tests-docker-image-gcr
+    type: docker-image
+    source:
+      repository: ((docker-registry-gcr))/rm/census-rm-performance-tests
       username: _json_key
       password: ((gcp.service_account_json))
 
@@ -1145,6 +1169,50 @@ jobs:
         cache_from:
           - exception-manager-docker-image-ci
         tag_file: exception-manager-release/tag
+        tag_as_latest: false
+      get_params:
+        skip_download: true
+
+  - name: build-performance-tests-release
+    plan:
+    - get: performance-tests-release
+      params:
+        include_source_tarball: true
+      trigger: true
+    - task: Build Data Exporter Image (release)
+      on_failure: *slack_failure_alert_prebuild
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: alpine
+        inputs:
+          - name: performance-tests-release
+        outputs:
+          - name: extracted-performance-tests
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              cd performance-tests-release
+              tar -xzf source.tar.gz -C ../extracted-performance-tests --strip-components=1
+    - put: performance-tests-docker-image-ci
+      on_failure: *slack_failure_alert_ci
+      params:
+        build: extracted-performance-tests/docker
+        tag_file: performance-tests-release/tag
+        tag_as_latest: false
+      get_params:
+        save: true
+    - put: performance-tests-docker-image-gcr
+      on_failure: *slack_failure_alert_gcr
+      params:
+        build: extracted-performance-tests/docker
+        cache_from:
+          - performance-tests-docker-image-ci
+        tag_file: performance-tests-release/tag
         tag_as_latest: false
       get_params:
         skip_download: true

--- a/validate-pipelines.sh
+++ b/validate-pipelines.sh
@@ -2,6 +2,7 @@
 
 EXIT_STATUS=0
 for i in pipelines/*.yml; do
+    echo "Validating $i"
     fly validate-pipeline -c $i
     VALIDATE_STATUS=$?
     if [ $VALIDATE_STATUS -ne 0 ]; then


### PR DESCRIPTION
# Motivation and Context
We need docker images built for census-rm-performance-tests in GCR from latest/master and releases

# What has changed
* Add master and release builds of performance tests images
* Show pipeline paths in validate pipelines script

# How to test?
Validate the pipeline, inspect for mistakes

# Links
https://trello.com/c/ZQK1bhle/1372-build-and-push-census-rm-performance-image-3