### PR TITLE
Add on_error alerts to pipelines

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -545,35 +545,71 @@ templating:
       icon_emoji: ":concourse:"
       username: Concourse
       attachments: [
+        {
+          "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "title": "$BUILD_JOB_NAME failed",
+          "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "fields": [
             {
-                "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-                "title": "$BUILD_JOB_NAME failed",
-                "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-                "fields": [
-                    {
-                        "title": "Pipeline",
-                        "value": "$BUILD_PIPELINE_NAME",
-                        "short": true
-                    },
-                    {
-                        "title": "Environment",
-                        "value": "((ci-gcp-environment-name))",
-                        "short": true
-                    },
-                    {
-                        "title": "Project",
-                        "value": "((ci-gcp-project-name))",
-                        "short": true
-                    },
-                    {
-                        "title": "Build",
-                        "value": "#$BUILD_NAME",
-                        "short": true
-                    }
-                ],
-                "color": "#F35A00"
+              "title": "Pipeline",
+              "value": "$BUILD_PIPELINE_NAME",
+              "short": true
+            },
+            {
+              "title": "Environment",
+              "value": "((ci-gcp-environment-name))",
+              "short": true
+            },
+            {
+              "title": "Project",
+              "value": "((ci-gcp-project-name))",
+              "short": true
+            },
+            {
+              "title": "Build",
+              "value": "#$BUILD_NAME",
+              "short": true
             }
-        ]
+          ],
+          "color": "#ff0000"
+        }
+      ]
+
+  slack_error_alert_ci: &slack_error_alert_ci
+    put: slack-alert
+    params:
+      icon_emoji: ":concourse:"
+      username: Concourse
+      attachments: [
+        {
+          "fallback": "$BUILD_JOB_NAME errored. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "title": "$BUILD_JOB_NAME errored",
+          "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "fields": [
+            {
+              "title": "Pipeline",
+              "value": "$BUILD_PIPELINE_NAME",
+              "short": true
+            },
+            {
+              "title": "Environment",
+              "value": "((ci-gcp-environment-name))",
+              "short": true
+            },
+            {
+              "title": "Project",
+              "value": "((ci-gcp-project-name))",
+              "short": true
+            },
+            {
+              "title": "Build",
+              "value": "#$BUILD_NAME",
+              "short": true
+            }
+          ],
+          "color": "#f58a3d"
+        }
+      ]
 
   slack_success_alert_ci: &slack_success_alert_ci
     put: slack-alert
@@ -581,35 +617,35 @@ templating:
       icon_emoji: ":concourse:"
       username: Concourse
       attachments: [
+        {
+          "fallback": "$BUILD_JOB_NAME succeeded. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "title": "$BUILD_JOB_NAME succeeded",
+          "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "fields": [
             {
-                "fallback": "$BUILD_JOB_NAME succeeded. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-                "title": "$BUILD_JOB_NAME succeeded",
-                "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-                "fields": [
-                    {
-                        "title": "Pipeline",
-                        "value": "$BUILD_PIPELINE_NAME",
-                        "short": true
-                    },
-                    {
-                        "title": "Environment",
-                        "value": "((ci-gcp-environment-name))",
-                        "short": true
-                    },
-                    {
-                        "title": "Project",
-                        "value": "((ci-gcp-project-name))",
-                        "short": true
-                    },
-                    {
-                        "title": "Build",
-                        "value": "#$BUILD_NAME",
-                        "short": true
-                    }
-                ],
-                "color": "#36a64f"
+              "title": "Pipeline",
+              "value": "$BUILD_PIPELINE_NAME",
+              "short": true
+            },
+            {
+              "title": "Environment",
+              "value": "((ci-gcp-environment-name))",
+              "short": true
+            },
+            {
+              "title": "Project",
+              "value": "((ci-gcp-project-name))",
+              "short": true
+            },
+            {
+              "title": "Build",
+              "value": "#$BUILD_NAME",
+              "short": true
             }
-        ]
+          ],
+          "color": "#36a64f"
+        }
+      ]
 
   slack_started_alert_ci: &slack_started_alert_ci
     put: slack-alert
@@ -617,35 +653,35 @@ templating:
       icon_emoji: ":concourse:"
       username: Concourse
       attachments: [
+        {
+          "fallback": "$BUILD_JOB_NAME started... See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "title": "$BUILD_JOB_NAME started...",
+          "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "fields": [
             {
-                "fallback": "$BUILD_JOB_NAME started... See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-                "title": "$BUILD_JOB_NAME started...",
-                "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-                "fields": [
-                    {
-                        "title": "Pipeline",
-                        "value": "$BUILD_PIPELINE_NAME",
-                        "short": true
-                    },
-                    {
-                        "title": "Environment",
-                        "value": "((ci-gcp-environment-name))",
-                        "short": true
-                    },
-                    {
-                        "title": "Project",
-                        "value": "((ci-gcp-project-name))",
-                        "short": true
-                    },
-                    {
-                        "title": "Build",
-                        "value": "#$BUILD_NAME",
-                        "short": true
-                    }
-                ],
-                "color": "#36a64f"
+              "title": "Pipeline",
+              "value": "$BUILD_PIPELINE_NAME",
+              "short": true
+            },
+            {
+              "title": "Environment",
+              "value": "((ci-gcp-environment-name))",
+              "short": true
+            },
+            {
+              "title": "Project",
+              "value": "((ci-gcp-project-name))",
+              "short": true
+            },
+            {
+              "title": "Build",
+              "value": "#$BUILD_NAME",
+              "short": true
             }
-        ]
+          ],
+          "color": "#36a64f"
+        }
+      ]
 
   slack_failure_alert_prebuild: &slack_failure_alert_prebuild
     put: slack-alert
@@ -653,24 +689,50 @@ templating:
       icon_emoji: ":concourse:"
       username: Concourse
       attachments: [
-          {
-              "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-              "title": "$BUILD_JOB_NAME failed",
-              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-              "fields": [
-                  {
-                      "title": "Pipeline",
-                      "value": "$BUILD_PIPELINE_NAME",
-                      "short": true
-                  },
-                  {
-                      "title": "Build",
-                      "value": "#$BUILD_NAME",
-                      "short": true
-                  }
-              ],
-              "color": "#F35A00"
-          }
+        {
+          "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "title": "$BUILD_JOB_NAME failed",
+          "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "fields": [
+            {
+              "title": "Pipeline",
+              "value": "$BUILD_PIPELINE_NAME",
+              "short": true
+            },
+            {
+              "title": "Build",
+              "value": "#$BUILD_NAME",
+              "short": true
+            }
+        ],
+          "color": "#ff0000"
+        }
+      ]
+
+  slack_error_alert_prebuild: &slack_error_alert_prebuild
+    put: slack-alert
+    params:
+      icon_emoji: ":concourse:"
+      username: Concourse
+      attachments: [
+        {
+          "fallback": "$BUILD_JOB_NAME errored. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "title": "$BUILD_JOB_NAME errored",
+          "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "fields": [
+            {
+              "title": "Pipeline",
+              "value": "$BUILD_PIPELINE_NAME",
+              "short": true
+            },
+            {
+              "title": "Build",
+              "value": "#$BUILD_NAME",
+              "short": true
+            }
+        ],
+          "color": "#f58a3d"
+        }
       ]
 
   slack_docker_build_failure_ci: &slack_docker_build_failure_ci
