### PR TITLE
auto scale performance tests infrastructure

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -1,71 +1,4 @@
----
-groups:
-- name: Overview
-  jobs:
-  - Trigger Deployment
-  - Action Scheduler
-  - Action Worker
-  - Case API
-  - Case Processor
-  - Database Monitor
-  - Exception Manager
-  - Fieldwork Adapter
-  - Notify Processor
-  - Print File Service
-  - PubSub Service
-  - Rabbit Monitor
-  - Toolbox
-  - UAC QID Service
-  - Report Deployment Success
-  - Trigger Performance Tests
-  - Scale Down Apps
-  - Reset DB
-  - Scale Up Apps
-  - Performance Tests
-  - Trigger Terraform
-  - Run Terraform
-  - Run Rabbit Helm
-  - Report Terraform Success
 
-- name: Manual Triggers
-  jobs:
-  - Trigger Deployment
-  - Trigger Performance Tests
-  - Trigger Terraform
-
-- name: Terraform
-  jobs:
-  - Trigger Terraform
-  - Run Terraform
-  - Run Rabbit Helm
-  - Report Terraform Success
-
-- name: Deployments
-  jobs:
-  - Trigger Deployment
-  - Action Scheduler
-  - Action Worker
-  - Case API
-  - Case Processor
-  - Database Monitor
-  - Exception Manager
-  - Fieldwork Adapter
-  - Notify Processor
-  - Print File Service
-  - PubSub Service
-  - Rabbit Monitor
-  - Toolbox
-  - UAC QID Service
-  - Report Deployment Success
-  
-- name: Performance Tests
-  jobs:
-  - Trigger Performance Tests
-  - Scale Down Apps
-  - Reset DB
-  - Scale Up Apps
-  - Performance Tests
-  
 resource_types:
 - name: slack-notification
   type: docker-image
@@ -85,14 +18,6 @@ resources:
     uri: git@github.com:ONSdigital/census-rm-deploy.git
     private_key: ((github.service_account_private_key))
 
