### PR TITLE
Limit perf env to only release versions

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -1,4 +1,3 @@
-
 resource_types:
 - name: slack-notification
   type: docker-image
@@ -43,14 +42,16 @@ resources:
     branch: ((terraform-branch))
     uri: git@github.com:ONSdigital/census-rm-terraform.git
     private_key: ((github.service_account_private_key))
-
+    tag_filter: v*.*.*
+    
 - name: census-rm-kubernetes-dependencies-repo
   type: git
   source:
     uri: git@github.com:ONSdigital/census-rm-kubernetes.git
     private_key: ((github.service_account_private_key))
     paths: [dependencies/*, rabbitmq/*, setup-dependencies.sh]
-
+    tag_filter: v*.*.*
+    
 - name: census-rm-kubernetes-release	
   type: git	
   source:
@@ -58,6 +59,7 @@ resources:
     private_key: ((github.service_account_private_key))	
     paths: [release/*]
     branch: master
+    tag_filter: v*.*.*
 
 templating:
 


### PR DESCRIPTION
# Motivation and Context
Our performance environment keeps breaking because terraform, rabbit, DB etc. keep getting out of sync with the services.

# What has changed
Limited the git repo sources to only release tagged commits.

# How to test?
Fly. Run.

# Links
Trello: https://trello.com/c/22YJRUdx