### PR TITLE
Add selection job for 30 million performance test

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -250,6 +250,34 @@ slack_performance_tests_started: &slack_performance_tests_started
 
 jobs:
 
+- name: "Select Test - 30 million"
+  plan:
+  - task: "Select test scenario"
+    config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: google/cloud-sdk
+        params:
+          SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+          KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
+          GCP_PROJECT_NAME: ((performance-gcp-project-name))
+        run:
+          path: bash
+          args:
+            - -exc
+            - |
+              cat >~/gcloud-service-key.json <<EOL
+              $SERVICE_ACCOUNT_JSON
+              EOL
+
+              # Use gcloud service account to configure kubectl
+              gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+              gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
+
+              echo "\"@thirty-million\"" | gsutil cp - gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
+
 - name: "Select Test - 3.5 million"
   plan:
   - task: "Select test scenario"


### PR DESCRIPTION
# Motivation and Context
We're adding a 30 million unit performance test and need a job to select it in the performance pipeline

# What has changed
* Add selection job for 30 million performance test to performance pipeline

# How to test?
Check over the pipeline changes, 🙏 

# Links
https://trello.com/c/U9tox7yV/672-automate-30-million-sample-load-test-8