### PR TITLE
Trigger CI AT's from repo resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Create a config YAML file containing the required configuration:
 | gcp-project-name         | String                                                                              | The name of the GCP project targeted cluster belongs to                                                       |
 
 #### Force checking for older versions
-By default the github resource will only pick tags from the newest since the pipeline was first flown. If you need to use an older tag you can force it to check older resources versions with the [`check-resource` fly command](https://concourse-ci.org/managing-resources.html#fly-check-resource) with an appropraite `from`, e.g.
+By default the github resource will only pick tags from the newest since the pipeline was first flown. If you need to use an older tag you can force it to check older resources versions with the [`check-resource` fly command](https://concourse-ci.org/managing-resources.html#fly-check-resource) with an appropriate `from -f` flag, e.g.
 
 ```shell-script
 fly -t <target> check-resource -r <pipeline>/census-rm-kubernetes-release -f ref:v1.0.0

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -166,13 +166,6 @@ resources:
     private_key: ((github.service_account_private_key))
     paths: [dependencies/*, rabbitmq/*, setup-dependencies.sh]
 
-- name: acceptance-tests-repo
-  type: git
-  source:
-    uri: git@github.com:ONSdigital/census-rm-acceptance-tests.git
-    private_key: ((github.service_account_private_key))
-    paths: [kubernetes.env, tasks/*]
-
 - name: census-rm-terraform
   type: git
   source:
@@ -1999,7 +1992,7 @@ jobs:
              "CI Deploy Event Latency Monitor",
              "CI Deploy Rabbit Monitor",
              "CI Deploy Regional Counts"]
-  - get: acceptance-tests-repo
+  - get: acceptance-tests-master
     trigger: true
     passed: ["Build Acceptance Tests Latest"]
   - get: acceptance-tests-docker-image-gcr
@@ -2064,7 +2057,7 @@ jobs:
              "CI Deploy Rabbit Monitor",
              "CI Deploy Regional Counts"]
   - task: "Run Acceptance Tests (in K8s)"
-    file: acceptance-tests-repo/tasks/kubectl-run-acceptance-tests.yml
+    file: acceptance-tests-master/tasks/kubectl-run-acceptance-tests.yml
     on_failure: *slack_failure_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -2072,7 +2065,7 @@ jobs:
       KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
       ACCEPTANCE_TESTS_IMAGE: ((acceptance-tests-image))
       BATCH_RUNNER_CONFIG: batch-runner-repo/qid-batch-runner.yml
-    input_mapping: {acceptance-tests-repo: acceptance-tests-repo,
+    input_mapping: {acceptance-tests-repo: acceptance-tests-master,
                     batch-runner-repo: qid-batch-runner-master}
 
 # WL Terraform

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2000,8 +2000,9 @@ jobs:
              "CI Deploy Rabbit Monitor",
              "CI Deploy Regional Counts"]
   - get: acceptance-tests-repo
-  - get: acceptance-tests-docker-image-gcr
     trigger: true
+    passed: ["Build Acceptance Tests Latest"]
+  - get: acceptance-tests-docker-image-gcr
     params:
       skip_download: true
   - get: census-rm-kubernetes-dependencies-repo


### PR DESCRIPTION
# Motivation and Context
Change to use the acceptance tests image to trigger the job in CI Concourse pipeline instead of the docker image resource, this makes it easier to trace which code changes triggered/were used in the tests

# What has changed
* Trigger CI AT's from repo resource
* Remove duplicate AT repo resource
* Fix unrelated README typo

# Links
https://trello.com/c/96T3nZf8/432-trigger-ci-acceptance-tests-on-repo-instead-of-image