### PR TITLE
Use generic terraform-env for CI infrastructure deploy

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -140,12 +140,6 @@ resources:
     uri: git@github.com:ONSdigital/census-rm-deploy.git
     private_key: ((github.service_account_private_key))
 
-- name: census-rm-kubernetes-repo
-  type: git
-  source:
-    uri: git@github.com:ONSdigital/census-rm-kubernetes.git
-    private_key: ((github.service_account_private_key))
-
 - name: census-rm-kubernetes-microservices-repo
   type: git
   source:

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -1475,18 +1475,18 @@ jobs:
   on_success: *slack_success_alert_ci
   on_failure: *slack_failure_alert_ci
   plan:
-    - get: census-rm-terraform
+  - get: census-rm-terraform
     trigger: true
   - get: census-rm-deploy
   - *slack_started_alert_ci
   - task: "CI Terraform"
     file: census-rm-deploy/tasks/terraform-env.yml
-      params:
-        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-        ENV: ci
-        VAR_FILE: ./tfvars/census-rm-ci.tfvars
-        KUBERNETES_CLUSTER: rm-k8s-cluster
-      input_mapping: {census-rm-terraform: census-rm-terraform}
+    params:
+      ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      ENV: ci
+      VAR_FILE: ./tfvars/census-rm-ci.tfvars
+      KUBERNETES_CLUSTER: rm-k8s-cluster
+    input_mapping: {census-rm-terraform: census-rm-terraform}
 
 - name: "CI Rabbit Helm"
   serial: true

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -1485,6 +1485,7 @@ jobs:
 - name: "CI Rabbit Helm"
   serial: true
   serial_groups: [ci-terraform,
+                  ci-acceptance-tests,
                   action-scheduler-deploy,
                   action-worker-deploy,
                   case-api-deploy,

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -20,7 +20,8 @@ groups:
   - "Build Sample Loader Latest"
   - "Build Toolbox Latest"
   - "Build UAC QID Service Latest"
-  - "CI Deploy Infrastructure"
+  - "CI Terraform"
+  - "CI Rabbit Helm"
   - "CI Deploy Action-Scheduler"
   - "CI Deploy Action-Worker"
   - "CI Deploy Case-API"
@@ -79,7 +80,8 @@ groups:
 
 - name: "CI"
   jobs:
-  - "CI Deploy Infrastructure"
+  - "CI Terraform"
+  - "CI Rabbit Helm"
   - "CI Deploy Action-Scheduler"
   - "CI Deploy Action-Worker"
   - "CI Deploy Case-API"
@@ -1450,11 +1452,9 @@ jobs:
     get_params:
       skip_download: true
 
-
-# CI Deployments
-- name: "CI Deploy Infrastructure"
+- name: "CI Terraform"
   serial: true
-  serial_groups: [ci-deploy-infrastructure,
+  serial_groups: [ci-terraform,
                   ci-acceptance-tests,
                   action-scheduler-deploy,
                   action-worker-deploy,
@@ -1472,57 +1472,57 @@ jobs:
                   rabbitmonitor-deploy,
                   regional-counts-deploy,
                   ops-deploy]
-  max_in_flight: 1
+  on_success: *slack_success_alert_ci
+  on_failure: *slack_failure_alert_ci
   plan:
-  - get: census-rm-terraform
+    - get: census-rm-terraform
     trigger: true
-  - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
-  - get: census-rm-kubernetes-repo
+  - get: census-rm-deploy
   - *slack_started_alert_ci
-  - task: "Build & Deploy Infrastructure"
-    on_success: *slack_success_alert_ci
-    on_failure: *slack_failure_alert_ci
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: google/cloud-sdk
+  - task: "CI Terraform"
+    file: census-rm-deploy/tasks/terraform-env.yml
       params:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-        AUTO_APPLY: true
-        DEV_DUMMY_PGP: true
-        DEV_PUBSUB: true
-        DISABLE_CI_BINDING: true
-        ENV: ((ci-gcp-environment-name))
-        GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json
-        KEEP_TMP_K8S: true
-        SKIP_DEPLOYMENTS: true
-      inputs:
-        - name: census-rm-terraform
-        - name: census-rm-kubernetes-repo
-      run:
-        path: bash
-        args:
-          - -exc
-          - |
-            apt-get install -y unzip procps  # NB: procps is used by Helm
-            git clone https://github.com/kamatama41/tfenv.git ~/.tfenv && \
-            ln -s /root/.tfenv/bin/* /usr/local/bin
-            cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
-            $ADMIN_SERVICE_ACCOUNT_JSON
-            EOL
-            gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
-            cp -R census-rm-kubernetes-repo/ census-rm-terraform/tmp_rm_kube
-            cd census-rm-terraform
-            tfenv install
-            curl -L https://git.io/get_helm.sh | bash && \
-            helm init --client-only && \
-            helm plugin install https://github.com/rimusz/helm-tiller
-            ./apply.sh
+        ENV: ci
+        VAR_FILE: ./tfvars/census-rm-ci.tfvars
+        KUBERNETES_CLUSTER: rm-k8s-cluster
+      input_mapping: {census-rm-terraform: census-rm-terraform}
 
+- name: "CI Rabbit Helm"
+  serial: true
+  serial_groups: [ci-terraform,
+                  action-scheduler-deploy,
+                  action-worker-deploy,
+                  case-api-deploy,
+                  case-processor-deploy,
+                  uac-qid-service-deploy,
+                  pubsub-deploy,
+                  print-file-service-deploy,
+                  fieldwork-adapter-deploy,
+                  notify-processor-deploy,
+                  notify-stub-deploy,
+                  exception-manager-deploy,
+                  toolbox-deploy,
+                  eventlatencymonitor-deploy,
+                  rabbitmonitor-deploy,
+                  regional-counts-deploy]
+  on_success: *slack_success_alert_ci
+  on_failure: *slack_failure_alert_ci
+  plan:
+    - get: census-rm-kubernetes-dependencies-repo
+      trigger: true
+      passed: ["CI Acceptance Tests"]
+    - get: census-rm-deploy
+    - *slack_started_alert_ci
+    - task: "CI Rabbit Helm"
+      file: census-rm-deploy/tasks/helm-rabbit.yml
+      params:
+        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+        ENV: ci
+        KUBERNETES_CLUSTER: rm-k8s-cluster
+      input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-dependencies-repo}
 
+# CI Deployments
 - name: "CI Deploy Action-Scheduler"
   serial: true
   serial_groups: [action-scheduler-build,
@@ -1530,7 +1530,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: action-scheduler-master
@@ -1563,7 +1566,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: action-worker-master
@@ -1596,7 +1602,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: case-api-master
@@ -1629,7 +1638,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: case-processor-master
@@ -1662,7 +1674,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: uac-qid-service-master
@@ -1695,7 +1710,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: pubsub-master
@@ -1728,7 +1746,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-ops-repo
     trigger: true
   - get: ops-master
@@ -1761,7 +1782,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: print-file-service-master
@@ -1794,7 +1818,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: fieldwork-adapter-master
@@ -1827,7 +1854,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: notify-processor-master
@@ -1860,7 +1890,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: notify-stub-master
@@ -1893,7 +1926,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: exception-manager-master
@@ -1926,7 +1962,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
@@ -1959,7 +1998,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
@@ -1992,7 +2034,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
@@ -2025,7 +2070,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Infrastructure"]
+    passed: ["CI Terraform"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Rabbit Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Updated the CI pipeline to use the generic `terraform-envs` task for infrastructure changes

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Remove old, inline CI deployment steps
* Use generic deployment task for CI

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check against the tfvars from [this branch](https://github.com/ONSdigital/census-rm-terraform/pull/118)

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/TqleWXgK/424-use-the-terraform-env-job-to-deploy-ci-infrastructure-5