### PR TITLE
Add multiple jobs to trigger different performance tests

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -23,6 +23,16 @@ resources:
   source:
     interval: 1m
 
+- name: select-test-scenario
+  type: time
+  source:
+    interval: 1m
+
+- name: trigger-the-tests
+  type: time
+  source:
+    interval: 1m
+
 - name: performance-tests-repo
   type: git
   source:
@@ -271,7 +281,7 @@ jobs:
   - get: performance-tests-docker-image
     params:
       skip_download: true
-  - get: every-minute
+  - get: select-test-scenario
   - *slack_performance_tests_started
   - task: "Select test scenario"
     config:
@@ -297,7 +307,7 @@ jobs:
               gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
               gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
-              echo three-and-a-half-million | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
+              echo "three-and-a-half-million or not local-docker" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
 
 - name: "Trigger Tests - 350k"
   serial: true
@@ -320,7 +330,7 @@ jobs:
   - get: performance-tests-docker-image
     params:
       skip_download: true
-  - get: every-minute
+  - get: select-test-scenario
   - *slack_performance_tests_started
   - task: "Select test scenario"
     config:
@@ -346,7 +356,7 @@ jobs:
               gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
               gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
-              echo three-hundred-and-fifty-thousand | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
+              echo "three-hundred-and-fifty-thousand or not local-docker" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
 
 - name: "Trigger Tests - PubSub"
   serial: true
@@ -369,7 +379,7 @@ jobs:
   - get: performance-tests-docker-image
     params:
       skip_download: true
-  - get: every-minute
+  - get: select-test-scenario
   - *slack_performance_tests_started
   - task: "Select test scenario"
     config:
@@ -395,7 +405,32 @@ jobs:
               gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
               gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
-              echo pubsub | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
+              echo "pubsub" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
+
+- name: "Trigger Requested Tests"
+  serial: true
+  serial_groups: [
+    action-scheduler,
+    action-worker,
+    case-api,
+    case-processor,
+    fieldwork-adapter,
+    notify-processor,
+    uac-qid-service,
+    pubsubsvc,
+    print-file-service,
+    exception-manager,
+    toolbox,
+    database-monitor,
+    rabbitmonitor]
+  plan:
+  - get: performance-tests-repo
+  - get: performance-tests-docker-image
+    params:
+      skip_download: true
+  - get: select-test-scenario
+    trigger: true
+  - *slack_performance_tests_started
 
 # Run Terraform
 - name: "Run Terraform"
@@ -422,13 +457,7 @@ jobs:
   plan:
     - get: every-minute
       trigger: true
-      passed: ["Trigger Tests - 3.5 million"]
-    - get: every-minute
-      trigger: true
-      passed: ["Trigger Tests - 350k"]
-    - get: every-minute
-      trigger: true
-      passed: ["Trigger Tests - PubSub"]
+      passed: ["Trigger Requested Tests"]
     - get: census-rm-terraform
     - get: census-rm-deploy
     - task: "Run Terraform"

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -338,7 +338,6 @@ jobs:
               echo "pubsub" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
 
 - name: "Trigger Requested Tests"
