### PR TITLE
Re-add QID batch runner repo AT input

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2012,7 +2012,8 @@ jobs:
       KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
       ACCEPTANCE_TESTS_IMAGE: ((acceptance-tests-image))
       BATCH_RUNNER_CONFIG: qid-batch-runner-master/qid-batch-runner.yml
-    input_mapping: {acceptance-tests-repo: acceptance-tests-repo}
+    input_mapping: {acceptance-tests-repo: acceptance-tests-repo,
+                    batch-runner-repo: qid-batch-runner-master}
 
 
 # WL Deployments


### PR DESCRIPTION
# Motivation and Context
batch-runner-repo input was missing

# What has changed
* Re-add batch-runner-repo input in CI AT job

# Links
https://trello.com/c/ziVpeo4D/1415-unify-latest-docker-builds-ci-deploy-test-into-single-grouped-pipeline-5