@@ -679,29 +741,60 @@ templating:
       icon_emoji: ":concourse:"
       username: Concourse
       attachments: [
-          {
-              "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-              "title": "$BUILD_JOB_NAME failed",
-              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-              "fields": [
-                  {
-                      "title": "Pipeline",
-                      "value": "$BUILD_PIPELINE_NAME",
-                      "short": true
-                  },
-                  {
-                      "title": "Registry",
-                      "value": "((docker-registry-ci))",
-                      "short": true
-                  },
-                  {
-                      "title": "Build",
-                      "value": "#$BUILD_NAME",
-                      "short": true
-                  }
-              ],
-              "color": "#F35A00"
-          }
+        {
+          "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "title": "$BUILD_JOB_NAME failed",
+          "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "fields": [
+            {
+              "title": "Pipeline",
+              "value": "$BUILD_PIPELINE_NAME",
+              "short": true
+            },
+            {
+              "title": "Registry",
+              "value": "((docker-registry-ci))",
+              "short": true
+            },
+            {
+              "title": "Build",
+              "value": "#$BUILD_NAME",
+              "short": true
+            }
+          ],
+          "color": "#ff0000"
+        }
+      ]
+
+  slack_docker_build_ereror_ci: &slack_docker_build_error_ci
+    put: slack-alert
+    params:
+      icon_emoji: ":concourse:"
+      username: Concourse
+      attachments: [
+        {
+          "fallback": "$BUILD_JOB_NAME errored. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "title": "$BUILD_JOB_NAME errored",
+          "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "fields": [
+            {
+              "title": "Pipeline",
+              "value": "$BUILD_PIPELINE_NAME",
+              "short": true
+            },
+            {
+              "title": "Registry",
+              "value": "((docker-registry-ci))",
+              "short": true
+            },
+            {
+              "title": "Build",
+              "value": "#$BUILD_NAME",
+              "short": true
+            }
+          ],
+          "color": "#f58a3d"
+        }
       ]
 
   slack_docker_build_failure_gcr: &slack_docker_build_failure_gcr
@@ -710,30 +803,62 @@ templating:
       icon_emoji: ":concourse:"
       username: Concourse
       attachments: [
-          {
-              "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-              "title": "$BUILD_JOB_NAME failed",
-              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-              "fields": [
-                  {
-                      "title": "Pipeline",
-                      "value": "$BUILD_PIPELINE_NAME",
-                      "short": true
-                  },
-                  {
-                      "title": "Registry",
-                      "value": "((docker-registry-gcr))",
-                      "short": true
-                  },
+        {
+          "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "title": "$BUILD_JOB_NAME failed",
+          "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "fields": [
+            {
+              "title": "Pipeline",
+              "value": "$BUILD_PIPELINE_NAME",
+              "short": true
+            },
+            {
+              "title": "Registry",
+              "value": "((docker-registry-gcr))",
+              "short": true
+            },
 
-                  {
-                      "title": "Build",
-                      "value": "#$BUILD_NAME",
-                      "short": true
-                  }
-              ],
-              "color": "#F35A00"
-          }
+            {
+              "title": "Build",
+              "value": "#$BUILD_NAME",
+              "short": true
+            }
+          ],
+          "color": "#ff0000"
+        }
+      ]
+
+  slack_docker_build_error_gcr: &slack_docker_build_error_gcr
+    put: slack-alert
+    params:
+      icon_emoji: ":concourse:"
+      username: Concourse
+      attachments: [
+        {
+          "fallback": "$BUILD_JOB_NAME errored. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "title": "$BUILD_JOB_NAME errored",
+          "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "fields": [
+            {
+              "title": "Pipeline",
+              "value": "$BUILD_PIPELINE_NAME",
+              "short": true
+            },
+            {
+              "title": "Registry",
+              "value": "((docker-registry-gcr))",
+              "short": true
+            },
+
+            {
+              "title": "Build",
+              "value": "#$BUILD_NAME",
+              "short": true
+            }
+          ],
+          "color": "#f58a3d"
+        }
       ]
 
   slack_failure_alert_wl: &slack_failure_alert_wl
@@ -742,30 +867,61 @@ templating:
       icon_emoji: ":concourse:"
       username: Concourse
       attachments: [
+        {
+          "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "title": "$BUILD_JOB_NAME failed",
+          "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "fields": [
             {
-                "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-                "title": "$BUILD_JOB_NAME failed",
-                "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-                "fields": [
-                    {
-                        "title": "Pipeline",
-                        "value": "$BUILD_PIPELINE_NAME",
-                        "short": true
-                    },
-                    {
-                        "title": "Project",
-                        "value": "((wl-gcp-project-name))",
-                        "short": true
-                    },
-                    {
-                        "title": "Build",
-                        "value": "#$BUILD_NAME",
-                        "short": true
-                    }
-                ],
-                "color": "#F35A00"
+              "title": "Pipeline",
+              "value": "$BUILD_PIPELINE_NAME",
+              "short": true
+            },
+            {
+              "title": "Project",
+              "value": "((wl-gcp-project-name))",
+              "short": true
+            },
+            {
+              "title": "Build",
+              "value": "#$BUILD_NAME",
+              "short": true
             }
-        ]
+          ],
+          "color": "#ff0000"
+        }
+      ]
+
+  slack_error_alert_wl: &slack_error_alert_wl
+    put: slack-alert
+    params:
+      icon_emoji: ":concourse:"
+      username: Concourse
+      attachments: [
+        {
+          "fallback": "$BUILD_JOB_NAME errored. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "title": "$BUILD_JOB_NAME errored",
+          "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "fields": [
+            {
+              "title": "Pipeline",
+              "value": "$BUILD_PIPELINE_NAME",
+              "short": true
+            },
+            {
+              "title": "Project",
+              "value": "((wl-gcp-project-name))",
+              "short": true
+            },
+            {
+              "title": "Build",
+              "value": "#$BUILD_NAME",
+              "short": true
+            }
+          ],
+          "color": "#f58a3d"
+        }
+      ]
 
   slack_success_alert_wl: &slack_success_alert_wl
     put: slack-alert
@@ -773,30 +929,30 @@ templating:
       icon_emoji: ":concourse:"
       username: Concourse
       attachments: [
+        {
+          "fallback": "$BUILD_JOB_NAME succeeded. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "title": "$BUILD_JOB_NAME succeeded",
+          "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "fields": [
             {
-                "fallback": "$BUILD_JOB_NAME succeeded. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-                "title": "$BUILD_JOB_NAME succeeded",
-                "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-                "fields": [
-                    {
-                        "title": "Pipeline",
-                        "value": "$BUILD_PIPELINE_NAME",
-                        "short": true
-                    },
-                    {
-                        "title": "Project",
-                        "value": "((wl-gcp-project-name))",
-                        "short": true
-                    },
-                    {
-                        "title": "Build",
-                        "value": "#$BUILD_NAME",
-                        "short": true
-                    }
-                ],
-                "color": "#36a64f"
+              "title": "Pipeline",
+              "value": "$BUILD_PIPELINE_NAME",
+              "short": true
+            },
+            {
+              "title": "Project",
+              "value": "((wl-gcp-project-name))",
+              "short": true
+            },
+            {
+                "title": "Build",
+                "value": "#$BUILD_NAME",
+                "short": true
             }
-        ]
+          ],
+          "color": "#36a64f"
+       }
+      ]
 
   slack_started_alert_wl: &slack_started_alert_wl
     put: slack-alert
