### PR TITLE
Revert #86

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2011,7 +2011,7 @@ jobs:
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
       KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
       ACCEPTANCE_TESTS_IMAGE: ((acceptance-tests-image))
-      BATCH_RUNNER_CONFIG: qid-batch-runner-master/qid-batch-runner.yml
+      BATCH_RUNNER_CONFIG: batch-runner-repo/qid-batch-runner.yml
     input_mapping: {acceptance-tests-repo: acceptance-tests-repo,
                     batch-runner-repo: qid-batch-runner-master}
 


### PR DESCRIPTION
# Motivation and Context
#86 was mistaken, the directory it refers to is within the AT job where is named `batch-runner-repo`

# What has changed
* revert #86 

# Links
https://trello.com/c/ziVpeo4D/1415-unify-latest-docker-builds-ci-deploy-test-into-single-grouped-pipeline-5