### PR TITLE
Fix QID batch runner input name mismatch

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2011,7 +2011,7 @@ jobs:
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
       KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
       ACCEPTANCE_TESTS_IMAGE: ((acceptance-tests-image))
-      BATCH_RUNNER_CONFIG: qid-batch-runner-repo/qid-batch-runner.yml
+      BATCH_RUNNER_CONFIG: qid-batch-runner-master/qid-batch-runner.yml
     input_mapping: {acceptance-tests-repo: acceptance-tests-repo}
 
 


### PR DESCRIPTION
# Motivation and Context
It's broken

# What has changed
Fix it

# Links
https://trello.com/c/ziVpeo4D/1415-unify-latest-docker-builds-ci-deploy-test-into-single-grouped-pipeline-5