### PR TITLE
Remove tag filter from kuberenetes repo release resource

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -49,7 +49,6 @@ resources:
     uri: git@github.com:ONSdigital/census-rm-kubernetes.git
     private_key: ((github.service_account_private_key))
     paths: [release/*]
-    tag_filter: v*.*.*
     branch: master
 
 - name: every-minute


### PR DESCRIPTION
# Motivation and Context
We don't want to have to release the kubernetes repo to deploy changes to the performance environment

# What has changed
* Remove tag filter from kuberenetes repo release resource

# Links
https://trello.com/c/WiicGgid/334-rebuild-database-from-ground-zero-before-test-in-pipeline-8#