### PR TITLE
Removing printfiles from performance bucket

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -914,7 +914,7 @@ jobs:
               gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
               # Remove items from bucket
-              gsutil -m rm gs://census-rm-performance-sent-print-files/**
+              gsutil -m rm gs://census-rm-performance-sent-print-files/** || true
 
   - task: "Tear Down Rabbit"
     config:

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -889,6 +889,33 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Performance Tests"]
+  - task: "Remove Print Files"
+    config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: google/cloud-sdk
+        params:
+          SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+          KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+          GCP_PROJECT_NAME: ((performance-gcp-project-name))
+        run:
+          path: bash
+          args:
+            - -exc
+            - |
+              cat >~/gcloud-service-key.json <<EOL
+              $SERVICE_ACCOUNT_JSON
+              EOL
+
+              # Use gcloud service account to configure kubectl
+              gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+              gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
+
+              # Remove items from bucket
+              gsutil -m rm gs://census-rm-performance-sent-print-files/**
+
   - task: "Tear Down Rabbit"
     config:
       platform: linux


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When the new print file service changes get released, the `census-rm-performance-sent-print-files` bucket will be getting filled with print files after each performance test. To prevent unnecessary  storage build up, I've put in a command to remove the print files after the test has completed.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added task to the teardown job to remove the print files in the bucket.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/Sv8Nkwfm)