@@ -804,30 +960,30 @@ templating:
       icon_emoji: ":concourse:"
       username: Concourse
       attachments: [
+        {
+          "fallback": "$BUILD_JOB_NAME started... See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "title": "$BUILD_JOB_NAME started...",
+          "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+          "fields": [
             {
-                "fallback": "$BUILD_JOB_NAME started... See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-                "title": "$BUILD_JOB_NAME started...",
-                "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-                "fields": [
-                    {
-                        "title": "Pipeline",
-                        "value": "$BUILD_PIPELINE_NAME",
-                        "short": true
-                    },
-                    {
-                        "title": "Project",
-                        "value": "((wl-gcp-project-name))",
-                        "short": true
-                    },
-                    {
-                        "title": "Build",
-                        "value": "#$BUILD_NAME",
-                        "short": true
-                    }
-                ],
-                "color": "#36a64f"
+              "title": "Pipeline",
+              "value": "$BUILD_PIPELINE_NAME",
+              "short": true
+          },
+            {
+              "title": "Project",
+              "value": "((wl-gcp-project-name))",
+              "short": true
+            },
+            {
+              "title": "Build",
+              "value": "#$BUILD_NAME",
+              "short": true
             }
-        ]
+          ],
+          "color": "#36a64f"
+        }
+      ]
 
 
 jobs:
@@ -840,6 +996,7 @@ jobs:
     trigger: true
   - task: Build Action Scheduler Image (master)
     on_failure: *slack_failure_alert_prebuild
+    on_error: *slack_error_alert_prebuild
     config:
       platform: linux
       image_resource:
@@ -863,6 +1020,7 @@ jobs:
             cp healthcheck.sh ../build
   - put: action-scheduler-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: build
       tag_file: action-scheduler-master/.git/ref
@@ -871,6 +1029,7 @@ jobs:
       save: true
   - put: action-scheduler-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_failure_gcr
     params:
       build: build
       cache_from:
@@ -887,6 +1046,7 @@ jobs:
     trigger: true
   - task: Build Action Worker Image (master)
     on_failure: *slack_failure_alert_prebuild
+    on_error: *slack_error_alert_prebuild
     config:
       platform: linux
       image_resource:
@@ -910,6 +1070,7 @@ jobs:
             cp healthcheck.sh ../build
   - put: action-worker-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: build
       tag_file: action-worker-master/.git/ref
@@ -918,6 +1079,7 @@ jobs:
       save: true
   - put: action-worker-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: build
       cache_from:
@@ -934,6 +1096,7 @@ jobs:
     trigger: true
   - task: Build Case API Image (master)
     on_failure: *slack_failure_alert_prebuild
+    on_error: *slack_error_alert_prebuild
     config:
       platform: linux
       image_resource:
@@ -956,6 +1119,7 @@ jobs:
             cp Dockerfile ../build
   - put: case-api-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: build
       tag_file: case-api-master/.git/ref
@@ -964,6 +1128,7 @@ jobs:
       save: true
   - put: case-api-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: build
       cache_from:
@@ -980,6 +1145,7 @@ jobs:
     trigger: true
   - task: Build Case Processor Image (master)
     on_failure: *slack_failure_alert_prebuild
+    on_error: *slack_error_alert_prebuild
     config:
       platform: linux
       image_resource:
@@ -1003,6 +1169,7 @@ jobs:
             cp healthcheck.sh ../build
   - put: case-processor-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: build
       tag_file: case-processor-master/.git/ref
@@ -1011,6 +1178,7 @@ jobs:
       save: true
   - put: case-processor-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: build
       cache_from:
@@ -1027,6 +1195,7 @@ jobs:
     trigger: true
   - put: print-file-service-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: print-file-service-master
       tag_file: print-file-service-master/.git/ref
@@ -1035,6 +1204,7 @@ jobs:
       save: true
   - put: print-file-service-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: print-file-service-master
       cache_from:
@@ -1051,6 +1221,7 @@ jobs:
     trigger: true
   - task: Build UAC QID Service Image (master)
     on_failure: *slack_failure_alert_prebuild
+    on_error: *slack_error_alert_prebuild
     config:
       platform: linux
       image_resource:
@@ -1073,6 +1244,7 @@ jobs:
             cp Dockerfile ../build
   - put: uac-qid-service-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: build
       tag_file: uac-qid-service-master/.git/ref
@@ -1081,6 +1253,7 @@ jobs:
       save: true
   - put: uac-qid-service-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: build
       cache_from:
@@ -1097,6 +1270,7 @@ jobs:
     trigger: true
   - put: ops-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: ops-master
       tag_file: ops-master/.git/ref
@@ -1105,6 +1279,7 @@ jobs:
       save: true
   - put: ops-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: ops-master
       cache_from:
@@ -1121,6 +1296,7 @@ jobs:
     trigger: true
   - put: toolbox-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: toolbox-master
       tag_file: toolbox-master/.git/ref
@@ -1129,6 +1305,7 @@ jobs:
       save: true
   - put: toolbox-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: toolbox-master
       cache_from:
@@ -1145,6 +1322,7 @@ jobs:
     trigger: true
   - put: pubsub-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: pubsub-master
       tag_file: pubsub-master/.git/ref
@@ -1153,6 +1331,7 @@ jobs:
       save: true
   - put: pubsub-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: pubsub-master
       cache_from:
@@ -1169,6 +1348,7 @@ jobs:
     trigger: true
   - put: qid-batch-runner-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: qid-batch-runner-master
       tag_file: qid-batch-runner-master/.git/ref
@@ -1177,6 +1357,7 @@ jobs:
       save: true
   - put: qid-batch-runner-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: qid-batch-runner-master
       cache_from:
@@ -1193,6 +1374,7 @@ jobs:
     trigger: true
   - put: sample-loader-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: sample-loader-master
       tag_file: sample-loader-master/.git/ref
@@ -1201,6 +1383,7 @@ jobs:
       save: true
   - put: sample-loader-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: sample-loader-master
       cache_from:
@@ -1217,6 +1400,7 @@ jobs:
     trigger: true
   - put: acceptance-tests-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: acceptance-tests-master
       tag_file: acceptance-tests-master/.git/ref
@@ -1225,6 +1409,7 @@ jobs:
       save: true
   - put: acceptance-tests-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: acceptance-tests-master
       cache_from:
@@ -1241,6 +1426,7 @@ jobs:
     trigger: true
   - task: Build Fieldwork Adapter Image (master)
     on_failure: *slack_failure_alert_prebuild
+    on_error: *slack_error_alert_prebuild
     config:
       platform: linux
       image_resource:
@@ -1264,6 +1450,7 @@ jobs:
             cp healthcheck.sh ../build
   - put: fieldwork-adapter-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: build
       tag_file: fieldwork-adapter-master/.git/ref
@@ -1272,6 +1459,7 @@ jobs:
       save: true
   - put: fieldwork-adapter-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: build
       cache_from:
