### PR TITLE
Increase number of Action Workers

### DIFF
--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -116,5 +116,5 @@ jobs:
             performance-kubernetes-cluster-name: rm-k8s-cluster
             performance-tests-image: eu.gcr.io/census-gcr-rm/rm/census-rm-performance-tests
             case-processor-replicas: 4
-            action-worker-replicas: 1
+            action-worker-replicas: 10
             uac-qid-replicas: 2


### PR DESCRIPTION
# Motivation and Context
Now we can horizontally scale the Action Workers, we should check to see how much it improves performance.

# What has changed
Increased number of Action Workers from 1 to 10.

# How to test?
Merge. Run the performance pipeline. Profit

# Links
Trello: https://trello.com/c/AfyTFqUe