### PR TITLE
Avoid deleting monitoring node pool in the perf pipeline teardown

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -1126,11 +1126,14 @@ jobs:
             gcloud config set container/use_client_certificate True --project ${GCP_PROJECT_NAME}
 
 
-            # Delete cluster node pools
+            # Delete cluster node pools except for the monitoring one -
+            # We still need access to graphs and stats after the tests have finished running
             NODE_POOL_LIST=`gcloud container node-pools list --cluster=${KUBERNETES_CLUSTER} --region=europe-west2 --format="value(name)" --project ${GCP_PROJECT_NAME}`
             for NODE_POOL in $NODE_POOL_LIST ; do
+              if [ "$NODE_POOL" != "monitoring-node-pool" ]; then
                 echo deleting $NODE_POOL
                 gcloud container node-pools delete $NODE_POOL --cluster=${KUBERNETES_CLUSTER} --region=europe-west2 --quiet --project ${GCP_PROJECT_NAME}
+              fi
             done
   on_failure: *slack_failure_alert
   on_error: *slack_error_alert


### PR DESCRIPTION
# Motivation and Context
The performance pipeline teardown job was deleting the node pool after the tests had finished.  This meant that the monitoring apps couldn't run outside of the test runs.  The solution was to create a separate node pool and deploy the monitoring apps to the new pool.  This PR is to ensure that the new node pool doesn't get deleted with the others after the tests have finished running.

# What has changed
- Added a check to ensure that the monitoring node pool doesn't get deleted

# How to test?
- The pipeline will need to point to the correct branches of the kubernetes and terraform repos so that the node pool is created to begin with and the monitoring apps are deployed to it (see links below).
- Run the pipeline - the monitoring apps should stay alive and be accessible after the tests have finished running.

# Links
- https://trello.com/c/vjBvRS1E
- https://github.com/ONSdigital/census-rm-kubernetes/pull/232
- https://github.com/ONSdigital/census-rm-terraform/pull/164