### PR TITLE
Changed toolbox to use non-dev deployment file

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -1982,7 +1982,7 @@ jobs:
       KUBERNETES_DEPLOYMENT_NAME: census-rm-toolbox
       KUBERNETES_SELECTOR: app=census-rm-toolbox
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
-      KUBERNETES_FILE_PREFIX: census-rm-toolbox-dev
+      KUBERNETES_FILE_PREFIX: census-rm-toolbox
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
       docker-image-resource: toolbox-docker-image-gcr,


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At the moment Toolbox is getting stuck in a `Container creating` state. I think it's because it's using the toolbox-dev deployment file instead of the one with read/write. This PR just changes which deployment file it uses.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Uses non-dev deployment file for toolbox in CI