@@ -1288,6 +1476,7 @@ jobs:
     trigger: true
   - task: Build Notify Processor Image (master)
     on_failure: *slack_failure_alert_prebuild
+    on_error: *slack_error_alert_prebuild
     config:
       platform: linux
       image_resource:
@@ -1311,6 +1500,7 @@ jobs:
             cp healthcheck.sh ../build
   - put: notify-processor-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: build
       tag_file: notify-processor-master/.git/ref
@@ -1319,6 +1509,7 @@ jobs:
       save: true
   - put: notify-processor-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: build
       cache_from:
@@ -1335,6 +1526,7 @@ jobs:
     trigger: true
   - put: notify-stub-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: notify-stub-master
       tag_file: notify-stub-master/.git/ref
@@ -1343,6 +1535,7 @@ jobs:
       save: true
   - put: notify-stub-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: notify-stub-master
       cache_from:
@@ -1359,6 +1552,7 @@ jobs:
     trigger: true
   - put: data-exporter-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: data-exporter-master/docker
       tag_file: data-exporter-master/.git/ref
@@ -1367,6 +1561,7 @@ jobs:
       save: true
   - put: data-exporter-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: data-exporter-master/docker
       cache_from:
@@ -1383,6 +1578,7 @@ jobs:
     trigger: true
   - task: Build Exception Manager Image (master)
     on_failure: *slack_failure_alert_prebuild
+    on_error: *slack_error_alert_prebuild
     config:
       platform: linux
       image_resource:
@@ -1405,6 +1601,7 @@ jobs:
             cp Dockerfile ../build
   - put: exception-manager-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: build
       tag_file: exception-manager-master/.git/ref
@@ -1413,6 +1610,7 @@ jobs:
       save: true
   - put: exception-manager-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: build
       cache_from:
@@ -1429,6 +1627,7 @@ jobs:
     trigger: true
   - put: performance-tests-docker-image-ci
     on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
     params:
       build: performance-tests-master
       tag_file: performance-tests-master/.git/ref
@@ -1437,6 +1636,7 @@ jobs:
       save: true
   - put: performance-tests-docker-image-gcr
     on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
     params:
       build: performance-tests-master
       cache_from:
@@ -1468,6 +1668,7 @@ jobs:
                   ops-deploy]
   on_success: *slack_success_alert_ci
   on_failure: *slack_failure_alert_ci
+  on_error: *slack_error_alert_ci
   plan:
   - get: census-rm-terraform
     trigger: true
@@ -1503,6 +1704,7 @@ jobs:
                   regional-counts-deploy]
   on_success: *slack_success_alert_ci
   on_failure: *slack_failure_alert_ci
+  on_error: *slack_error_alert_ci
   plan:
     - get: census-rm-kubernetes-dependencies-repo
       trigger: true
@@ -1543,6 +1745,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -1579,6 +1782,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -1615,6 +1819,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -1651,6 +1856,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -1687,6 +1893,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -1723,6 +1930,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -1759,6 +1967,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -1795,6 +2004,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-statefulset.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -1831,6 +2041,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -1867,6 +2078,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -1903,6 +2115,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -1939,6 +2152,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -1975,6 +2189,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -2011,6 +2226,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -2047,6 +2263,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -2083,6 +2300,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -2219,6 +2437,7 @@ jobs:
   - task: "Run Acceptance Tests (in K8s)"
     file: acceptance-tests-master/tasks/kubectl-run-acceptance-tests.yml
     on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
@@ -2248,6 +2467,7 @@ jobs:
                   wl-regional-counts]
   on_success: *slack_success_alert_wl
   on_failure: *slack_failure_alert_wl
+  on_error: *slack_error_alert_wl
   plan:
     - get: census-rm-terraform
       trigger: true
@@ -2283,6 +2503,7 @@ jobs:
                   wl-regional-counts]
   on_success: *slack_success_alert_wl
   on_failure: *slack_failure_alert_wl
+  on_error: *slack_error_alert_wl
   plan:
     - get: census-rm-kubernetes-dependencies-repo
       trigger: true
@@ -2322,6 +2543,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))
@@ -2358,6 +2580,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))
@@ -2394,6 +2617,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-statefulset.yml
     on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))
@@ -2430,6 +2654,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))
@@ -2466,6 +2691,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))
@@ -2502,6 +2728,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))
@@ -2538,6 +2765,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))
@@ -2572,6 +2800,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))
@@ -2608,6 +2837,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))
@@ -2644,6 +2874,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))
@@ -2680,6 +2911,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))
@@ -2716,6 +2948,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))
@@ -2752,6 +2985,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))
@@ -2788,6 +3022,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))
@@ -2824,6 +3059,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -48,25 +48,52 @@ jobs:
           icon_emoji: ":concourse:"
           username: Concourse
           attachments: [
-              {
-                  "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-                  "title": "$BUILD_JOB_NAME failed",
-                  "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-                  "fields": [
-                      {
-                          "title": "Pipeline",
-                          "value": "$BUILD_PIPELINE_NAME",
-                          "short": true
-                      },
-                      {
-                          "title": "Build",
-                          "value": "#$BUILD_NAME",
-                          "short": true
-                      }
-                  ],
-                  "color": "#F35A00"
-              }
+            {
+              "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+              "title": "$BUILD_JOB_NAME failed",
+              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+              "fields": [
+                {
+                  "title": "Pipeline",
+                  "value": "$BUILD_PIPELINE_NAME",
+                  "short": true
+                },
+                {
+                  "title": "Build",
+                  "value": "#$BUILD_NAME",
+                  "short": true
+                }
+              ],
+              "color": "#ff0000"
+            }
           ]
+
+      on_error:
+        put: slack-alert
+        params:
+          icon_emoji: ":concourse:"
+          username: Concourse
+          attachments: [
+            {
+              "fallback": "$BUILD_JOB_NAME errored. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+              "title": "$BUILD_JOB_NAME failed",
+              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+              "fields": [
+                {
+                  "title": "Pipeline",
+                  "value": "$BUILD_PIPELINE_NAME",
+                  "short": true
+                },
+                {
+                  "title": "Build",
+                  "value": "#$BUILD_NAME",
+                  "short": true
+                }
+              ],
+              "color": "#f58a3d"
+            }
+          ]
+
       params:
         pipelines:
 

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
           attachments: [
             {
               "fallback": "$BUILD_JOB_NAME errored. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-              "title": "$BUILD_JOB_NAME failed",
+              "title": "$BUILD_JOB_NAME errored",
               "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
               "fields": [
                 {

--- a/pipelines/docker-release-pipeline.yml
+++ b/pipelines/docker-release-pipeline.yml
@@ -403,24 +403,24 @@ slack_failure_alert_prebuild: &slack_failure_alert_prebuild
     icon_emoji: ":concourse:"
     username: Concourse
     attachments: [
-        {
-            "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-            "title": "$BUILD_JOB_NAME failed",
-            "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-            "fields": [
-                {
-                    "title": "Pipeline",
-                    "value": "$BUILD_PIPELINE_NAME",
-                    "short": true
-                },
-                {
-                    "title": "Build",
-                    "value": "#$BUILD_NAME",
-                    "short": true
-                }
-            ],
-            "color": "#F35A00"
-        }
+      {
+        "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "title": "$BUILD_JOB_NAME failed",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "fields": [
+          {
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Build",
+            "value": "#$BUILD_NAME",
+            "short": true
+          }
+        ],
+        "color": "#ff0000"
+      }
     ]
 
 slack_failure_alert_ci: &slack_failure_alert_ci
@@ -429,29 +429,29 @@ slack_failure_alert_ci: &slack_failure_alert_ci
     icon_emoji: ":concourse:"
     username: Concourse
     attachments: [
-        {
-            "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-            "title": "$BUILD_JOB_NAME failed",
-            "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-            "fields": [
-                {
-                    "title": "Pipeline",
-                    "value": "$BUILD_PIPELINE_NAME",
-                    "short": true
-                },
-                {
-                    "title": "Registry",
-                    "value": "((docker-registry-ci))",
-                    "short": true
-                },
-                {
-                    "title": "Build",
-                    "value": "#$BUILD_NAME",
-                    "short": true
-                }
-            ],
-            "color": "#F35A00"
-        }
+      {
+        "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "title": "$BUILD_JOB_NAME failed",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "fields": [
+          {
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Registry",
+            "value": "((docker-registry-ci))",
+            "short": true
+          },
+          {
+            "title": "Build",
+            "value": "#$BUILD_NAME",
+            "short": true
+          }
+        ],
+        "color": "#ff0000"
+      }
     ]
 
 slack_failure_alert_gcr: &slack_failure_alert_gcr
