### PR TITLE
Fix config file path in concourse-pipelines pipeline

### DIFF
--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
 
         - name: CI-Whitelodge Deploy
           team: rm
-          config_file: census-rm-deploy/pipelines/ci-sit-kubernetes-pipeline.yml
+          config_file: census-rm-deploy/pipelines/build-deploy-test-CI-WL.yml
           unpaused: true
           vars:
             acceptance-tests-image: eu.gcr.io/census-gcr-rm/rm/census-rm-acceptance-tests:latest


### PR DESCRIPTION
# Motivation and Context
The config file path in the pipeline pipeline is wrong

# What has changed
* Fix path to CI WL pipeline in flying pipeline

# Links
https://trello.com/c/ziVpeo4D/1415-unify-latest-docker-builds-ci-deploy-test-into-single-grouped-pipeline-5