### PR TITLE
Change Action Worker from Service to Deployment

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -1574,7 +1574,7 @@ jobs:
       skip_download: true
   - get: census-rm-deploy
   - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -2310,7 +2310,7 @@ jobs:
       skip_download: true
   - get: census-rm-deploy
   - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -181,7 +181,7 @@ jobs:
     trigger: true
     passed: ["Deploy"]
   - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -369,7 +369,7 @@ jobs:
     trigger: true
     passed: ["Trigger Deployment"]
   - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_release_failure
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))


### PR DESCRIPTION
# Motivation and Context
Action Worker was being deployed as a service.

# What has changed
Deployed as deployment.

# How to test?
Merge. Fly. Run.

# Links
Trello: https://trello.com/c/462ZhSzd