### PR TITLE
Fix Action Worker scale-up timeout issue

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -820,7 +820,7 @@ jobs:
 
             # Wait for rollout to finish
             kubectl rollout status deploy action-scheduler --watch=true --timeout=200s
-            kubectl rollout status deploy action-worker --watch=true --timeout=200s
+            kubectl rollout status deploy action-worker --watch=true --timeout=400s
             kubectl rollout status deploy case-api --watch=true --timeout=200s
             kubectl rollout status deploy case-processor --watch=true --timeout=200s
             kubectl rollout status deploy uacqidservice --watch=true --timeout=200s


### PR DESCRIPTION
# Motivation and Context
Action worker has 10 instances and it can take quite a long time to start up (longer than 3 minutes and 20 seconds) causing intermittent failures of the poopline.

# What has changed
Increased the timeout.

# How to test?
Fly the pipeline.

# Links
Trello: https://trello.com/c/GfDN1o2F