-- name: census-rm-kubernetes-release
-  type: git
-  source:
-    uri: git@github.com:ONSdigital/census-rm-kubernetes.git
-    private_key: ((github.service_account_private_key))
-    paths: [release/*]
-    branch: master
-
 - name: every-minute
   type: time
   source:
@@ -106,7 +31,7 @@ resources:
     private_key: ((github.service_account_private_key))
 
 - name: performance-tests-docker-image
-  type: docker-image
+  type: docker-imagex
   source:
     repository: ((performance-tests-image))
     username: _json_key
@@ -349,32 +274,15 @@ slack_terraform_success: &slack_terraform_success
 
 jobs:
 
-- name: "Trigger Deployment"
-  serial: true
-  plan:
-    - get: every-minute
-    - get: census-rm-kubernetes-release
-    - get: performance-tests-repo
-    - task: start-infrastructure
-      file: performance-tests-repo/tasks/start-performance-infrastructure.yml
-      params:
-        SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-        KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-        GCP_PROJECT_NAME: ((performance-gcp-project-name))
-  on_success: *slack_release_in_progress
-
 - name: "Action Scheduler"
   disable_manual_trigger: true
   serial: true
   serial_groups: [action-scheduler]
   plan:
-  - get: census-rm-kubernetes-release
-    trigger: true
-    passed: ["Trigger Deployment"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger Deployment"]
+    passed: ["Run Terraform"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -394,13 +302,10 @@ jobs:
   serial: true
   serial_groups: [action-worker]
   plan:
-  - get: census-rm-kubernetes-release
-    trigger: true
-    passed: ["Trigger Deployment"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger Deployment"]
+    passed: ["Run Terraform"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -420,13 +325,10 @@ jobs:
   serial: true
   serial_groups: [case-api]
   plan:
-  - get: census-rm-kubernetes-release
-    trigger: true
-    passed: ["Trigger Deployment"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger Deployment"]
+    passed: ["Run Terraform"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -446,13 +348,10 @@ jobs:
   serial: true
   serial_groups: [case-processor]
   plan:
-  - get: census-rm-kubernetes-release
-    trigger: true
-    passed: ["Trigger Deployment"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger Deployment"]
+    passed: ["Run Terraform"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -472,13 +371,10 @@ jobs:
   serial: true
   serial_groups: [uac-qid-service]
   plan:
-  - get: census-rm-kubernetes-release
-    trigger: true
-    passed: ["Trigger Deployment"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger Deployment"]
+    passed: ["Run Terraform"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -498,13 +394,10 @@ jobs:
   serial: true
   serial_groups: [pubsubsvc]
   plan:
-  - get: census-rm-kubernetes-release
-    trigger: true
-    passed: ["Trigger Deployment"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger Deployment"]
+    passed: ["Run Terraform"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -524,13 +417,10 @@ jobs:
   serial: true
   serial_groups: [print-file-service]
   plan:
-  - get: census-rm-kubernetes-release
-    trigger: true
-    passed: ["Trigger Deployment"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger Deployment"]
+    passed: ["Run Terraform"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
     on_failure: *slack_failure_alert
@@ -550,13 +440,10 @@ jobs:
   serial: true
   serial_groups: [fieldwork-adapter]
   plan:
-  - get: census-rm-kubernetes-release
-    trigger: true
-    passed: ["Trigger Deployment"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger Deployment"]
+    passed: ["Run Terraform"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -576,13 +463,10 @@ jobs:
   serial: true
   serial_groups: [notify-processor]
   plan:
-  - get: census-rm-kubernetes-release
-    trigger: true
-    passed: ["Trigger Deployment"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger Deployment"]
+    passed: ["Run Terraform"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -602,13 +486,10 @@ jobs:
   serial: true
   serial_groups: [exception-manager]
   plan:
-  - get: census-rm-kubernetes-release
-    trigger: true
-    passed: ["Trigger Deployment"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger Deployment"]
+    passed: ["Run Terraform"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -628,13 +509,10 @@ jobs:
   serial: true
   serial_groups: [toolbox]
   plan:
-  - get: census-rm-kubernetes-release
-    trigger: true
-    passed: ["Trigger Deployment"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger Deployment"]
+    passed: ["Run Terraform"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -654,13 +532,10 @@ jobs:
   serial: true
   serial_groups: [database-monitor]
   plan:
-  - get: census-rm-kubernetes-release
-    trigger: true
-    passed: ["Trigger Deployment"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger Deployment"]
+    passed: ["Run Terraform"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -680,13 +555,10 @@ jobs:
   serial: true
   serial_groups: [rabbitmonitor]
   plan:
-  - get: census-rm-kubernetes-release
-    trigger: true
-    passed: ["Trigger Deployment"]
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Trigger Deployment"]
+    passed: ["Run Terraform"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -700,35 +572,6 @@ jobs:
       KUBERNETES_FILE_PREFIX: rabbitmonitor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
-
-- name: "Report Deployment Success"
-  disable_manual_trigger: true
-  serial: true
-  plan:
-  - get: every-minute
-    trigger: true
-    passed: [
-      "Action Scheduler",
-      "Action Worker",
-      "Case API",
-      "Case Processor",
-      "UAC QID Service",
-      "PubSub Service",
-      "Print File Service",
-      "Fieldwork Adapter",
-      "Notify Processor",
-      "Exception Manager",
-      "Toolbox",
-      "Database Monitor",
-      "Rabbit Monitor"]
-  - get: performance-tests-repo
-  - task: stop-infrastructure
-    file: performance-tests-repo/tasks/stop-performance-infrastructure.yml
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
-  - *slack_release_success
 
 - name: "Trigger Performance Tests"
   serial: true
@@ -786,7 +629,21 @@ jobs:
       skip_download: true
   - get: every-minute
     trigger: true
-    passed: ["Trigger Performance Tests"]
+    passed: [
+      "Action Scheduler",
+      "Action Worker",
+      "Case API",
+      "Case Processor",
+      "UAC QID Service",
+      "PubSub Service",
+      "Print File Service",
+      "Fieldwork Adapter",
+      "Notify Processor",
+      "Exception Manager",
+      "Toolbox",
+      "Database Monitor",
+      "Run Rabbit Helm",
+      "Rabbit Monitor"]
   - task: "Scale down pre ground zero"
     config:
       platform: linux
@@ -993,35 +850,6 @@ jobs:
   on_failure: *slack_failure_alert
   on_success: *slack_performance_tests_finished
 
-- name: "Trigger Terraform"
-  serial: true
-  serial_groups: [
-    scale-down,
-    scale-apps,
-    performance-tests,
-    action-scheduler,
-    action-worker,
-    case-api,
-    case-processor,
-    fieldwork-adapter,
-    notify-processor,
-    uac-qid-service,
-    pubsubsvc,
-    print-file-service,
-    exception-manager,
-    toolbox,
-    database-monitor,
-    rabbitmonitor]
-  plan:
-    - get: every-minute
-    - get: performance-tests-repo
-    - task: start-infrastructure
-      file: performance-tests-repo/tasks/start-performance-infrastructure.yml
-      params:
-        SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-        KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-        GCP_PROJECT_NAME: ((performance-gcp-project-name))
-
 # Run Terraform
 - name: "Run Terraform"
   disable_manual_trigger: true
@@ -1046,7 +874,7 @@ jobs:
   plan:
     - get: every-minute
       trigger: true
-      passed: ["Trigger Terraform"]
+      passed: ["Trigger Performance Tests"]
     - get: census-rm-terraform
     - get: census-rm-deploy
     - task: "Run Terraform"
@@ -1093,21 +921,3 @@ jobs:
         KUBERNETES_CLUSTER: rm-k8s-cluster
         RABBITMQ_CONFIG_VALUES_FILE: release/rabbitmq/values_prod.yml
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-dependencies-repo}
-
-- name: "Report Terraform Success"
-  disable_manual_trigger: true
-  serial: true
-  plan:
-  - get: every-minute
-    trigger: true
-    passed: [
-      "Run Terraform",
-      "Run Rabbit Helm"]
-  - get: performance-tests-repo
-  - task: stop-infrastructure
-    file: performance-tests-repo/tasks/stop-performance-infrastructure.yml
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
-  - *slack_terraform_success

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -752,7 +752,6 @@ jobs:
     params:
       skip_download: true
   - get: every-minute
-  - get: performance-tests-repo
   - task: start-infrastructure
     file: performance-tests-repo/tasks/start-performance-infrastructure.yml
     params:
@@ -985,7 +984,6 @@ jobs:
       KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
       PERFORMANCE_TESTS_IMAGE: ((performance-tests-image))
     input_mapping: {performance-tests-repo: performance-tests-repo}
-  - get: performance-tests-repo
   - task: stop-infrastructure
     file: performance-tests-repo/tasks/stop-performance-infrastructure.yml
     params:

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -65,7 +65,7 @@ groups:
   - Reset DB
   - Scale Up Apps
   - Performance Tests
-
+  
 resource_types:
 - name: slack-notification
   type: docker-image
@@ -354,6 +354,13 @@ jobs:
   plan:
     - get: every-minute
     - get: census-rm-kubernetes-release
+    - get: performance-tests-repo
+    - task: start-infrastructure
+      file: performance-tests-repo/tasks/start-performance-infrastructure.yml
+      params:
+        SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+        KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+        GCP_PROJECT_NAME: ((performance-gcp-project-name))
   on_success: *slack_release_in_progress
 
 - name: "Action Scheduler"
@@ -714,6 +721,13 @@ jobs:
       "Toolbox",
       "Database Monitor",
       "Rabbit Monitor"]
+  - get: performance-tests-repo
+  - task: stop-infrastructure
+    file: performance-tests-repo/tasks/stop-performance-infrastructure.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
   - *slack_release_success
 
 - name: "Trigger Performance Tests"
@@ -738,6 +752,13 @@ jobs:
     params:
       skip_download: true
   - get: every-minute
+  - get: performance-tests-repo
+  - task: start-infrastructure
+    file: performance-tests-repo/tasks/start-performance-infrastructure.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
   - *slack_performance_tests_started
 
 - name: "Scale Down Apps"
@@ -964,6 +985,13 @@ jobs:
       KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
       PERFORMANCE_TESTS_IMAGE: ((performance-tests-image))
     input_mapping: {performance-tests-repo: performance-tests-repo}
+  - get: performance-tests-repo
+  - task: stop-infrastructure
+    file: performance-tests-repo/tasks/stop-performance-infrastructure.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
   on_failure: *slack_failure_alert
   on_success: *slack_performance_tests_finished
 
@@ -988,6 +1016,13 @@ jobs:
     rabbitmonitor]
   plan:
     - get: every-minute
+    - get: performance-tests-repo
+    - task: start-infrastructure
+      file: performance-tests-repo/tasks/start-performance-infrastructure.yml
+      params:
+        SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+        KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+        GCP_PROJECT_NAME: ((performance-gcp-project-name))
 
 # Run Terraform
 - name: "Run Terraform"
@@ -1070,4 +1105,11 @@ jobs:
     passed: [
       "Run Terraform",
       "Run Rabbit Helm"]
+  - get: performance-tests-repo
+  - task: stop-infrastructure
+    file: performance-tests-repo/tasks/stop-performance-infrastructure.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
   - *slack_terraform_success

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -5,14 +5,6 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
 
-- name: census-rm-kubernetes-release	
-  type: git	
-  source:
-    uri: git@github.com:ONSdigital/census-rm-kubernetes.git	
-    private_key: ((github.service_account_private_key))	
-    paths: [release/*]
-    branch: master
-
 resources:
 
 - name: slack-alert
@@ -58,6 +50,14 @@ resources:
     uri: git@github.com:ONSdigital/census-rm-kubernetes.git
     private_key: ((github.service_account_private_key))
     paths: [dependencies/*, rabbitmq/*, setup-dependencies.sh]
+
+- name: census-rm-kubernetes-release	
+  type: git	
+  source:
+    uri: git@github.com:ONSdigital/census-rm-kubernetes.git	
+    private_key: ((github.service_account_private_key))	
+    paths: [release/*]
+    branch: master
 
 templating:
 
@@ -282,305 +282,6 @@ slack_terraform_success: &slack_terraform_success
 
 jobs:
 
-- name: "Action Scheduler"
-  disable_manual_trigger: true
-  serial: true
-  serial_groups: [action-scheduler]
-  plan:
-  - get: census-rm-deploy
-  - get: every-minute
-    trigger: true
-    passed: ["Scale Down Apps and Reset DB"]
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_failure: *slack_failure_alert
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: action-scheduler
-      KUBERNETES_SELECTOR: app=action-scheduler
-      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
-      KUBERNETES_FILE_PREFIX: action-scheduler
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
-
-- name: "Action Worker"
-  disable_manual_trigger: true
-  serial: true
-  serial_groups: [action-worker]
-  plan:
-  - get: census-rm-deploy
-  - get: every-minute
-    trigger: true
-    passed: ["Scale Down Apps and Reset DB"]
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: action-worker
-      KUBERNETES_SELECTOR: app=action-worker
-      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
-      KUBERNETES_FILE_PREFIX: action-worker
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
-
-- name: "Case API"
-  disable_manual_trigger: true
-  serial: true
-  serial_groups: [case-api]
-  plan:
-  - get: census-rm-deploy
-  - get: every-minute
-    trigger: true
-    passed: ["Scale Down Apps and Reset DB"]
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_failure: *slack_failure_alert
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: case-api
-      KUBERNETES_SELECTOR: app=case-api
-      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
-      KUBERNETES_FILE_PREFIX: case-api
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
-
-- name: "Case Processor"
-  disable_manual_trigger: true
-  serial: true
-  serial_groups: [case-processor]
-  plan:
-  - get: census-rm-deploy
-  - get: every-minute
-    trigger: true
-    passed: ["Scale Down Apps and Reset DB"]
-  - task: apply-deployment
-    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: case-processor
-      KUBERNETES_SELECTOR: app=case-processor
-      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
-      KUBERNETES_FILE_PREFIX: case-processor
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
-
-- name: "UAC QID Service"
-  disable_manual_trigger: true
-  serial: true
-  serial_groups: [uac-qid-service]
-  plan:
-  - get: census-rm-deploy
-  - get: every-minute
-    trigger: true
-    passed: ["Scale Down Apps and Reset DB"]
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_failure: *slack_failure_alert
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: uacqidservice
-      KUBERNETES_SELECTOR: app=uacqidservice
-      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
-      KUBERNETES_FILE_PREFIX: uac-qid-service
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
-
-- name: "PubSub Service"
-  disable_manual_trigger: true
-  serial: true
-  serial_groups: [pubsubsvc]
-  plan:
-  - get: census-rm-deploy
-  - get: every-minute
-    trigger: true
-    passed: ["Scale Down Apps and Reset DB"]
-  - task: apply-deployment
-    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: pubsubsvc
-      KUBERNETES_SELECTOR: app=pubsubsvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
-      KUBERNETES_FILE_PREFIX: pubsub
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
-
-- name: "Print File Service"
-  disable_manual_trigger: true
-  serial: true
-  serial_groups: [print-file-service]
-  plan:
-  - get: census-rm-deploy
-  - get: every-minute
-    trigger: true
-    passed: ["Scale Down Apps and Reset DB"]
-  - task: apply-deployment
-    file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
-    on_failure: *slack_failure_alert
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      KUBERNETES_STATEFULSET_NAME: printfilesvc
-      KUBERNETES_SELECTOR: app=printfilesvc
-      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
-      KUBERNETES_FILE_PREFIX: print-file-service
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
-
-- name: "Fieldwork Adapter"
-  disable_manual_trigger: true
-  serial: true
-  serial_groups: [fieldwork-adapter]
-  plan:
-  - get: census-rm-deploy
-  - get: every-minute
-    trigger: true
-    passed: ["Scale Down Apps and Reset DB"]
-  - task: apply-deployment
-    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: fieldwork-adapter
-      KUBERNETES_SELECTOR: app=fieldwork-adapter
-      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
-      KUBERNETES_FILE_PREFIX: fieldwork-adapter
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
-
-- name: "Notify Processor"
-  disable_manual_trigger: true
-  serial: true
-  serial_groups: [notify-processor]
-  plan:
-  - get: census-rm-deploy
-  - get: every-minute
-    trigger: true
-    passed: ["Scale Down Apps and Reset DB"]
-  - task: apply-deployment
-    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: notify-processor
-      KUBERNETES_SELECTOR: app=notify-processor
-      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
-      KUBERNETES_FILE_PREFIX: notify-processor
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
-
-- name: "Exception Manager"
-  disable_manual_trigger: true
-  serial: true
-  serial_groups: [exception-manager]
-  plan:
-  - get: census-rm-deploy
-  - get: every-minute
-    trigger: true
-    passed: ["Scale Down Apps and Reset DB"]
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_failure: *slack_failure_alert
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: exception-manager
-      KUBERNETES_SELECTOR: app=exception-manager
-      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
-      KUBERNETES_FILE_PREFIX: exception-manager
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
-
-- name: "Toolbox"
-  disable_manual_trigger: true
-  serial: true
-  serial_groups: [toolbox]
-  plan:
-  - get: census-rm-deploy
-  - get: every-minute
-    trigger: true
-    passed: ["Scale Down Apps and Reset DB"]
-  - task: apply-deployment
-    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: census-rm-toolbox
-      KUBERNETES_SELECTOR: app=census-rm-toolbox
-      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
-      KUBERNETES_FILE_PREFIX: census-rm-toolbox
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
-
-- name: "Database Monitor"
-  disable_manual_trigger: true
-  serial: true
-  serial_groups: [database-monitor]
-  plan:
-  - get: census-rm-deploy
-  - get: every-minute
-    trigger: true
-    passed: ["Scale Down Apps and Reset DB"]
-  - task: apply-deployment
-    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: database-monitor
-      KUBERNETES_SELECTOR: app=database-monitor
-      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
-      KUBERNETES_FILE_PREFIX: database-monitor
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
-
-- name: "Rabbit Monitor"
-  disable_manual_trigger: true
-  serial: true
-  serial_groups: [rabbitmonitor]
-  plan:
-  - get: census-rm-deploy
-  - get: every-minute
-    trigger: true
-    passed: ["Scale Down Apps and Reset DB"]
-  - task: apply-deployment
-    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: rabbitmonitor
-      KUBERNETES_SELECTOR: app=rabbitmonitor
-      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
-      KUBERNETES_FILE_PREFIX: rabbitmonitor
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
-
 - name: "Trigger Performance Tests"
   serial: true
   serial_groups: [
@@ -610,6 +311,42 @@ jobs:
       KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
   - *slack_performance_tests_started
+
+# Run Terraform
+- name: "Run Terraform"
+  disable_manual_trigger: true
+  serial: true
+  on_failure: *slack_failure_alert
+  serial_groups: [scale-down,
+                  scale-apps,
+                  performance-tests,
+                  action-scheduler,
+                  action-worker,
+                  case-api,
+                  case-processor,
+                  fieldwork-adapter,
+                  notify-processor,
+                  uac-qid-service,
+                  pubsubsvc,
+                  print-file-service,
+                  exception-manager,
+                  toolbox,
+                  database-monitor,
+                  rabbitmonitor]
+  plan:
+    - get: every-minute
+      trigger: true
+      passed: ["Trigger Performance Tests"]
+    - get: census-rm-terraform
+    - get: census-rm-deploy
+    - task: "Run Terraform"
+      file: census-rm-deploy/tasks/terraform-env.yml
+      params:
+        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+        ENV: performance
+        VAR_FILE: ./tfvars/census-rm-performance.tfvars
+        KUBERNETES_CLUSTER: rm-k8s-cluster
+      input_mapping: {census-rm-terraform: census-rm-terraform}
 
 - name: "Scale Down Apps and Reset DB"
   disable_manual_trigger: true
@@ -674,6 +411,354 @@ jobs:
             # Wipe and rebuild database
             kubectl exec $(kubectl get pods --selector=app=census-rm-toolbox -o jsonpath='{.items[*].metadata.name}') -- /bin/bash /app/groundzero/rebuild_from_ground_zero.sh
   on_failure: *slack_performance_setup_failure
+
+- name: "Action Scheduler"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [action-scheduler]
+  plan:
+  - get: census-rm-kubernetes-release
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Scale Down Apps and Reset DB"]
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: action-scheduler
+      KUBERNETES_SELECTOR: app=action-scheduler
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: action-scheduler
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "Action Worker"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [action-worker]
+  plan:
+  - get: census-rm-kubernetes-release
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Scale Down Apps and Reset DB"]
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: action-worker
+      KUBERNETES_SELECTOR: app=action-worker
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: action-worker
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "Case API"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [case-api]
+  plan:
+  - get: census-rm-kubernetes-release
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Scale Down Apps and Reset DB"]
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: case-api
+      KUBERNETES_SELECTOR: app=case-api
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: case-api
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "Case Processor"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [case-processor]
+  plan:
+  - get: census-rm-kubernetes-release
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Scale Down Apps and Reset DB"]
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: case-processor
+      KUBERNETES_SELECTOR: app=case-processor
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: case-processor
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "UAC QID Service"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [uac-qid-service]
+  plan:
+  - get: census-rm-kubernetes-release
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Scale Down Apps and Reset DB"]
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: uacqidservice
+      KUBERNETES_SELECTOR: app=uacqidservice
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: uac-qid-service
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "PubSub Service"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [pubsubsvc]
+  plan:
+  - get: census-rm-kubernetes-release
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Scale Down Apps and Reset DB"]
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: pubsubsvc
+      KUBERNETES_SELECTOR: app=pubsubsvc
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: pubsub
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "Print File Service"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [print-file-service]
+  plan:
+  - get: census-rm-kubernetes-release
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Scale Down Apps and Reset DB"]
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      KUBERNETES_STATEFULSET_NAME: printfilesvc
+      KUBERNETES_SELECTOR: app=printfilesvc
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: print-file-service
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "Fieldwork Adapter"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [fieldwork-adapter]
+  plan:
+  - get: census-rm-kubernetes-release
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Scale Down Apps and Reset DB"]
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: fieldwork-adapter
+      KUBERNETES_SELECTOR: app=fieldwork-adapter
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: fieldwork-adapter
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "Notify Processor"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [notify-processor]
+  plan:
+  - get: census-rm-kubernetes-release
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Scale Down Apps and Reset DB"]
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: notify-processor
+      KUBERNETES_SELECTOR: app=notify-processor
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: notify-processor
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "Exception Manager"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [exception-manager]
+  plan:
+  - get: census-rm-kubernetes-release
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Scale Down Apps and Reset DB"]
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: exception-manager
+      KUBERNETES_SELECTOR: app=exception-manager
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: exception-manager
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "Toolbox"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [toolbox]
+  plan:
+  - get: census-rm-kubernetes-release
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Scale Down Apps and Reset DB"]
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: census-rm-toolbox
+      KUBERNETES_SELECTOR: app=census-rm-toolbox
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
+      KUBERNETES_FILE_PREFIX: census-rm-toolbox
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+- name: "Database Monitor"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [database-monitor]
+  plan:
+  - get: census-rm-kubernetes-release
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Scale Down Apps and Reset DB"]
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: database-monitor
+      KUBERNETES_SELECTOR: app=database-monitor
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
+      KUBERNETES_FILE_PREFIX: database-monitor
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+
+# Run Rabbit Helm
+- name: "Run Rabbit Helm"
+  disable_manual_trigger: true
+  serial: true
+  on_failure: *slack_failure_alert
+  serial_groups: [scale-down,
+                  scale-apps,
+                  performance-tests,
+                  action-scheduler,
+                  action-worker,
+                  case-api,
+                  case-processor,
+                  fieldwork-adapter,
+                  notify-processor,
+                  uac-qid-service,
+                  pubsubsvc,
+                  print-file-service,
+                  exception-manager,
+                  toolbox,
+                  database-monitor,
+                  rabbitmonitor]
+  plan:
+    - get: every-minute
+      trigger: true
+      passed: ["Scale Down Apps and Reset DB"]
+    - get: census-rm-kubernetes-dependencies-repo
+    - get: census-rm-deploy
+    - task: "Run Rabbit Helm"
+      file: census-rm-deploy/tasks/helm-rabbit.yml
+      params:
+        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+        ENV: performance
+        KUBERNETES_CLUSTER: rm-k8s-cluster
+        RABBITMQ_CONFIG_VALUES_FILE: release/rabbitmq/values_prod.yml
+      input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-dependencies-repo}
+
+- name: "Rabbit Monitor"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [rabbitmonitor]
+  plan:
+  - get: census-rm-kubernetes-release
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Scale Down Apps and Reset DB"]
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_failure: *slack_failure_alert
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((performance-gcp-project-name))
+      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: rabbitmonitor
+      KUBERNETES_SELECTOR: app=rabbitmonitor
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
+      KUBERNETES_FILE_PREFIX: rabbitmonitor
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
 - name: "Scale Up Apps"
   disable_manual_trigger: true
@@ -802,78 +887,6 @@ jobs:
       KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
   on_failure: *slack_failure_alert
-
-# Run Terraform
-- name: "Run Terraform"
-  disable_manual_trigger: true
-  serial: true
-  on_failure: *slack_failure_alert
-  serial_groups: [scale-down,
-                  scale-apps,
-                  performance-tests,
-                  action-scheduler,
-                  action-worker,
-                  case-api,
-                  case-processor,
-                  fieldwork-adapter,
-                  notify-processor,
-                  uac-qid-service,
-                  pubsubsvc,
-                  print-file-service,
-                  exception-manager,
-                  toolbox,
-                  database-monitor,
-                  rabbitmonitor]
-  plan:
-    - get: every-minute
-      trigger: true
-      passed: ["Trigger Performance Tests"]
-    - get: census-rm-terraform
-    - get: census-rm-deploy
-    - task: "Run Terraform"
-      file: census-rm-deploy/tasks/terraform-env.yml
-      params:
-        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-        ENV: performance
-        VAR_FILE: ./tfvars/census-rm-performance.tfvars
-        KUBERNETES_CLUSTER: rm-k8s-cluster
-      input_mapping: {census-rm-terraform: census-rm-terraform}
-
-# Run Rabbit Helm
-- name: "Run Rabbit Helm"
-  disable_manual_trigger: true
-  serial: true
-  on_failure: *slack_failure_alert
-  serial_groups: [scale-down,
-                  scale-apps,
-                  performance-tests,
-                  action-scheduler,
-                  action-worker,
-                  case-api,
-                  case-processor,
-                  fieldwork-adapter,
-                  notify-processor,
-                  uac-qid-service,
-                  pubsubsvc,
-                  print-file-service,
-                  exception-manager,
-                  toolbox,
-                  database-monitor,
-                  rabbitmonitor]
-  plan:
-    - get: every-minute
-      trigger: true
-      passed: ["Scale Down Apps and Reset DB"]
-    - get: census-rm-kubernetes-dependencies-repo
-    - get: census-rm-deploy
-    - task: "Run Rabbit Helm"
-      file: census-rm-deploy/tasks/helm-rabbit.yml
-      params:
-        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-        ENV: performance
-        KUBERNETES_CLUSTER: rm-k8s-cluster
-        RABBITMQ_CONFIG_VALUES_FILE: release/rabbitmq/values_prod.yml
-      input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-dependencies-repo}
 
 - name: "Remove Cluster Nodes"
   disable_manual_trigger: true

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -304,12 +304,6 @@ jobs:
     params:
       skip_download: true
   - get: every-minute
-  - task: start-infrastructure
-    file: performance-tests-repo/tasks/start-performance-infrastructure.yml
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      GCP_PROJECT_NAME: ((performance-gcp-project-name))
   - *slack_performance_tests_started
 
 # Run Terraform

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -290,7 +290,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Terraform"]
+    passed: ["Reset DB"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -313,7 +313,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Terraform"]
+    passed: ["Reset DB"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -336,7 +336,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Terraform"]
+    passed: ["Reset DB"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -359,7 +359,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Terraform"]
+    passed: ["Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -382,7 +382,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Terraform"]
+    passed: ["Reset DB"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -405,7 +405,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Terraform"]
+    passed: ["Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -428,7 +428,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Terraform"]
+    passed: ["Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
     on_failure: *slack_failure_alert
@@ -451,7 +451,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Terraform"]
+    passed: ["Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -474,7 +474,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Terraform"]
+    passed: ["Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -497,7 +497,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Terraform"]
+    passed: ["Reset DB"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -520,7 +520,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Terraform"]
+    passed: ["Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -543,7 +543,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Terraform"]
+    passed: ["Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -566,7 +566,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Terraform"]
+    passed: ["Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -637,21 +637,7 @@ jobs:
       skip_download: true
   - get: every-minute
     trigger: true
-    passed: [
-      "Action Scheduler",
-      "Action Worker",
-      "Case API",
-      "Case Processor",
-      "UAC QID Service",
-      "PubSub Service",
-      "Print File Service",
-      "Fieldwork Adapter",
-      "Notify Processor",
-      "Exception Manager",
-      "Toolbox",
-      "Database Monitor",
-      "Run Rabbit Helm",
-      "Rabbit Monitor"]
+    passed: ["Run Terraform"]
   - task: "Scale down pre ground zero"
     config:
       platform: linux
@@ -769,7 +755,21 @@ jobs:
       skip_download: true
   - get: every-minute
     trigger: true
-    passed: ["Reset DB"]
+    passed: [
+      "Action Scheduler",
+      "Action Worker",
+      "Case API",
+      "Case Processor",
+      "UAC QID Service",
+      "PubSub Service",
+      "Print File Service",
+      "Fieldwork Adapter",
+      "Notify Processor",
+      "Exception Manager",
+      "Toolbox",
+      "Database Monitor",
+      "Run Rabbit Helm",
+      "Rabbit Monitor"]
   - task: "Scale apps"
     config:
       platform: linux
@@ -918,7 +918,7 @@ jobs:
   plan:
     - get: every-minute
       trigger: true
-      passed: ["Run Terraform"]
+      passed: ["Reset DB"]
     - get: census-rm-kubernetes-dependencies-repo
     - get: census-rm-deploy
     - task: "Run Rabbit Helm"

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -380,8 +380,6 @@ jobs:
         SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
         GCP_PROJECT_NAME: ((performance-gcp-project-name))
-        CASE_PROCESSOR_REPLICAS: ((case-processor-replicas))
-        UAC_QID_REPLICAS: ((uac-qid-replicas))
       run:
         path: bash
         args:

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -290,7 +290,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Reset DB"]
+    passed: ["Scale Down Apps and Reset DB"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -313,7 +313,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Reset DB"]
+    passed: ["Scale Down Apps and Reset DB"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -336,7 +336,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Reset DB"]
+    passed: ["Scale Down Apps and Reset DB"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -359,7 +359,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Reset DB"]
+    passed: ["Scale Down Apps and Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -382,7 +382,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Reset DB"]
+    passed: ["Scale Down Apps and Reset DB"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -405,7 +405,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Reset DB"]
+    passed: ["Scale Down Apps and Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -428,7 +428,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Reset DB"]
+    passed: ["Scale Down Apps and Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
     on_failure: *slack_failure_alert
@@ -451,7 +451,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Reset DB"]
+    passed: ["Scale Down Apps and Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -474,7 +474,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Reset DB"]
+    passed: ["Scale Down Apps and Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -497,7 +497,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Reset DB"]
+    passed: ["Scale Down Apps and Reset DB"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -520,7 +520,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Reset DB"]
+    passed: ["Scale Down Apps and Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -543,7 +543,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Reset DB"]
+    passed: ["Scale Down Apps and Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -566,7 +566,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Reset DB"]
+    passed: ["Scale Down Apps and Reset DB"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -611,7 +611,7 @@ jobs:
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
   - *slack_performance_tests_started
 
-- name: "Scale Down Apps"
+- name: "Scale Down Apps and Reset DB"
   disable_manual_trigger: true
   serial: true
   serial_groups: [
@@ -670,60 +670,6 @@ jobs:
             kubectl scale deployment case-api --replicas=0
             kubectl scale deployment case-processor --replicas=0
             kubectl scale deployment uacqidservice --replicas=0
-  on_failure: *slack_performance_setup_failure
-
-- name: "Reset DB"
-  disable_manual_trigger: true
-  serial: true
-  serial_groups: [
-    scale-down,
-    scale-apps,
-    action-scheduler,
-    action-worker,
-    case-api,
-    case-processor,
-    fieldwork-adapter,
-    notify-processor,
-    uac-qid-service,
-    pubsubsvc,
-    print-file-service,
-    exception-manager,
-    toolbox,
-    database-monitor,
-    rabbitmonitor]
-  plan:
-  - get: performance-tests-repo
-  - get: performance-tests-docker-image
-    params:
-      skip_download: true
-  - get: every-minute
-    trigger: true
-    passed: ["Scale Down Apps"]
-  - task: "Wipe DB and rebuild from ground zero"
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: eu.gcr.io/census-gcr/gcloud-kubectl
-      params:
-        SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-        KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-        GCP_PROJECT_NAME: ((performance-gcp-project-name))
-        CASE_PROCESSOR_REPLICAS: ((case-processor-replicas))
-        UAC_QID_REPLICAS: ((uac-qid-replicas))
-      run:
-        path: bash
-        args:
-          - -exc
-          - |
-            cat >~/gcloud-service-key.json <<EOL
-            $SERVICE_ACCOUNT_JSON
-            EOL
-
-            # Use gcloud service account to configure kubectl
-            gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
-            gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
             # Wipe and rebuild database
             kubectl exec $(kubectl get pods --selector=app=census-rm-toolbox -o jsonpath='{.items[*].metadata.name}') -- /bin/bash /app/groundzero/rebuild_from_ground_zero.sh
@@ -856,7 +802,6 @@ jobs:
       KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
   on_failure: *slack_failure_alert
-  on_success: *slack_performance_tests_finished
 
 # Run Terraform
 - name: "Run Terraform"
@@ -918,7 +863,7 @@ jobs:
   plan:
     - get: every-minute
       trigger: true
-      passed: ["Reset DB"]
+      passed: ["Scale Down Apps and Reset DB"]
     - get: census-rm-kubernetes-dependencies-repo
     - get: census-rm-deploy
     - task: "Run Rabbit Helm"
@@ -929,3 +874,59 @@ jobs:
         KUBERNETES_CLUSTER: rm-k8s-cluster
         RABBITMQ_CONFIG_VALUES_FILE: release/rabbitmq/values_prod.yml
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-dependencies-repo}
+
+- name: "Remove Cluster Nodes"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [
+    scale-down,
+    scale-apps,
+    action-scheduler,
+    action-worker,
+    case-api,
+    case-processor,
+    fieldwork-adapter,
+    notify-processor,
+    uac-qid-service,
+    pubsubsvc,
+    print-file-service,
+    exception-manager,
+    toolbox,
+    database-monitor,
+    rabbitmonitor]
+  plan:
+  - get: every-minute
+    trigger: true
+    passed: ["Performance Tests"]
+  - task: "Scale down pre ground zero"
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: eu.gcr.io/census-gcr/gcloud-kubectl
+      params:
+        SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+        KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+        GCP_PROJECT_NAME: ((performance-gcp-project-name))
+      run:
+        path: bash
+        args:
+          - -exc
+          - |
+            cat >~/gcloud-service-key.json <<EOL
+            $SERVICE_ACCOUNT_JSON
+            EOL
+
+            # Use gcloud service account to configure kubectl
+            gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+            gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
+
+            # Delete cluster node pools
+            NODE_POOL_LIST=`gcloud container node-pools list --cluster=${KUBERNETES_CLUSTER} --region=europe-west2 --format="value(name)"`
+            for NODE_POOL in $NODE_POOL_LIST ; do
+                echo scaling $NODE_POOL
+                gcloud container node-pools delete $NODE_POOL --cluster=${KUBERNETES_CLUSTER} --region=europe-west2 --quiet
+            done
+    on_failure: *slack_failure_alert
+    on_success: *slack_performance_tests_finished

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -5,6 +5,14 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
 
+- name: census-rm-kubernetes-release	
+  type: git	
+  source:
+    uri: git@github.com:ONSdigital/census-rm-kubernetes.git	
+    private_key: ((github.service_account_private_key))	
+    paths: [release/*]
+    branch: master
+
 resources:
 
 - name: slack-alert
@@ -31,7 +39,7 @@ resources:
     private_key: ((github.service_account_private_key))
 
 - name: performance-tests-docker-image
-  type: docker-imagex
+  type: docker-image
   source:
     repository: ((performance-tests-image))
     username: _json_key


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There is no need for the performance tests infrastructure to be running 24/7, so tasks have been created to scale down certain parts of the infrastructure.
Following a successful performance test, the pipeline calls tasks located in the performance test repo to do the following:

- delete DB read replica (DB won't stop if a read replica is present)
- stop DB
- delete cluster node pools (not deleting whole cluster)

When the performance tests are triggered, a task runs to start the DB, terraform will then take care of adding the DB read replica and relevant node pools.

The pipeline has been simplified so there is now one route through, take a look at the RM concourse sandbox at the pipeline called hughs-test to see how it looks.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Performance test pipeline call tasks (located in census-rm-performance-tests repo) to scale up and down the infrastructure.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Validate the pipeline, check it alongside the PR in census-rm-performance-tests on the branch with the same name as this one:
https://github.com/ONSdigital/census-rm-performance-tests/pull/14

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/Noi86T6D/268-scale-performance-environment-automatically-8

# Screenshots (if appropriate):