### PR TITLE
Add grafana-dashboards directory to census-rm-kubernetes-dependencies…

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -166,7 +166,7 @@ resources:
   source:
     uri: git@github.com:ONSdigital/census-rm-kubernetes.git
     private_key: ((github.service_account_private_key))
-    paths: [dependencies/*, rabbitmq/*, setup-dependencies.sh]
+    paths: [dependencies/*, grafana-dashboards/*, rabbitmq/*, setup-dependencies.sh]
 
 - name: census-rm-terraform
   type: git


### PR DESCRIPTION
The Helm job in the pipeline couldn't see the grafana-dashboards directory.  Hopefully this should fix it.

# How to test?
Run the Helm in in the ci pipeline.