### PR TITLE
Set prometheus config file in each pipeline

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -21,7 +21,7 @@ groups:
   - "Build Toolbox Latest"
   - "Build UAC QID Service Latest"
   - "CI Terraform"
-  - "CI Rabbit Helm"
+  - "CI Helm"
   - "CI Deploy Action-Scheduler"
   - "CI Deploy Action-Worker"
   - "CI Deploy Case-API"
@@ -40,7 +40,7 @@ groups:
   - "CI Deploy Regional Counts"
   - "CI Acceptance Tests"
   - "WL Terraform"
-  - "WL Rabbit Helm"
+  - "WL Helm"
   - "WL Deploy Action-Scheduler"
   - "WL Deploy Action-Worker"
   - "WL Deploy Case-API"
@@ -81,7 +81,7 @@ groups:
 - name: "CI"
   jobs:
   - "CI Terraform"
-  - "CI Rabbit Helm"
+  - "CI Helm"
   - "CI Deploy Action-Scheduler"
   - "CI Deploy Action-Worker"
   - "CI Deploy Case-API"
@@ -103,7 +103,7 @@ groups:
 - name: "Whitelodge"
   jobs:
   - "WL Terraform"
-  - "WL Rabbit Helm"
+  - "WL Helm"
   - "WL Deploy Action-Scheduler"
   - "WL Deploy Action-Worker"
   - "WL Deploy Case-API"
@@ -1683,7 +1683,7 @@ jobs:
       KUBERNETES_CLUSTER: rm-k8s-cluster
     input_mapping: {census-rm-terraform: census-rm-terraform}
 
-- name: "CI Rabbit Helm"
+- name: "CI Helm"
   serial: true
   serial_groups: [ci-terraform,
                   ci-acceptance-tests,
@@ -1712,13 +1712,14 @@ jobs:
     - get: census-rm-terraform
       passed: ["CI Terraform"]
     - *slack_started_alert_ci
-    - task: "CI Rabbit Helm"
-      file: census-rm-deploy/tasks/helm-rabbit.yml
+    - task: "CI Helm"
+      file: census-rm-deploy/tasks/helm.yml
       params:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: ci
         KUBERNETES_CLUSTER: rm-k8s-cluster
         RABBITMQ_CONFIG_VALUES_FILE: rabbitmq/values.yml
+        PROMETHEUS_CONFIG_VALUES_FILE: prometheus/values.yml
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-dependencies-repo}
 
 # CI Deployments
@@ -1732,7 +1733,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: action-scheduler-master
@@ -1769,7 +1770,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: action-worker-master
@@ -1806,7 +1807,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: case-api-master
@@ -1843,7 +1844,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: case-processor-master
@@ -1880,7 +1881,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: uac-qid-service-master
@@ -1917,7 +1918,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: pubsub-master
@@ -1954,7 +1955,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-ops-repo
     trigger: true
   - get: ops-master
