### PR TITLE
Preprod pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Required configuration:
 
 
 #### How to fly manually
+To access fly locally, you'll now need to access it through a bastion.  Run the following at the start of a session then log into your Google account when prompted:
+```bash
+gcloud compute ssh bastion --project census-ci --zone europe-west2-a -- -D 1080 -f -N
+export HTTPS_PROXY=socks5://localhost:1080
+```
+
 Run the fly command:
 ```bash
 fly -t <target> set-pipeline -p <pipeline-name> -c pipelines/ci-kubernetes-pipeline.yml -l <path-to-config-yml>

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -98,7 +98,7 @@ jobs:
             gcp-environment-name: blacklodge
             gcp-project-name: census-rm-blacklodge
             kubernetes-cluster-name: rm-k8s-cluster
-            rabbit_config: release/rabbitmq/values.yml
+            rabbit-config: release/rabbitmq/values.yml
 
         - name: release-images
           team: rm

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -25,7 +25,6 @@ resources:
       - "pipelines"
       - "tasks"
       private_key: ((github.service_account_private_key))
-      branch: preprod-pipeline
 
   - name: pipelines
     type: concourse-pipeline

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -98,6 +98,7 @@ jobs:
             gcp-environment-name: blacklodge
             gcp-project-name: census-rm-blacklodge
             kubernetes-cluster-name: rm-k8s-cluster
+            rabbit_config: release/rabbitmq/values.yml
 
         - name: release-images
           team: rm
@@ -127,3 +128,4 @@ jobs:
             gcp-environment-name: preprod
             gcp-project-name: census-rm-preprod
             kubernetes-cluster-name: rm-k8s-cluster
+            rabbit-config: release/rabbitmq/values_prod.yml

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -25,6 +25,7 @@ resources:
       - "pipelines"
       - "tasks"
       private_key: ((github.service_account_private_key))
+      branch: preprod-pipeline
 
   - name: pipelines
     type: concourse-pipeline
@@ -119,3 +120,11 @@ jobs:
             action-worker-replicas: 10
             uac-qid-replicas: 2
             terraform-branch: master
+
+        - name: census-rm-preprod
+          team: rm
+          config_file: census-rm-deploy/pipelines/manual-release-pipeline.yml
+          vars:
+            gcp-environment-name: preprod
+            gcp-project-name: census-rm-preprod
+            kubernetes-cluster-name: rm-k8s-cluster

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -76,7 +76,6 @@ resources:
   source:
     uri: git@github.com:ONSdigital/census-rm-terraform.git
     private_key: ((github.service_account_private_key))
-    tag_filter: v*.*.*
     branch: update-print-file-folders-for-preprod
 
 - name: census-rm-kubernetes-release

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -696,7 +696,7 @@ jobs:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: ((gcp-environment-name))
         KUBERNETES_CLUSTER: rm-k8s-cluster
-        RABBITMQ_CONFIG_VALUES_FILE: ((rabit-config))
+        RABBITMQ_CONFIG_VALUES_FILE: ((rabbit-config))
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release}
 
 - name: "Report Terraform Success"

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -69,6 +69,7 @@ resources:
   source:
     uri: git@github.com:ONSdigital/census-rm-deploy.git
     private_key: ((github.service_account_private_key))
+    branch: preprod-pipeline
 
 - name: census-rm-terraform-release
   type: git

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -669,7 +669,7 @@ jobs:
       input_mapping: {census-rm-terraform: census-rm-terraform-release}
 
 - name: "Run Rabbit Helm"
-  disable_manual_trigger: true
+  disable_manual_trigger: false
   serial: true
   serial_groups: [action-scheduler,
                   action-worker,

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -696,7 +696,7 @@ jobs:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: ((gcp-environment-name))
         KUBERNETES_CLUSTER: rm-k8s-cluster
-        RABBITMQ_CONFIG_VALUES_FILE: release/rabbitmq/values_prod.yml
+        RABBITMQ_CONFIG_VALUES_FILE: ((rabit-config))
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release}
 
 - name: "Report Terraform Success"

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -663,7 +663,7 @@ jobs:
       params:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: ((gcp-environment-name))
-        VAR_FILE: ./tfvars/census-rm-blacklodge.tfvars
+        VAR_FILE: ./tfvars/((gcp-environment-name)).tfvars
         KUBERNETES_CLUSTER: rm-k8s-cluster
       input_mapping: {census-rm-terraform: census-rm-terraform-release}
 

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -77,7 +77,7 @@ resources:
     uri: git@github.com:ONSdigital/census-rm-terraform.git
     private_key: ((github.service_account_private_key))
     tag_filter: v*.*.*
-    branch: master
+    branch: update-print-file-folders-for-preprod
 
 - name: census-rm-kubernetes-release
   type: git

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -697,7 +697,7 @@ jobs:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: ((gcp-environment-name))
         KUBERNETES_CLUSTER: rm-k8s-cluster
-        RABBITMQ_CONFIG_VALUES_FILE: release/rabbitmq/values.yml
+        RABBITMQ_CONFIG_VALUES_FILE: release/rabbitmq/values_prod.yml
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release}
 
 - name: "Report Terraform Success"

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -69,14 +69,14 @@ resources:
   source:
     uri: git@github.com:ONSdigital/census-rm-deploy.git
     private_key: ((github.service_account_private_key))
-    branch: preprod-pipeline
 
 - name: census-rm-terraform-release
   type: git
   source:
     uri: git@github.com:ONSdigital/census-rm-terraform.git
     private_key: ((github.service_account_private_key))
-    branch: update-print-file-folders-for-preprod
+    tag_filter: v*.*.*
+    branch: master
 
 - name: census-rm-kubernetes-release
   type: git
@@ -668,7 +668,7 @@ jobs:
       input_mapping: {census-rm-terraform: census-rm-terraform-release}
 
 - name: "Run Rabbit Helm"
-  disable_manual_trigger: false
+  disable_manual_trigger: true
   serial: true
   serial_groups: [action-scheduler,
                   action-worker,

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -664,7 +664,7 @@ jobs:
       params:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: ((gcp-environment-name))
-        VAR_FILE: ./tfvars/((gcp-environment-name)).tfvars
+        VAR_FILE: ./tfvars/((gcp-project-name)).tfvars
         KUBERNETES_CLUSTER: rm-k8s-cluster
       input_mapping: {census-rm-terraform: census-rm-terraform-release}
 

--- a/tasks/terraform-env.yml
+++ b/tasks/terraform-env.yml
@@ -23,9 +23,9 @@ run:
       cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
       $ADMIN_SERVICE_ACCOUNT_JSON
       EOL
+      gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
       gcloud services enable container.googleapis.com
       gcloud config set container/use_client_certificate True
-      gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
       gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT}
       cd census-rm-terraform
       tfenv install

--- a/tasks/terraform-env.yml
+++ b/tasks/terraform-env.yml
@@ -24,8 +24,6 @@ run:
       $ADMIN_SERVICE_ACCOUNT_JSON
       EOL
       gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
-      gcloud services enable container.googleapis.com
-      gcloud config set container/use_client_certificate True
       gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT}
       cd census-rm-terraform
       tfenv install

--- a/tasks/terraform-env.yml
+++ b/tasks/terraform-env.yml
@@ -24,9 +24,9 @@ run:
       $ADMIN_SERVICE_ACCOUNT_JSON
       EOL
       gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
-      gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT}
       gcloud services enable container.googleapis.com
       gcloud config set container/use_client_certificate True
+      gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT}
       cd census-rm-terraform
       tfenv install
 

--- a/tasks/terraform-env.yml
+++ b/tasks/terraform-env.yml
@@ -25,6 +25,8 @@ run:
       EOL
       gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
       gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT}
+      gcloud services enable container.googleapis.com
+      gcloud config set container/use_client_certificate True
       cd census-rm-terraform
       tfenv install
 

--- a/tasks/terraform-env.yml
+++ b/tasks/terraform-env.yml
@@ -23,9 +23,9 @@ run:
       cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
       $ADMIN_SERVICE_ACCOUNT_JSON
       EOL
-      gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
       gcloud services enable container.googleapis.com
       gcloud config set container/use_client_certificate True
+      gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
       gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT}
       cd census-rm-terraform
       tfenv install


### PR DESCRIPTION
# Motivation and Context
Added a preprod pipeline.  This terraforms the environment, runs Helm and deploys all apps.

# What has changed
- New preprod pipeline, based off the manual-release-pipeline

# How to test?
To test this, you'll need to change some of the config to point to this dev branch rather than master (or tagged releases):
- In the `census-rm-deploy` resource, add `branch: preprod-pipeline` to the source config for the manual-release-pipeline.yml and concourse-pipelines.yml
- For the `census-rm-terraform-release` git resource in the manual-release-pipeline config, remove the tag-filter and change the branch to the dev one (`update-print-file-folders-for-preprod`)
- Fly the `fly-pipelines` pipeline and use that to create the preprod one
- Run the `Trigger Terraform` and `Trigger Deployment` jobs and check that everything goes green

# Links
- https://github.com/ONSdigital/census-rm-terraform/pull/133
- https://trello.com/c/wUbodyI8

# Screenshots (if appropriate):