@@ -460,30 +460,117 @@ slack_failure_alert_gcr: &slack_failure_alert_gcr
     icon_emoji: ":concourse:"
     username: Concourse
     attachments: [
-        {
-            "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-            "title": "$BUILD_JOB_NAME failed",
-            "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-            "fields": [
-                {
-                    "title": "Pipeline",
-                    "value": "$BUILD_PIPELINE_NAME",
-                    "short": true
-                },
-                {
-                    "title": "Registry",
-                    "value": "((docker-registry-gcr))",
-                    "short": true
-                },
+      {
+        "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "title": "$BUILD_JOB_NAME failed",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "fields": [
+          {
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Registry",
+            "value": "((docker-registry-gcr))",
+            "short": true
+          },
+          {
+            "title": "Build",
+            "value": "#$BUILD_NAME",
+            "short": true
+          }
+        ],
+        "color": "#ff0000"
+      }
+    ]
 
-                {
-                    "title": "Build",
-                    "value": "#$BUILD_NAME",
-                    "short": true
-                }
-            ],
-            "color": "#F35A00"
-        }
+slack_error_alert_prebuild: &slack_error_alert_prebuild
+  put: slack-alert
+  params:
+    icon_emoji: ":concourse:"
+    username: Concourse
+    attachments: [
+      {
+        "fallback": "$BUILD_JOB_NAME errored. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "title": "$BUILD_JOB_NAME errored",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "fields": [
+          {
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Build",
+            "value": "#$BUILD_NAME",
+            "short": true
+          }
+        ],
+        "color": "#f58a3d"
+      }
+    ]
+
+slack_error_alert_ci: &slack_error_alert_ci
+  put: slack-alert
+  params:
+    icon_emoji: ":concourse:"
+    username: Concourse
+    attachments: [
+      {
+        "fallback": "$BUILD_JOB_NAME errored. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "title": "$BUILD_JOB_NAME errored",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "fields": [
+          {
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Registry",
+            "value": "((docker-registry-ci))",
+            "short": true
+          },
+          {
+            "title": "Build",
+            "value": "#$BUILD_NAME",
+            "short": true
+          }
+        ],
+        "color": "#f58a3d"
+      }
+    ]
+
+slack_error_alert_gcr: &slack_error_alert_gcr
+  put: slack-alert
+  params:
+    icon_emoji: ":concourse:"
+    username: Concourse
+    attachments: [
+      {
+        "fallback": "$BUILD_JOB_NAME errored. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "title": "$BUILD_JOB_NAME errored",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "fields": [
+          {
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Registry",
+            "value": "((docker-registry-gcr))",
+            "short": true
+          },
+          {
+            "title": "Build",
+            "value": "#$BUILD_NAME",
+            "short": true
+          }
+        ],
+        "color": "#f58a3d"
+      }
     ]
 
 jobs:
@@ -496,6 +583,7 @@ jobs:
       trigger: true
     - task: Build Action Scheduler Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -522,6 +610,7 @@ jobs:
               cp healthcheck.sh ../build
     - put: action-scheduler-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: build
         tag_file: action-scheduler-release/tag
@@ -530,6 +619,7 @@ jobs:
         save: true
     - put: action-scheduler-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: build
         cache_from:
@@ -547,6 +637,7 @@ jobs:
       trigger: true
     - task: Build Action Worker Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -573,6 +664,7 @@ jobs:
               cp healthcheck.sh ../build
     - put: action-worker-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: build
         tag_file: action-worker-release/tag
@@ -581,6 +673,7 @@ jobs:
         save: true
     - put: action-worker-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: build
         cache_from:
@@ -598,6 +691,7 @@ jobs:
       trigger: true
     - task: Build Case API Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -623,6 +717,7 @@ jobs:
               cp Dockerfile ../build
     - put: case-api-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: build
         tag_file: case-api-release/tag
@@ -631,6 +726,7 @@ jobs:
         save: true
     - put: case-api-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: build
         cache_from:
@@ -648,6 +744,7 @@ jobs:
       trigger: true
     - task: Build Case Processor Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -674,6 +771,7 @@ jobs:
               cp healthcheck.sh ../build
     - put: case-processor-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: build
         tag_file: case-processor-release/tag
@@ -682,6 +780,7 @@ jobs:
         save: true
     - put: case-processor-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: build
         cache_from:
@@ -699,6 +798,7 @@ jobs:
       trigger: true
     - task: Build Print File Service Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -718,6 +818,7 @@ jobs:
               tar -xzf source.tar.gz -C ../extracted-print-file-service --strip-components=1
     - put: print-file-service-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: extracted-print-file-service
         tag_file: print-file-service-release/tag
@@ -726,6 +827,7 @@ jobs:
         save: true
     - put: print-file-service-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: extracted-print-file-service
         cache_from:
@@ -743,6 +845,7 @@ jobs:
       trigger: true
     - task: Build UAC QID Service Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -768,6 +871,7 @@ jobs:
               cp Dockerfile ../build
     - put: uac-qid-service-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: build
         tag_file: uac-qid-service-release/tag
@@ -776,6 +880,7 @@ jobs:
         save: true
     - put: uac-qid-service-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: build
         cache_from:
@@ -793,6 +898,7 @@ jobs:
       trigger: true
     - task: Build Ops Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -812,6 +918,7 @@ jobs:
               tar -xzf source.tar.gz -C ../extracted-ops --strip-components=1
     - put: ops-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: extracted-ops
         tag_file: ops-release/tag
@@ -820,6 +927,7 @@ jobs:
         save: true
     - put: ops-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: extracted-ops
         cache_from:
@@ -837,6 +945,7 @@ jobs:
       trigger: true
     - task: Build RM-toolbox Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -856,6 +965,7 @@ jobs:
               tar -xzf source.tar.gz -C ../extracted-rm-toolbox --strip-components=1
     - put: rm-toolbox-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: extracted-rm-toolbox
         tag_file: rm-toolbox-release/tag
