### PR TITLE
Pass fetched vars into apply-prod script instead of appending to tfvars

### DIFF
--- a/tasks/terraform-env.yml
+++ b/tasks/terraform-env.yml
@@ -28,8 +28,8 @@ run:
       cd census-rm-terraform
       tfenv install
 
-      echo db_user_password = $(kubectl get secret db-credentials -o=jsonpath="{.data.password}" | base64 --decode) >> $VAR_FILE
-      echo sftp_user_name = $(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.username}" | base64 --decode) >> $VAR_FILE
-      echo sftp_user_password = $(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.passphrase}" | base64 --decode) >> $VAR_FILE
+      DB_PASSWORD=$(kubectl get secret db-credentials -o=jsonpath="{.data.password}" | base64 --decode)
+      SFTP_USER_NAME=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.username}" | base64 --decode)
+      SFTP_PASSPHRASE=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.passphrase}" | base64 --decode)
 
-      SKIP_REPLICA_DB_SSL_RESET=true SKIP_DB_SSL_RESET=true AUTO_APPLY=true ./apply-prod.sh 
+      SKIP_REPLICA_DB_SSL_RESET=true SKIP_DB_SSL_RESET=true AUTO_APPLY=true ./apply-prod.sh "db_user_password=$DB_PASSWORD" "sftp_user_name=$SFTP_USER_NAME" "sftp_user_password=$SFTP_PASSPHRASE"


### PR DESCRIPTION
# Motivation and Context
We need to pass the vars into the apply-prod script in the terraform env job instead of appending to the tfvars file.

# What has changed
* Pass fetched vars into apply-prod script instead of appending to tfvars

# Links
https://trello.com/c/dx8b9cdR/360-build-an-environment-from-pipeline-13