### PR TITLE
Reduce Slack noise

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -1666,14 +1666,12 @@ jobs:
                   rabbitmonitor-deploy,
                   regional-counts-deploy,
                   ops-deploy]
-  on_success: *slack_success_alert_ci
   on_failure: *slack_failure_alert_ci
   on_error: *slack_error_alert_ci
   plan:
   - get: census-rm-terraform
     trigger: true
   - get: census-rm-deploy
-  - *slack_started_alert_ci
   - task: "CI Terraform"
     file: census-rm-deploy/tasks/terraform-env.yml
     params:
@@ -1702,7 +1700,6 @@ jobs:
                   database-monitor-deploy,
                   rabbitmonitor-deploy,
                   regional-counts-deploy]
-  on_success: *slack_success_alert_ci
   on_failure: *slack_failure_alert_ci
   on_error: *slack_error_alert_ci
   plan:
@@ -1711,7 +1708,6 @@ jobs:
     - get: census-rm-deploy
     - get: census-rm-terraform
       passed: ["CI Terraform"]
-    - *slack_started_alert_ci
     - task: "CI Helm"
       file: census-rm-deploy/tasks/helm.yml
       params:

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2462,7 +2462,6 @@ jobs:
                   wl-database-monitor,
                   wl-rabbitmonitor,
                   wl-regional-counts]
-  on_success: *slack_success_alert_wl
   on_failure: *slack_failure_alert_wl
   on_error: *slack_error_alert_wl
   plan:
@@ -2498,7 +2497,6 @@ jobs:
                   wl-database-monitor,
                   wl-rabbitmonitor,
                   wl-regional-counts]
-  on_success: *slack_success_alert_wl
   on_failure: *slack_failure_alert_wl
   on_error: *slack_error_alert_wl
   plan:

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -238,7 +238,6 @@ jobs:
   plan:
     - get: every-minute
     - get: census-rm-kubernetes-release
-  on_success: *slack_in_progress_alert
 
 - name: "Apply Database Patches"
   disable_manual_trigger: true

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -704,7 +704,6 @@ jobs:
             "Database Monitor",
             "Rabbit Monitor",
             "Regional Counts"]
-  - *slack_success_alert
 
 # Infrastructure
 - name: "Trigger Terraform"
@@ -801,4 +800,3 @@ jobs:
     passed: [
       "Run Terraform",
       "Run Helm"]
-  - *slack_success_alert

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -412,7 +412,6 @@ jobs:
     params:
       skip_download: true
   - get: every-minute
-  - *slack_performance_tests_started
 
 # Run Terraform
 - name: "Run Terraform"


### PR DESCRIPTION
# Motivation and Context
The Slack channel `census-rm-alerts` had become quite noisy, so it was sometimes hard to keep track of who was investigating an issue. By removing success/starting slack messages, we are only left with the errors/failures, which means we can work better as a team to make sure everything stays green while working from home.

# What has changed
Removed success/starting slack messages from jobs.

# How to test?
Fly the pipeline.

# Links
Trello: https://trello.com/c/R49DYilk