-  disable_manual_trigger: true
   serial: true
   serial_groups: [
     action-scheduler,

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -277,7 +277,7 @@ jobs:
               gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
               gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
-              echo "three-and-a-half-million or not local-docker" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
+              echo "\"three-and-a-half-million or not local-docker\""" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
 
 - name: "Select Test - 350k"
   plan:
@@ -306,7 +306,7 @@ jobs:
               gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
               gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
-              echo "three-hundred-and-fifty-thousand or not local-docker" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
+              echo "\"three-hundred-and-fifty-thousand or not local-docker\"" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
 
 - name: "Select Test - PubSub"
   plan:
@@ -335,7 +335,7 @@ jobs:
               gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
               gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
-              echo "pubsub" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
+              echo "\"pubsub\"" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
 
 - name: "Trigger Selected Test"
   serial: true

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -346,7 +346,7 @@ jobs:
               gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
               gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
-              echo three-hundred-and-fifty | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
+              echo three-hundred-and-fifty-thousand | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
 
 - name: "Trigger Tests - PubSub"
   serial: true

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -408,6 +408,7 @@ jobs:
               echo "pubsub" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
 
 - name: "Trigger Requested Tests"
+  disable_manual_trigger: true
   serial: true
   serial_groups: [
     action-scheduler,
@@ -429,6 +430,8 @@ jobs:
     params:
       skip_download: true
   - get: select-test-scenario
+    trigger: true
+  - get: trigger-the-tests
     trigger: true
   - *slack_performance_tests_started
 
@@ -455,7 +458,7 @@ jobs:
                   database-monitor,
                   rabbitmonitor]
   plan:
-    - get: every-minute
+    - get: trigger-the-tests
       trigger: true
       passed: ["Trigger Requested Tests"]
     - get: census-rm-terraform

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -250,7 +250,7 @@ slack_performance_tests_started: &slack_performance_tests_started
 
 jobs:
 
-- name: "Trigger Performance Tests"
+- name: "Trigger Tests - 3.5 million"
   serial: true
   serial_groups: [
     action-scheduler,
@@ -273,6 +273,129 @@ jobs:
       skip_download: true
   - get: every-minute
   - *slack_performance_tests_started
+  - task: "Select test scenario"
+    config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: google/cloud-sdk
+        params:
+          SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+          KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+          GCP_PROJECT_NAME: ((performance-gcp-project-name))
+        run:
+          path: bash
+          args:
+            - -exc
+            - |
+              cat >~/gcloud-service-key.json <<EOL
+              $SERVICE_ACCOUNT_JSON
+              EOL
+
+              # Use gcloud service account to configure kubectl
+              gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+              gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
+
+              echo three-and-a-half-million | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
+
+- name: "Trigger Tests - 350k"
+  serial: true
+  serial_groups: [
+    action-scheduler,
+    action-worker,
+    case-api,
+    case-processor,
+    fieldwork-adapter,
+    notify-processor,
+    uac-qid-service,
+    pubsubsvc,
+    print-file-service,
+    exception-manager,
+    toolbox,
+    database-monitor,
+    rabbitmonitor]
+  plan:
+  - get: performance-tests-repo
+  - get: performance-tests-docker-image
+    params:
+      skip_download: true
+  - get: every-minute
+  - *slack_performance_tests_started
+  - task: "Select test scenario"
+    config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: google/cloud-sdk
+        params:
+          SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+          KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+          GCP_PROJECT_NAME: ((performance-gcp-project-name))
+        run:
+          path: bash
+          args:
+            - -exc
+            - |
+              cat >~/gcloud-service-key.json <<EOL
+              $SERVICE_ACCOUNT_JSON
+              EOL
+
+              # Use gcloud service account to configure kubectl
+              gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+              gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
+
+              echo three-hundred-and-fifty | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
+
+- name: "Trigger Tests - PubSub"
+  serial: true
+  serial_groups: [
+    action-scheduler,
+    action-worker,
+    case-api,
+    case-processor,
+    fieldwork-adapter,
+    notify-processor,
+    uac-qid-service,
+    pubsubsvc,
+    print-file-service,
+    exception-manager,
+    toolbox,
+    database-monitor,
+    rabbitmonitor]
+  plan:
+  - get: performance-tests-repo
+  - get: performance-tests-docker-image
+    params:
+      skip_download: true
+  - get: every-minute
+  - *slack_performance_tests_started
+  - task: "Select test scenario"
+    config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: google/cloud-sdk
+        params:
+          SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+          KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+          GCP_PROJECT_NAME: ((performance-gcp-project-name))
+        run:
+          path: bash
+          args:
+            - -exc
+            - |
+              cat >~/gcloud-service-key.json <<EOL
+              $SERVICE_ACCOUNT_JSON
+              EOL
+
+              # Use gcloud service account to configure kubectl
+              gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+              gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
+
+              echo pubsub | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
 
 # Run Terraform
 - name: "Run Terraform"
@@ -299,7 +422,13 @@ jobs:
   plan:
     - get: every-minute
       trigger: true
-      passed: ["Trigger Performance Tests"]
+      passed: ["Trigger Tests - 3.5 million"]
+    - get: every-minute
+      trigger: true
+      passed: ["Trigger Tests - 350k"]
+    - get: every-minute
+      trigger: true
+      passed: ["Trigger Tests - PubSub"]
     - get: census-rm-terraform
     - get: census-rm-deploy
     - task: "Run Terraform"

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -431,6 +431,7 @@ jobs:
       skip_download: true
   - get: select-test-scenario
     trigger: true
+  - get: every-minute
   - get: trigger-the-tests
     trigger: true
   - *slack_performance_tests_started

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -462,6 +462,7 @@ jobs:
     - get: trigger-the-tests
       trigger: true
       passed: ["Trigger Requested Tests"]
+    - get: every-minute
     - get: census-rm-terraform
     - get: census-rm-deploy
     - task: "Run Terraform"

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -250,7 +250,7 @@ slack_performance_tests_started: &slack_performance_tests_started
 
 jobs:
 
-- name: "Trigger Tests - 3.5 million"
+- name: "Select Test - 3.5 million"
   plan:
   - *slack_performance_tests_started
   - task: "Select test scenario"
@@ -279,7 +279,7 @@ jobs:
 
               echo "three-and-a-half-million or not local-docker" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
 
-- name: "Trigger Tests - 350k"
+- name: "Select Test - 350k"
   plan:
   - *slack_performance_tests_started
   - task: "Select test scenario"
@@ -308,7 +308,7 @@ jobs:
 
               echo "three-hundred-and-fifty-thousand or not local-docker" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
 
-- name: "Trigger Tests - PubSub"
+- name: "Select Test - PubSub"
   plan:
   - *slack_performance_tests_started
   - task: "Select test scenario"
@@ -337,7 +337,7 @@ jobs:
 
               echo "pubsub" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
 
-- name: "Trigger Requested Tests"
+- name: "Trigger Selected Test"
   serial: true
   serial_groups: [
     action-scheduler,
@@ -386,8 +386,7 @@ jobs:
   plan:
     - get: every-minute
       trigger: true
-      passed: ["Trigger Requested Tests"]
-    - get: every-minute
+      passed: ["Trigger Selected Test"]
     - get: census-rm-terraform
     - get: census-rm-deploy
     - task: "Run Terraform"

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -23,16 +23,6 @@ resources:
   source:
     interval: 1m
 
-- name: select-test-scenario
-  type: time
-  source:
-    interval: 1m
-
-- name: trigger-the-tests
-  type: time
-  source:
-    interval: 1m
-
 - name: performance-tests-repo
   type: git
   source:
@@ -261,27 +251,7 @@ slack_performance_tests_started: &slack_performance_tests_started
 jobs:
 
 - name: "Trigger Tests - 3.5 million"
-  serial: true
-  serial_groups: [
-    action-scheduler,
-    action-worker,
-    case-api,
-    case-processor,
-    fieldwork-adapter,
-    notify-processor,
-    uac-qid-service,
-    pubsubsvc,
-    print-file-service,
-    exception-manager,
-    toolbox,
-    database-monitor,
-    rabbitmonitor]
   plan:
-  - get: performance-tests-repo
-  - get: performance-tests-docker-image
-    params:
-      skip_download: true
-  - get: select-test-scenario
   - *slack_performance_tests_started
   - task: "Select test scenario"
     config:
@@ -310,27 +280,7 @@ jobs:
               echo "three-and-a-half-million or not local-docker" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
 
 - name: "Trigger Tests - 350k"
-  serial: true
-  serial_groups: [
-    action-scheduler,
-    action-worker,
-    case-api,
-    case-processor,
-    fieldwork-adapter,
-    notify-processor,
-    uac-qid-service,
-    pubsubsvc,
-    print-file-service,
-    exception-manager,
-    toolbox,
-    database-monitor,
-    rabbitmonitor]
   plan:
-  - get: performance-tests-repo
-  - get: performance-tests-docker-image
-    params:
-      skip_download: true
-  - get: select-test-scenario
   - *slack_performance_tests_started
   - task: "Select test scenario"
     config:
@@ -359,27 +309,7 @@ jobs:
               echo "three-hundred-and-fifty-thousand or not local-docker" | gsutil cp -I gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
 
 - name: "Trigger Tests - PubSub"
-  serial: true
-  serial_groups: [
-    action-scheduler,
-    action-worker,
-    case-api,
-    case-processor,
-    fieldwork-adapter,
-    notify-processor,
-    uac-qid-service,
-    pubsubsvc,
-    print-file-service,
-    exception-manager,
-    toolbox,
-    database-monitor,
-    rabbitmonitor]
   plan:
-  - get: performance-tests-repo
-  - get: performance-tests-docker-image
-    params:
-      skip_download: true
-  - get: select-test-scenario
   - *slack_performance_tests_started
   - task: "Select test scenario"
     config:
@@ -429,11 +359,7 @@ jobs:
   - get: performance-tests-docker-image
     params:
       skip_download: true
-  - get: select-test-scenario
-    trigger: true
   - get: every-minute
-  - get: trigger-the-tests
-    trigger: true
   - *slack_performance_tests_started
 
 # Run Terraform
@@ -459,7 +385,7 @@ jobs:
                   database-monitor,
                   rabbitmonitor]
   plan:
-    - get: trigger-the-tests
+    - get: every-minute
       trigger: true
       passed: ["Trigger Requested Tests"]
     - get: every-minute


### PR DESCRIPTION
# Motivation and Context
30 million takes ages. 3.5 million takes 3 hours. 350k takes 40 minutes. PubSub takes a couple of minutes. We want a way to run the test we want, not have to run ALL of them.

# What has changed
Added multiple trigger jobs for different poipoises.

# How to test?
Fly. Fly. Fly.

# Links
Trello: https://trello.com/c/zWLwrX72