### PR TITLE
fixed groundzero location

### DIFF
--- a/tasks/kubectl-run-groundzero-script.yml
+++ b/tasks/kubectl-run-groundzero-script.yml
@@ -31,7 +31,7 @@ run:
       kubectl apply -f ${KUBERNETES_FILE_PATH}/census-rm-ddl-pod.yml --record
       kubectl wait --for=condition=Ready pod/census-rm-ddl --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT}
 
-      kubectl exec $(kubectl get pods --selector=app=census-rm-ddl -o jsonpath='{.items[*].metadata.name}') -- /bin/bash /groundzero_ddl/rebuild_from_ground_zero.sh
+      kubectl exec $(kubectl get pods --selector=app=census-rm-ddl -o jsonpath='{.items[*].metadata.name}') -- /bin/bash groundzero_ddl/rebuild_from_ground_zero.sh
 
       # Tidy up pod
       kubectl delete pod census-rm-ddl || true


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There was a leading slash on the groundzero script that wasn't being to be executed correctly so I fixed it.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Removed leading slash from exec command

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Create a ddl pod with [this pr](https://github.com/ONSdigital/census-rm-ddl/pull/34) and run the command `kubectl exec $(kubectl get pods --selector=app=census-rm-ddl -o jsonpath='{.items[*].metadata.name}') -- /bin/bash groundzero_ddl/rebuild_from_ground_zero.sh`

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):