### PR TITLE
Add missing failure alerts

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -128,37 +128,6 @@ resources:
 
 templating:
 
-slack_release_failure: &slack_release_failure
-  put: slack-alert
-  params:
-    icon_emoji: ":concourse:"
-    username: Concourse
-    attachments: [
-          {
-              "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-              "title": "$BUILD_JOB_NAME failed",
-              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-              "fields": [
-                  {
-                      "title": "Pipeline",
-                      "value": "$BUILD_PIPELINE_NAME",
-                      "short": true
-                  },
-                  {
-                      "title": "Project",
-                      "value": "((performance-gcp-project-name))",
-                      "short": true
-                  },
-                  {
-                      "title": "Build",
-                      "value": "#$BUILD_NAME",
-                      "short": true
-                  }
-              ],
-              "color": "#F35A00"
-          }
-      ]
-
 slack_release_success: &slack_release_success
   put: slack-alert
   params:
@@ -221,14 +190,14 @@ slack_release_in_progress: &slack_release_in_progress
           }
       ]
 
-slack_performance_tests_failure: &slack_performance_tests_failure
+slack_failure_alert: &slack_failure_alert
   put: slack-alert
   params:
     icon_emoji: ":concourse:"
     username: Concourse
     attachments: [
           {
-              "fallback": "Performance tests failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+              "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
               "title": "$BUILD_JOB_NAME failed",
               "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
               "fields": [
@@ -401,7 +370,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_failure: *slack_release_failure
+    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -427,7 +396,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_release_failure
+    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -453,7 +422,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_failure: *slack_release_failure
+    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -479,7 +448,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_release_failure
+    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -505,7 +474,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_failure: *slack_release_failure
+    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -531,7 +500,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_release_failure
+    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -557,7 +526,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
-    on_failure: *slack_release_failure
+    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -583,7 +552,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_release_failure
+    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -609,7 +578,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_release_failure
+    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -635,7 +604,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_failure: *slack_release_failure
+    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -661,7 +630,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_release_failure
+    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -687,7 +656,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_release_failure
+    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -713,7 +682,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_release_failure
+    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -995,7 +964,7 @@ jobs:
       KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
       PERFORMANCE_TESTS_IMAGE: ((performance-tests-image))
     input_mapping: {performance-tests-repo: performance-tests-repo}
-  on_failure: *slack_performance_tests_failure
+  on_failure: *slack_failure_alert
   on_success: *slack_performance_tests_finished
 
 - name: "Trigger Terraform"
@@ -1024,6 +993,7 @@ jobs:
 - name: "Run Terraform"
   disable_manual_trigger: true
   serial: true
+  on_failure: *slack_failure_alert
   serial_groups: [scale-down,
                   scale-apps,
                   performance-tests,
@@ -1059,6 +1029,7 @@ jobs:
 - name: "Run Rabbit Helm"
   disable_manual_trigger: true
   serial: true
+  on_failure: *slack_failure_alert
   serial_groups: [scale-down,
                   scale-apps,
                   performance-tests,


### PR DESCRIPTION
# Motivation and Context
We need alerts on failures as we don't have good visibility of the pipeline currently.

# What has changed
* Add missing failure alerts
* Use generic failure alert in performance pipeline

# Links
https://trello.com/c/RZCuJYhC/446-add-missing-slack-alerts-3