@@ -1991,7 +1992,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: print-file-service-master
@@ -2028,7 +2029,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: fieldwork-adapter-master
@@ -2065,7 +2066,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: notify-processor-master
@@ -2102,7 +2103,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: notify-stub-master
@@ -2139,7 +2140,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: exception-manager-master
@@ -2176,7 +2177,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
@@ -2213,7 +2214,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
@@ -2250,7 +2251,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
@@ -2287,7 +2288,7 @@ jobs:
     passed: ["CI Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Rabbit Helm"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
@@ -2483,8 +2484,8 @@ jobs:
         KUBERNETES_CLUSTER: rm-k8s-cluster
       input_mapping: {census-rm-terraform: census-rm-terraform}
 
-# WL Rabbit Helm
-- name: "WL Rabbit Helm"
+# WL Helm
+- name: "WL Helm"
   serial: true
   serial_groups: [wl-terraform,
                   wl-action-scheduler,
@@ -2510,13 +2511,14 @@ jobs:
       passed: ["CI Acceptance Tests"]
     - get: census-rm-deploy
     - *slack_started_alert_wl
-    - task: "WL Rabbit Helm"
-      file: census-rm-deploy/tasks/helm-rabbit.yml
+    - task: "WL Helm"
+      file: census-rm-deploy/tasks/helm.yml
       params:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: whitelodge
         KUBERNETES_CLUSTER: rm-k8s-cluster
         RABBITMQ_CONFIG_VALUES_FILE: rabbitmq/values.yml
+        PROMETHEUS_CONFIG_VALUES_FILE: prometheus/values.yml
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-dependencies-repo}
 
 # WL Deployments
@@ -2529,7 +2531,7 @@ jobs:
     passed: ["WL Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["WL Rabbit Helm"]
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2566,7 +2568,7 @@ jobs:
     passed: ["WL Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["WL Rabbit Helm"]
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2603,7 +2605,7 @@ jobs:
     passed: ["WL Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["WL Rabbit Helm"]
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2640,7 +2642,7 @@ jobs:
     passed: ["WL Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["WL Rabbit Helm"]
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2677,7 +2679,7 @@ jobs:
     passed: ["WL Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["WL Rabbit Helm"]
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2714,7 +2716,7 @@ jobs:
     passed: ["WL Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["WL Rabbit Helm"]
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2751,7 +2753,7 @@ jobs:
     passed: ["WL Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["WL Rabbit Helm"]
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2788,7 +2790,7 @@ jobs:
     passed: ["WL Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["WL Rabbit Helm"]
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-ops-repo
     trigger: true
   - get: ops-master
@@ -2823,7 +2825,7 @@ jobs:
     passed: ["WL Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["WL Rabbit Helm"]
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2860,7 +2862,7 @@ jobs:
     passed: ["WL Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["WL Rabbit Helm"]
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2897,7 +2899,7 @@ jobs:
     passed: ["WL Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["WL Rabbit Helm"]
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2934,7 +2936,7 @@ jobs:
     passed: ["WL Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["WL Rabbit Helm"]
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2971,7 +2973,7 @@ jobs:
     passed: ["WL Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["WL Rabbit Helm"]
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -3008,7 +3010,7 @@ jobs:
     passed: ["WL Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["WL Rabbit Helm"]
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -3045,7 +3047,7 @@ jobs:
     passed: ["WL Terraform"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["WL Rabbit Helm"]
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
     passed: ["CI Acceptance Tests"]

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -126,6 +126,7 @@ jobs:
             gcp-project-name: census-rm-blacklodge
             kubernetes-cluster-name: rm-k8s-cluster
             rabbit-config: release/rabbitmq/values.yml
+            prometheus-config: release/prometheus/values.yml
 
         - name: release-images
           team: rm
@@ -156,3 +157,4 @@ jobs:
             gcp-project-name: census-rm-preprod
             kubernetes-cluster-name: rm-k8s-cluster
             rabbit-config: release/rabbitmq/values_prod.yml
+            prometheus-config: release/prometheus/values.yml

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -800,5 +800,5 @@ jobs:
     trigger: true
     passed: [
       "Run Terraform",
-      "Run Rabbit Helm"]
+      "Run Helm"]
   - *slack_success_alert

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -22,14 +22,14 @@ groups:
   - "Report Deployment Success"
   - "Trigger Terraform"
   - "Run Terraform"
-  - "Run Rabbit Helm"
+  - "Run Helm"
   - "Report Terraform Success"
 
 - name: "Infrastructure"
   jobs:
   - "Trigger Terraform"
   - "Run Terraform"
-  - "Run Rabbit Helm"
+  - "Run Helm"
   - "Report Terraform Success"
 
 - name: "App Deployment"

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -759,7 +759,7 @@ jobs:
         KUBERNETES_CLUSTER: rm-k8s-cluster
       input_mapping: {census-rm-terraform: census-rm-terraform-release}
 
-- name: "Run Rabbit Helm"
+- name: "Run Helm"
   disable_manual_trigger: true
   serial: true
   serial_groups: [action-scheduler,
@@ -782,13 +782,14 @@ jobs:
       passed: ["Run Terraform"]
     - get: census-rm-kubernetes-release
     - get: census-rm-deploy
-    - task: "Run Rabbit Helm"
-      file: census-rm-deploy/tasks/helm-rabbit.yml
+    - task: "Run Helm"
+      file: census-rm-deploy/tasks/helm.yml
       params:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: ((gcp-environment-name))
         KUBERNETES_CLUSTER: rm-k8s-cluster
         RABBITMQ_CONFIG_VALUES_FILE: ((rabbit-config))
+        PROMETHEUS_CONFIG_VALUES_FILE: ((prometheus-config))
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release}
 
 - name: "Report Terraform Success"

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -494,8 +494,8 @@ jobs:
   on_failure: *slack_performance_setup_failure
   on_error: *slack_error_alert
 
-  # Run Rabbit Helm
-- name: "Run Rabbit Helm"
+  # Run Helm
+- name: "Run Helm"
   disable_manual_trigger: true
   serial: true
   on_failure: *slack_failure_alert
@@ -522,13 +522,14 @@ jobs:
       passed: ["Scale Down Apps and Reset DB"]
     - get: census-rm-kubernetes-dependencies-repo
     - get: census-rm-deploy
-    - task: "Run Rabbit Helm"
+    - task: "Run Helm"
       file: census-rm-deploy/tasks/helm.yml
       params:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: performance
         KUBERNETES_CLUSTER: rm-k8s-cluster
         RABBITMQ_CONFIG_VALUES_FILE: release/rabbitmq/values_prod.yml
+        PROMETHEUS_CONFIG_VALUES_FILE: release/prometheus/values.yml
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-dependencies-repo}
 
 - name: "Action Scheduler"
@@ -540,7 +541,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Rabbit Helm"]
+    passed: ["Run Helm"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -565,7 +566,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Rabbit Helm"]
+    passed: ["Run Helm"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -590,7 +591,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Rabbit Helm"]
+    passed: ["Run Helm"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -615,7 +616,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Rabbit Helm"]
+    passed: ["Run Helm"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -640,7 +641,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Rabbit Helm"]
+    passed: ["Run Helm"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -665,7 +666,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Rabbit Helm"]
+    passed: ["Run Helm"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -690,7 +691,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Rabbit Helm"]
+    passed: ["Run Helm"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
     on_failure: *slack_failure_alert
@@ -715,7 +716,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Rabbit Helm"]
+    passed: ["Run Helm"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -740,7 +741,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Rabbit Helm"]
+    passed: ["Run Helm"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -765,7 +766,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Rabbit Helm"]
+    passed: ["Run Helm"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     on_failure: *slack_failure_alert
@@ -790,7 +791,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Rabbit Helm"]
+    passed: ["Run Helm"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -815,7 +816,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Rabbit Helm"]
+    passed: ["Run Helm"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert
@@ -840,7 +841,7 @@ jobs:
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
-    passed: ["Run Rabbit Helm"]
+    passed: ["Run Helm"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     on_failure: *slack_failure_alert

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -523,7 +523,7 @@ jobs:
     - get: census-rm-kubernetes-dependencies-repo
     - get: census-rm-deploy
     - task: "Run Rabbit Helm"
-      file: census-rm-deploy/tasks/helm-rabbit.yml
+      file: census-rm-deploy/tasks/helm.yml
       params:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: performance

--- a/tasks/helm.yml
+++ b/tasks/helm.yml
@@ -30,4 +30,4 @@ run:
 
       cd census-rm-kubernetes-dependencies-repo
       GCP_RABBIT_IP=`gcloud compute addresses describe rm-rabbitmq-$ENV-lb --project=$GCP_PROJECT --region=europe-west2 --format='value(address)'`
-      GCP_RABBIT_IP=${GCP_RABBIT_IP} RABBITMQ_CONFIG_VALUES_FILE=${RABBITMQ_CONFIG_VALUES_FILE} ./setup-dependencies.sh
+      GCP_RABBIT_IP=${GCP_RABBIT_IP} RABBITMQ_CONFIG_VALUES_FILE=${RABBITMQ_CONFIG_VALUES_FILE} PROMETHEUS_CONFIG_VALUES_FILE=${PROMETHEUS_CONFIG_VALUES_FILE} ./setup-dependencies.sh

--- a/tasks/helm.yml
+++ b/tasks/helm.yml
@@ -29,5 +29,4 @@ run:
       helm plugin install https://github.com/rimusz/helm-tiller
 
       cd census-rm-kubernetes-dependencies-repo
-      GCP_RABBIT_IP=`gcloud compute addresses describe rm-rabbitmq-$ENV-lb --project=$GCP_PROJECT --region=europe-west2 --format='value(address)'`
-      GCP_RABBIT_IP=${GCP_RABBIT_IP} RABBITMQ_CONFIG_VALUES_FILE=${RABBITMQ_CONFIG_VALUES_FILE} PROMETHEUS_CONFIG_VALUES_FILE=${PROMETHEUS_CONFIG_VALUES_FILE} ./setup-dependencies.sh
+      ENV=${ENV} RABBITMQ_CONFIG_VALUES_FILE=${RABBITMQ_CONFIG_VALUES_FILE} PROMETHEUS_CONFIG_VALUES_FILE=${PROMETHEUS_CONFIG_VALUES_FILE} ./setup-dependencies.sh


### PR DESCRIPTION
# Motivation and Context
Set which Prometheus value file should be used, depending on environment.

# What has changed
- Parameterised the Prometheus values file, which is used by the helm job
- Renamed the helm jobs as these now do more than just Rabbit

# How to test?
- Run the pipeline, pointing to the branches of Terraform and Kubernetes (linked below)
- Everything should run as normal

# Links
- https://trello.com/c/kMdSe1x8
- https://github.com/ONSdigital/census-rm-kubernetes/pull/209
- https://github.com/ONSdigital/census-rm-terraform/pull/150