@@ -864,6 +974,7 @@ jobs:
         save: true
     - put: rm-toolbox-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: extracted-rm-toolbox
         cache_from:
@@ -882,6 +993,7 @@ jobs:
       trigger: true
     - task: Build PubSub Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -901,6 +1013,7 @@ jobs:
               tar -xzf source.tar.gz -C ../extracted-pubsub --strip-components=1
     - put: pubsub-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: extracted-pubsub
         tag_file: pubsub-release/tag
@@ -909,6 +1022,7 @@ jobs:
         save: true
     - put: pubsub-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: extracted-pubsub
         cache_from:
@@ -926,6 +1040,7 @@ jobs:
       trigger: true
     - task: Build Batch Runner Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -945,6 +1060,7 @@ jobs:
               tar -xzf source.tar.gz -C ../extracted-batch-runner --strip-components=1
     - put: qid-batch-runner-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: extracted-batch-runner
         tag_file: qid-batch-runner-release/tag
@@ -953,6 +1069,7 @@ jobs:
         save: true
     - put: qid-batch-runner-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: extracted-batch-runner
         cache_from:
@@ -970,6 +1087,7 @@ jobs:
       trigger: true
     - task: Build Sample Loader Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -989,6 +1107,7 @@ jobs:
               tar -xzf source.tar.gz -C ../extracted-sample-loader --strip-components=1
     - put: sample-loader-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: extracted-sample-loader
         tag_file: sample-loader-release/tag
@@ -997,6 +1116,7 @@ jobs:
         save: true
     - put: sample-loader-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: extracted-sample-loader
         cache_from:
@@ -1014,6 +1134,7 @@ jobs:
       trigger: true
     - task: Build Fieldwork Adapter Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -1040,6 +1161,7 @@ jobs:
               cp healthcheck.sh ../build
     - put: fieldwork-adapter-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: build
         tag_file: fieldwork-adapter-release/tag
@@ -1048,6 +1170,7 @@ jobs:
         save: true
     - put: fieldwork-adapter-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: build
         cache_from:
@@ -1065,6 +1188,7 @@ jobs:
       trigger: true
     - task: Build Notify Processor Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -1091,6 +1215,7 @@ jobs:
               cp healthcheck.sh ../build
     - put: notify-processor-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: build
         tag_file: notify-processor-release/tag
@@ -1099,6 +1224,7 @@ jobs:
         save: true
     - put: notify-processor-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: build
         cache_from:
@@ -1116,6 +1242,7 @@ jobs:
       trigger: true
     - task: Build Acceptance Tests Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -1135,6 +1262,7 @@ jobs:
               tar -xzf source.tar.gz -C ../extracted-acceptance-tests --strip-components=1
     - put: acceptance-tests-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: extracted-acceptance-tests
         tag_file: acceptance-tests-release/tag
@@ -1143,6 +1271,7 @@ jobs:
         save: true
     - put: acceptance-tests-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: extracted-acceptance-tests
         cache_from:
@@ -1160,6 +1289,7 @@ jobs:
       trigger: true
     - task: Build Data Exporter Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -1179,6 +1309,7 @@ jobs:
               tar -xzf source.tar.gz -C ../extracted-data-exporter --strip-components=1
     - put: data-exporter-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: extracted-data-exporter/docker
         tag_file: data-exporter-release/tag
@@ -1187,6 +1318,7 @@ jobs:
         save: true
     - put: data-exporter-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: extracted-data-exporter/docker
         cache_from:
@@ -1204,6 +1336,7 @@ jobs:
       trigger: true
     - task: Build Exception Manager Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -1229,6 +1362,7 @@ jobs:
               cp Dockerfile ../build
     - put: exception-manager-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: build
         tag_file: exception-manager-release/tag
@@ -1237,6 +1371,7 @@ jobs:
         save: true
     - put: exception-manager-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: build
         cache_from:
@@ -1254,6 +1389,7 @@ jobs:
       trigger: true
     - task: Build Data Exporter Image (release)
       on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
       config:
         platform: linux
         image_resource:
@@ -1273,6 +1409,7 @@ jobs:
               tar -xzf source.tar.gz -C ../extracted-performance-tests --strip-components=1
     - put: performance-tests-docker-image-ci
       on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
       params:
         build: extracted-performance-tests
         tag_file: performance-tests-release/tag
@@ -1281,6 +1418,7 @@ jobs:
         save: true
     - put: performance-tests-docker-image-gcr
       on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
       params:
         build: extracted-performance-tests
         cache_from:

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -100,35 +100,71 @@ slack_failure_alert: &slack_failure_alert
     icon_emoji: ":concourse:"
     username: Concourse
     attachments: [
+      {
+        "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "title": "$BUILD_JOB_NAME failed",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "fields": [
           {
-              "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-              "title": "$BUILD_JOB_NAME failed",
-              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-              "fields": [
-                  {
-                      "title": "Pipeline",
-                      "value": "$BUILD_PIPELINE_NAME",
-                      "short": true
-                  },
-                  {
-                      "title": "Environment",
-                      "value": "((gcp-environment-name))",
-                      "short": true
-                  },
-                  {
-                      "title": "Project",
-                      "value": "((gcp-project-name))",
-                      "short": true
-                  },
-                  {
-                      "title": "Build",
-                      "value": "#$BUILD_NAME",
-                      "short": true
-                  }
-              ],
-              "color": "#F35A00"
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Environment",
+            "value": "((gcp-environment-name))",
+            "short": true
+          },
+          {
+            "title": "Project",
+            "value": "((gcp-project-name))",
+            "short": true
+          },
+          {
+            "title": "Build",
+            "value": "#$BUILD_NAME",
+            "short": true
           }
-      ]
+        ],
+          "color": "#ff0000"
+      }
+    ]
+
+slack_error_alert: &slack_error_alert
+  put: slack-alert
+  params:
+    icon_emoji: ":concourse:"
+    username: Concourse
+    attachments: [
+      {
+        "fallback": "$BUILD_JOB_NAME errored. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "title": "$BUILD_JOB_NAME errored",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "fields": [
+          {
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Environment",
+            "value": "((gcp-environment-name))",
+            "short": true
+          },
+          {
+            "title": "Project",
+            "value": "((gcp-project-name))",
+            "short": true
+          },
+          {
+            "title": "Build",
+            "value": "#$BUILD_NAME",
+            "short": true
+          }
+        ],
+        "color": "#f58a3d"
+      }
+    ]
 
 slack_success_alert: &slack_success_alert
   put: slack-alert
@@ -136,30 +172,30 @@ slack_success_alert: &slack_success_alert
     icon_emoji: ":concourse:"
     username: Concourse
     attachments: [
+      {
+        "fallback": "((gcp-environment-name)) release succeeded. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+        "title": "((gcp-environment-name)) Release Succeeded",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+        "fields": [
           {
-              "fallback": "((gcp-environment-name)) release succeeded. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
-              "title": "((gcp-environment-name)) Release Succeeded",
-              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
-              "fields": [
-                  {
-                      "title": "Pipeline",
-                      "value": "$BUILD_PIPELINE_NAME",
-                      "short": true
-                  },
-                  {
-                      "title": "Environment",
-                      "value": "((gcp-environment-name))",
-                      "short": true
-                  },
-                  {
-                      "title": "Project",
-                      "value": "((gcp-project-name))",
-                      "short": true
-                  }
-              ],
-              "color": "#36a64f"
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Environment",
+            "value": "((gcp-environment-name))",
+            "short": true
+          },
+          {
+            "title": "Project",
+            "value": "((gcp-project-name))",
+            "short": true
           }
-      ]
+        ],
+        "color": "#36a64f"
+      }
+    ]
 
 slack_in_progress_alert: &slack_in_progress_alert
   put: slack-alert
