### PR TITLE
Removal of sftp_user_name variable

### DIFF
--- a/tasks/terraform-env.yml
+++ b/tasks/terraform-env.yml
@@ -30,7 +30,6 @@ run:
 
       set +x
       echo "db_user_password = \"$(kubectl get secret db-credentials -o=jsonpath='{.data.password}' | base64 --decode)\"" >> secret.tfvars
-      echo "sftp_user_password = \"$(kubectl get secret sftp-ssh-credentials -o=jsonpath='{.data.passphrase}' | base64 --decode)\"" >> secret.tfvars
       set -x
       
       SKIP_REPLICA_DB_SSL_RESET=true SKIP_DB_SSL_RESET=true SECRETS_VAR_FILE=./secret.tfvars AUTO_APPLY=true ./apply-prod.sh

--- a/tasks/terraform-env.yml
+++ b/tasks/terraform-env.yml
@@ -30,7 +30,6 @@ run:
 
       set +x
       echo "db_user_password = \"$(kubectl get secret db-credentials -o=jsonpath='{.data.password}' | base64 --decode)\"" >> secret.tfvars
-      echo "sftp_user_name = \"$(kubectl get secret sftp-ssh-credentials -o=jsonpath='{.data.username}' | base64 --decode)\"" >>  secret.tfvars
       echo "sftp_user_password = \"$(kubectl get secret sftp-ssh-credentials -o=jsonpath='{.data.passphrase}' | base64 --decode)\"" >> secret.tfvars
       set -x
       


### PR DESCRIPTION
# Motivation and Context
Since upgrading terraform from 0.11 to 0.12, there are env vars in the terraform pipeline jobs that appear to be unused in the terraform scripts and are giving warnings that could turn into errors in future terraform versions

# What has changed
Removed sftp_user_name variable in secret.tfvars file

# How to test?
Run the pipelines and see if the warning occurs still

# Links
https://trello.com/c/p7oO8NH5