### PR TITLE
Pin helm to 2.16.3

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -1083,7 +1083,7 @@ jobs:
 
             # Install helm and helm-tiller
             apt-get install -y procps  # NB: procps is used by Helm
-            curl -L https://git.io/get_helm.sh | bash
+            curl -L https://git.io/get_helm.sh | bash -s -- --version v2.16.3
             helm init --client-only
             helm plugin install https://github.com/rimusz/helm-tiller
 

--- a/tasks/helm.yml
+++ b/tasks/helm.yml
@@ -25,7 +25,7 @@ run:
       gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT}
 
       apt-get install -y procps  # NB: procps is used by Helm
-      curl -L https://git.io/get_helm.sh | bash
+      curl -L https://git.io/get_helm.sh | bash -s -- --version v2.16.3
       helm init --client-only
       helm plugin install https://github.com/rimusz/helm-tiller
 


### PR DESCRIPTION
# Motivation and Context
There seems to be a problem deploying the rabbit helm charts with helm 2.16.4, so im pinning helm to 2.16.3 while we figure out what the problem is

# What has changed
updated bash command in the helm concourse task and the performance pipeline to pass in aspecific version of helm to be installed