@@ -167,30 +203,30 @@ slack_in_progress_alert: &slack_in_progress_alert
     icon_emoji: ":concourse:"
     username: Concourse
     attachments: [
+      {
+        "fallback": "((gcp-environment-name)) release started. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+        "title": "((gcp-environment-name)) Release Started",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+        "fields": [
           {
-              "fallback": "((gcp-environment-name)) release started. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
-              "title": "((gcp-environment-name)) Release Started",
-              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
-              "fields": [
-                  {
-                      "title": "Pipeline",
-                      "value": "$BUILD_PIPELINE_NAME",
-                      "short": true
-                  },
-                  {
-                      "title": "Environment",
-                      "value": "((gcp-environment-name))",
-                      "short": true
-                  },
-                  {
-                      "title": "Project",
-                      "value": "((gcp-project-name))",
-                      "short": true
-                  }
-              ],
-              "color": "#ffe100"
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Environment",
+            "value": "((gcp-environment-name))",
+            "short": true
+          },
+          {
+            "title": "Project",
+            "value": "((gcp-project-name))",
+            "short": true
           }
-      ]
+        ],
+        "color": "#ffe100"
+      }
+    ]
 
 
 jobs:
@@ -216,6 +252,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+    on_error: *slack_error_alert
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -242,6 +279,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_error: *slack_error_alert
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -268,6 +306,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+    on_error: *slack_error_alert
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -294,6 +333,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_error: *slack_error_alert
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -320,6 +360,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+    on_error: *slack_error_alert
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -346,6 +387,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_error: *slack_error_alert
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -372,6 +414,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+    on_error: *slack_error_alert
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -398,6 +441,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
+    on_error: *slack_error_alert
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -424,6 +468,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_error: *slack_error_alert
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -450,6 +495,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_error: *slack_error_alert
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -476,6 +522,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+    on_error: *slack_error_alert
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -502,6 +549,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_error: *slack_error_alert
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -528,6 +576,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_error: *slack_error_alert
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -554,6 +603,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_error: *slack_error_alert
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -580,6 +630,7 @@ jobs:
     passed: ["Trigger Deployment"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    on_error: *slack_error_alert
     on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -631,6 +682,7 @@ jobs:
     toolbox,
     event-latency-monitor,
     rabbitmonitor]
+  on_error: *slack_error_alert
   on_failure: *slack_failure_alert
   plan:
     - get: every-minute
@@ -651,6 +703,7 @@ jobs:
                   toolbox,
                   event-latency-monitor,
                   rabbitmonitor]
+  on_error: *slack_error_alert
   on_failure: *slack_failure_alert
   plan:
     - get: every-minute
@@ -683,6 +736,7 @@ jobs:
                   toolbox,
                   event-latency-monitor,
                   rabbitmonitor]
+  on_error: *slack_error_alert
   on_failure: *slack_failure_alert
   plan:
     - get: every-minute

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -61,67 +61,67 @@ resources:
 
 templating:
 
-slack_release_success: &slack_release_success
+slack_error_alert: &slack_error_alert
   put: slack-alert
   params:
     icon_emoji: ":concourse:"
     username: Concourse
     attachments: [
+      {
+        "fallback": "$BUILD_JOB_NAME errored. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "title": "$BUILD_JOB_NAME errored",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "fields": [
           {
-              "fallback": "((performance-gcp-project-name)) release succeeded. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
-              "title": "((performance-gcp-project-name)) Release Succeeded",
-              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
-              "fields": [
-                  {
-                      "title": "Pipeline",
-                      "value": "$BUILD_PIPELINE_NAME",
-                      "short": true
-                  }, 
-                  {
-                      "title": "Project",
-                      "value": "((performance-gcp-project-name))",
-                      "short": true
-                  },
-                  {
-                      "title": "Build",
-                      "value": "#$BUILD_NAME",
-                      "short": true
-                  }
-              ],
-              "color": "#36a64f"
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Project",
+            "value": "((performance-gcp-project-name))",
+            "short": true
+          },
+          {
+            "title": "Build",
+            "value": "#$BUILD_NAME",
+            "short": true
           }
-      ]
+        ],
+        "color": "#f58a3d"
+      }
+    ]
 
-slack_release_in_progress: &slack_release_in_progress
+slack_performance_setup_error: &slack_performance_setup_error
   put: slack-alert
   params:
     icon_emoji: ":concourse:"
     username: Concourse
     attachments: [
+      {
+        "fallback": "Performance tests setup errored. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "title": "$BUILD_JOB_NAME errored",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "fields": [
           {
-              "fallback": "((performance-gcp-project-name)) release started. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
-              "title": "((performance-gcp-project-name)) Release Started",
-              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
-              "fields": [
-                  {
-                      "title": "Pipeline",
-                      "value": "$BUILD_PIPELINE_NAME",
-                      "short": true
-                  },  
-                  {
-                      "title": "Project",
-                      "value": "((performance-gcp-project-name))",
-                      "short": true
-                  },
-                  {
-                      "title": "Build",
-                      "value": "#$BUILD_NAME",
-                      "short": true
-                  }
-              ],
-              "color": "#ffe100"
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Project",
+            "value": "((performance-gcp-project-name))",
+            "short": true
+          },
+          {
+            "title": "Build",
+            "value": "#$BUILD_NAME",
+            "short": true
           }
-      ]
+        ],
+        "color": "#f58a3d"
+      }
+    ]
 
 slack_failure_alert: &slack_failure_alert
   put: slack-alert
@@ -129,30 +129,30 @@ slack_failure_alert: &slack_failure_alert
     icon_emoji: ":concourse:"
     username: Concourse
     attachments: [
+      {
+        "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "title": "$BUILD_JOB_NAME failed",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "fields": [
           {
-              "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-              "title": "$BUILD_JOB_NAME failed",
-              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-              "fields": [
-                  {
-                      "title": "Pipeline",
-                      "value": "$BUILD_PIPELINE_NAME",
-                      "short": true
-                  },
-                  {
-                      "title": "Project",
-                      "value": "((performance-gcp-project-name))",
-                      "short": true
-                  },
-                  {
-                      "title": "Build",
-                      "value": "#$BUILD_NAME",
-                      "short": true
-                  }
-              ],
-              "color": "#F35A00"
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Project",
+            "value": "((performance-gcp-project-name))",
+            "short": true
+          },
+          {
+            "title": "Build",
+            "value": "#$BUILD_NAME",
+            "short": true
           }
-      ]
+        ],
+        "color": "#ff0000"
+      }
+    ]
 
 slack_performance_setup_failure: &slack_performance_setup_failure
   put: slack-alert
