### PR TITLE
Removed any reference of unused event-latency-monitor pod

### DIFF
--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -721,7 +721,6 @@ jobs:
     print-file-service,
     exception-manager,
     toolbox,
-    event-latency-monitor,
     rabbitmonitor]
   on_error: *slack_error_alert
   on_failure: *slack_failure_alert
@@ -742,7 +741,6 @@ jobs:
                   print-file-service,
                   exception-manager,
                   toolbox,
-                  event-latency-monitor,
                   rabbitmonitor]
   on_error: *slack_error_alert
   on_failure: *slack_failure_alert
@@ -775,7 +773,6 @@ jobs:
                   print-file-service,
                   exception-manager,
                   toolbox,
-                  event-latency-monitor,
                   rabbitmonitor]
   on_error: *slack_error_alert
   on_failure: *slack_failure_alert


### PR DESCRIPTION
# Motivation and Context
Some of the metrics were using the event-latency-monitor to get figures in BL which is now redundant as it has been replaced with the database-monitor

# What has changed
Removed reference to event-latency-monitor
Changed metrics in BL pointing at event-latency-monitor to database-monitor
Deleted pod in BL

# Links
https://trello.com/c/rX6v51tQ
https://trello.com/c/sO0yoQsB