@@ -160,31 +160,30 @@ slack_performance_setup_failure: &slack_performance_setup_failure
     icon_emoji: ":concourse:"
     username: Concourse
     attachments: [
+      {
+        "fallback": "Performance tests setup failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "title": "$BUILD_JOB_NAME failed",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "fields": [
           {
-              "fallback": "Performance tests setup failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-              "title": "$BUILD_JOB_NAME failed",
-              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
-              "fields": [
-                  {
-                      "title": "Pipeline",
-                      "value": "$BUILD_PIPELINE_NAME",
-                      "short": true
-                  },
-                  
-                  {
-                      "title": "Project",
-                      "value": "((performance-gcp-project-name))",
-                      "short": true
-                  },
-                  {
-                      "title": "Build",
-                      "value": "#$BUILD_NAME",
-                      "short": true
-                  }
-              ],
-              "color": "#F35A00"
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Project",
+            "value": "((performance-gcp-project-name))",
+            "short": true
+          },
+          {
+            "title": "Build",
+            "value": "#$BUILD_NAME",
+            "short": true
           }
-      ]
+        ],
+        "color": "#ff0000"
+      }
+    ]
 
 slack_performance_tests_finished: &slack_performance_tests_finished
   put: slack-alert
@@ -192,30 +191,30 @@ slack_performance_tests_finished: &slack_performance_tests_finished
     icon_emoji: ":concourse:"
     username: Concourse
     attachments: [
+      {
+        "fallback": "Performance tests finished. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+        "title": "Performance tests finished",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+        "fields": [
           {
-              "fallback": "Performance tests finished. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
-              "title": "Performance tests finished",
-              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
-              "fields": [
-                  {
-                      "title": "Pipeline",
-                      "value": "$BUILD_PIPELINE_NAME",
-                      "short": true
-                  },
-                  {
-                      "title": "Project",
-                      "value": "((performance-gcp-project-name))",
-                      "short": true
-                  },
-                  {
-                      "title": "Build",
-                      "value": "#$BUILD_NAME",
-                      "short": true
-                  }
-              ],
-              "color": "#36a64f"
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Project",
+            "value": "((performance-gcp-project-name))",
+            "short": true
+          },
+          {
+              "title": "Build",
+              "value": "#$BUILD_NAME",
+              "short": true
           }
-      ]
+        ],
+        "color": "#36a64f"
+      }
+    ]
 
 slack_performance_tests_started: &slack_performance_tests_started
   put: slack-alert
@@ -223,61 +222,30 @@ slack_performance_tests_started: &slack_performance_tests_started
     icon_emoji: ":concourse:"
     username: Concourse
     attachments: [
+      {
+        "fallback": "Performance tests run started. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+        "title": "Performance Tests Started",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+        "fields": [
           {
-              "fallback": "Performance tests run started. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
-              "title": "Performance Tests Started",
-              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
-              "fields": [
-                  {
-                      "title": "Pipeline",
-                      "value": "$BUILD_PIPELINE_NAME",
-                      "short": true
-                  },
-                  {
-                      "title": "Project",
-                      "value": "((performance-gcp-project-name))",
-                      "short": true
-                  },
-                  {
-                      "title": "Build",
-                      "value": "#$BUILD_NAME",
-                      "short": true
-                  }
-              ],
-              "color": "#ffe100"
-          }
-      ]
-
-slack_terraform_success: &slack_terraform_success
-  put: slack-alert
-  params:
-    icon_emoji: ":concourse:"
-    username: Concourse
-    attachments: [
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
           {
-              "fallback": "((performance-gcp-project-name)) Terraform succeeded. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
-              "title": "((performance-gcp-project-name)) Terraform Succeeded",
-              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
-              "fields": [
-                  {
-                      "title": "Pipeline",
-                      "value": "$BUILD_PIPELINE_NAME",
-                      "short": true
-                  },
-                  {
-                      "title": "Project",
-                      "value": "((performance-gcp-project-name))",
-                      "short": true
-                  },
-                  {
-                      "title": "Build",
-                      "value": "#$BUILD_NAME",
-                      "short": true
-                  }
-              ],
-              "color": "#36a64f"
+            "title": "Project",
+            "value": "((performance-gcp-project-name))",
+            "short": true
+          },
+          {
+            "title": "Build",
+            "value": "#$BUILD_NAME",
+            "short": true
           }
-      ]
+        ],
+        "color": "#ffe100"
+      }
+    ]
 
 
 jobs:
@@ -311,6 +279,7 @@ jobs:
   disable_manual_trigger: true
   serial: true
   on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   serial_groups: [scale-down,
                   scale-apps,
                   performance-tests,
@@ -403,12 +372,14 @@ jobs:
             # Wipe and rebuild database
             kubectl exec $(kubectl get pods --selector=app=census-rm-toolbox -o jsonpath='{.items[*].metadata.name}') -- /bin/bash /app/groundzero/rebuild_from_ground_zero.sh
   on_failure: *slack_performance_setup_failure
+  on_error: *slack_error_alert
 
   # Run Rabbit Helm
 - name: "Run Rabbit Helm"
   disable_manual_trigger: true
   serial: true
   on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   serial_groups: [scale-down,
                   scale-apps,
                   performance-tests,
@@ -453,6 +424,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
+    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -477,6 +449,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
+    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -501,6 +474,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
+    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -525,6 +499,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
+    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -549,6 +524,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
+    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -573,6 +549,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
+    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -597,6 +574,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
     on_failure: *slack_failure_alert
+    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -621,6 +599,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
+    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -645,6 +624,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
+    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -669,6 +649,7 @@ jobs:
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
+    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -693,6 +674,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
+    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -717,6 +699,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
+    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -741,6 +724,7 @@ jobs:
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
+    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -834,6 +818,7 @@ jobs:
             kubectl rollout status deploy uacqidservice --watch=true --timeout=200s
 
   on_failure: *slack_performance_setup_failure
+  on_error: *slack_performance_setup_error
 
 - name: "Performance Tests"
   disable_manual_trigger: true
@@ -872,6 +857,7 @@ jobs:
       PERFORMANCE_TESTS_IMAGE: ((performance-tests-image))
     input_mapping: {performance-tests-repo: performance-tests-repo}
   on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
 
 - name: "Remove Cluster Nodes"
   disable_manual_trigger: true
@@ -932,4 +918,5 @@ jobs:
                 gcloud container node-pools delete $NODE_POOL --cluster=${KUBERNETES_CLUSTER} --region=europe-west2 --quiet --project ${GCP_PROJECT_NAME}
             done
     on_failure: *slack_failure_alert
+    on_error: *slack_error_alert
     on_success: *slack_performance_tests_finished


### PR DESCRIPTION
# Motivation and Context
Add on_error alerts to all jobs in the pipeline so that when a job errors (goes orange), a Slack alert is sent, as it already is with job failures

# What has changed
- Added `on_error` steps to every job that already has an `on_failure` step
- Changed the colours of the `on failure` alerts to #ff0000 (red).  `on_error` alerts will be #f58a3d (orange) - to match the pipeline colours.
- Reformatted the `on_failure` alerts in the pipelines to remove unnecessary whitespace and to keep it tidy.
- Removed unused alerts from the performance pipeline

# How to test?
- Run the fly pipeline command (BUT DON'T APPLY IT!!) to check that no config had inadvertently changed

# Links
- https://trello.com/c/rODkj5dy