### PR TITLE
Separate out deployment of the monitoring apps from the Rabbit Helm job

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2551,8 +2551,9 @@ jobs:
   plan:
     - get: census-rm-kubernetes-monitoring-repo
       trigger: true
-      passed: ["WL Terraform"]
     - get: census-rm-deploy
+    - get: census-rm-terraform
+      passed: ["WL Terraform"]
     - task: "WL Monitoring"
       file: census-rm-deploy/tasks/monitoring.yml
       params:

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -21,6 +21,7 @@ groups:
   - "Build Toolbox Latest"
   - "Build UAC QID Service Latest"
   - "CI Terraform"
+  - "CI Monitoring"
   - "CI Helm"
   - "CI Deploy Action-Scheduler"
   - "CI Deploy Action-Worker"
@@ -40,6 +41,7 @@ groups:
   - "CI Deploy Regional Counts"
   - "CI Acceptance Tests"
   - "WL Terraform"
+  - "WL Monitoring"
   - "WL Helm"
   - "WL Deploy Action-Scheduler"
   - "WL Deploy Action-Worker"
@@ -81,6 +83,7 @@ groups:
 - name: "CI"
   jobs:
   - "CI Terraform"
+  - "CI Monitoring"
   - "CI Helm"
   - "CI Deploy Action-Scheduler"
   - "CI Deploy Action-Worker"
@@ -103,6 +106,7 @@ groups:
 - name: "Whitelodge"
   jobs:
   - "WL Terraform"
+  - "WL Monitoring"
   - "WL Helm"
   - "WL Deploy Action-Scheduler"
   - "WL Deploy Action-Worker"
@@ -166,7 +170,14 @@ resources:
   source:
     uri: git@github.com:ONSdigital/census-rm-kubernetes.git
     private_key: ((github.service_account_private_key))
-    paths: [dependencies/*, grafana-dashboards/*, rabbitmq/*, setup-dependencies.sh]
+    paths: [rabbitmq/*, setup-dependencies.sh]
+
+- name: census-rm-kubernetes-monitoring-repo
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-kubernetes.git
+    private_key: ((github.service_account_private_key))
+    paths: [monitoring/*, grafana-dashboards/*, setup-monitoring.sh]
 
 - name: census-rm-terraform
   type: git
@@ -1681,6 +1692,45 @@ jobs:
       KUBERNETES_CLUSTER: rm-k8s-cluster
     input_mapping: {census-rm-terraform: census-rm-terraform}
 
+# Deploy monitoring apps
+- name: "CI Monitoring"
+  serial: true
+  serial_groups: [ci-terraform,
+                  ci-acceptance-tests,
+                  action-scheduler-deploy,
+                  action-worker-deploy,
+                  case-api-deploy,
+                  case-processor-deploy,
+                  uac-qid-service-deploy,
+                  pubsub-deploy,
+                  print-file-service-deploy,
+                  fieldwork-adapter-deploy,
+                  notify-processor-deploy,
+                  notify-stub-deploy,
+                  exception-manager-deploy,
+                  toolbox-deploy,
+                  database-monitor-deploy,
+                  rabbitmonitor-deploy,
+                  regional-counts-deploy]
+  on_failure: *slack_failure_alert_ci
+  on_error: *slack_error_alert_ci
+  plan:
+    - get: every-minute
+      trigger: true
+      passed: ["CI Terraform"]
+    - get: census-rm-kubernetes-monitoring-repo
+    - get: census-rm-deploy
+    - task: "CI Monitoring"
+      file: census-rm-deploy/tasks/monitoring.yml
+      params:
+        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+        ENV: ci
+        KUBERNETES_CLUSTER: rm-k8s-cluster
+        PROMETHEUS_CONFIG_VALUES_FILE: monitoring/prometheus-values.yml
+        GRAFANA_CONFIG_VALUES_FILE: monitoring/grafana-deployment.yml
+      input_mapping: {census-rm-kubernetes-monitoring-repo: census-rm-kubernetes-monitoring-repo}
+
+
 - name: "CI Helm"
   serial: true
   serial_groups: [ci-terraform,
@@ -1715,7 +1765,6 @@ jobs:
         ENV: ci
         KUBERNETES_CLUSTER: rm-k8s-cluster
         RABBITMQ_CONFIG_VALUES_FILE: rabbitmq/values.yml
-        PROMETHEUS_CONFIG_VALUES_FILE: prometheus/values.yml
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-dependencies-repo}
 
 # CI Deployments
@@ -2479,6 +2528,42 @@ jobs:
         KUBERNETES_CLUSTER: rm-k8s-cluster
       input_mapping: {census-rm-terraform: census-rm-terraform}
 
+# Deploy monitoring apps
+- name: "WL Monitoring"
+  serial: true
+  serial_groups: [wl-terraform,
+                  wl-action-scheduler,
+                  wl-action-worker,
+                  wl-case-api,
+                  wl-case-processor,
+                  wl-uac-qid-service,
+                  wl-pubsub,
+                  wl-print-file-service,
+                  wl-fieldwork-adapter,
+                  wl-notify-processor,
+                  wl-exception-manager,
+                  wl-toolbox,
+                  wl-database-monitor,
+                  wl-rabbitmonitor,
+                  wl-regional-counts]
+  on_failure: *slack_failure_alert_wl
+  on_error: *slack_error_alert_wl
+  plan:
+    - get: every-minute
+      trigger: true
+      passed: ["WL Terraform"]
+    - get: census-rm-kubernetes-monitoring-repo
+    - get: census-rm-deploy
+    - task: "WL Monitoring"
+      file: census-rm-deploy/tasks/monitoring.yml
+      params:
+        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+        ENV: whitelodge
+        KUBERNETES_CLUSTER: rm-k8s-cluster
+        PROMETHEUS_CONFIG_VALUES_FILE: monitoring/prometheus-values.yml
+        GRAFANA_CONFIG_VALUES_FILE: monitoring/grafana-deployment.yml
+      input_mapping: {census-rm-kubernetes-monitoring-repo: census-rm-kubernetes-monitoring-repo}
+
 # WL Helm
 - name: "WL Helm"
   serial: true
@@ -2512,7 +2597,6 @@ jobs:
         ENV: whitelodge
         KUBERNETES_CLUSTER: rm-k8s-cluster
         RABBITMQ_CONFIG_VALUES_FILE: rabbitmq/values.yml
-        PROMETHEUS_CONFIG_VALUES_FILE: prometheus/values.yml
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-dependencies-repo}
 
 # WL Deployments

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -172,7 +172,7 @@ resources:
   source:
     uri: git@github.com:ONSdigital/census-rm-kubernetes.git
     private_key: ((github.service_account_private_key))
-    paths: [rabbitmq/*, setup-dependencies.sh]
+    paths: [dependencies/*, rabbitmq/*, setup-dependencies.sh]
 
 - name: census-rm-kubernetes-monitoring-repo
   type: git

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2549,7 +2549,7 @@ jobs:
   on_failure: *slack_failure_alert_wl
   on_error: *slack_error_alert_wl
   plan:
-    - get: census-rm-kubernetes-dependencies-repo
+    - get: census-rm-kubernetes-monitoring-repo
       trigger: true
       passed: ["WL Terraform"]
     - get: census-rm-deploy

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -1715,11 +1715,11 @@ jobs:
   on_failure: *slack_failure_alert_ci
   on_error: *slack_error_alert_ci
   plan:
-    - get: every-minute
-      trigger: true
-      passed: ["CI Terraform"]
     - get: census-rm-kubernetes-monitoring-repo
+      trigger: true
     - get: census-rm-deploy
+    - get: census-rm-terraform
+      passed: ["CI Terraform"]
     - task: "CI Monitoring"
       file: census-rm-deploy/tasks/monitoring.yml
       params:
@@ -2549,10 +2549,9 @@ jobs:
   on_failure: *slack_failure_alert_wl
   on_error: *slack_error_alert_wl
   plan:
-    - get: every-minute
+    - get: census-rm-kubernetes-dependencies-repo
       trigger: true
       passed: ["WL Terraform"]
-    - get: census-rm-kubernetes-monitoring-repo
     - get: census-rm-deploy
     - task: "WL Monitoring"
       file: census-rm-deploy/tasks/monitoring.yml

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -126,7 +126,8 @@ jobs:
             gcp-project-name: census-rm-blacklodge
             kubernetes-cluster-name: rm-k8s-cluster
             rabbit-config: release/rabbitmq/values.yml
-            prometheus-config: release/prometheus/values.yml
+            prometheus-config: release/monitoring/prometheus-values.yml
+            grafana-config: release/monitoring/grafana-deployment.yml
 
         - name: release-images
           team: rm
@@ -157,4 +158,5 @@ jobs:
             gcp-project-name: census-rm-preprod
             kubernetes-cluster-name: rm-k8s-cluster
             rabbit-config: release/rabbitmq/values_prod.yml
-            prometheus-config: release/prometheus/values.yml
+            prometheus-config: release/monitoring/prometheus-values.yml
+            grafana-config: release/monitoring/grafana-deployment.yml

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -787,7 +787,40 @@ jobs:
         ENV: ((gcp-environment-name))
         KUBERNETES_CLUSTER: rm-k8s-cluster
         RABBITMQ_CONFIG_VALUES_FILE: ((rabbit-config))
+      input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release}
+
+- name: "Deploy Monitoring"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [action-scheduler,
+                  action-worker,
+                  case-api,
+                  case-processor,
+                  fieldwork-adapter,
+                  notify-processor,
+                  uac-qid-service,
+                  pubsubsvc,
+                  print-file-service,
+                  exception-manager,
+                  toolbox,
+                  rabbitmonitor]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+    - get: every-minute
+      trigger: true
+      passed: ["Run Helm"]
+    - get: census-rm-kubernetes-release
+    - get: census-rm-deploy
+    - task: "Deploy Monitoring"
+      file: census-rm-deploy/tasks/helm.yml
+      params:
+        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+        ENV: ((gcp-environment-name))
+        KUBERNETES_CLUSTER: rm-k8s-cluster
+        RABBITMQ_CONFIG_VALUES_FILE: ((rabbit-config))
         PROMETHEUS_CONFIG_VALUES_FILE: ((prometheus-config))
+        GRAFANA_CONFIG_VALUES_FILE: ((grafana-config))
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release}
 
 - name: "Report Terraform Success"

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -23,6 +23,7 @@ groups:
   - "Trigger Terraform"
   - "Run Terraform"
   - "Run Helm"
+  - "Deploy Monitoring"
   - "Report Terraform Success"
 
 - name: "Infrastructure"
@@ -30,6 +31,7 @@ groups:
   - "Trigger Terraform"
   - "Run Terraform"
   - "Run Helm"
+  - "Deploy Monitoring"
   - "Report Terraform Success"
 
 - name: "App Deployment"

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -815,7 +815,7 @@ jobs:
     - get: census-rm-kubernetes-release
     - get: census-rm-deploy
     - task: "Deploy Monitoring"
-      file: census-rm-deploy/tasks/helm.yml
+      file: census-rm-deploy/tasks/monitoring.yml
       params:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: ((gcp-environment-name))

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -51,6 +51,14 @@ resources:
     private_key: ((github.service_account_private_key))
     paths: [dependencies/*, rabbitmq/*, setup-dependencies.sh]
     tag_filter: v*.*.*
+
+- name: census-rm-kubernetes-monitoring-repo
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-kubernetes.git
+    private_key: ((github.service_account_private_key))
+    paths: [release/monitoring/*, grafana-dashboards/*, setup-monitoring.sh]
+    tag_filter: v*.*.*
     
 - name: census-rm-kubernetes-release	
   type: git	
@@ -523,6 +531,43 @@ jobs:
   on_failure: *slack_performance_setup_failure
   on_error: *slack_error_alert
 
+# Deploy monitoring apps
+- name: "Monitoring"
+  serial: true
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
+  serial_groups: [scale-down,
+                  scale-apps,
+                  performance-tests,
+                  action-scheduler,
+                  action-worker,
+                  case-api,
+                  case-processor,
+                  fieldwork-adapter,
+                  notify-processor,
+                  uac-qid-service,
+                  pubsubsvc,
+                  print-file-service,
+                  exception-manager,
+                  toolbox,
+                  database-monitor,
+                  rabbitmonitor]
+  plan:
+    - get: every-minute
+      trigger: true
+      passed: ["Scale Down Apps and Reset DB"]
+    - get: census-rm-kubernetes-monitoring-repo
+    - get: census-rm-deploy
+    - task: "Monitoring"
+      file: census-rm-deploy/tasks/monitoring.yml
+      params:
+        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+        ENV: performance
+        KUBERNETES_CLUSTER: rm-k8s-cluster
+        PROMETHEUS_CONFIG_VALUES_FILE: release/monitoring/prometheus-values.yml
+        GRAFANA_CONFIG_VALUES_FILE: release/monitoring/grafana-deployment.yml
+      input_mapping: {census-rm-kubernetes-monitoring-repo: census-rm-kubernetes-monitoring-repo}
+
   # Run Helm
 - name: "Run Helm"
   disable_manual_trigger: true
@@ -548,7 +593,7 @@ jobs:
   plan:
     - get: every-minute
       trigger: true
-      passed: ["Scale Down Apps and Reset DB"]
+      passed: ["Monitoring"]
     - get: census-rm-kubernetes-dependencies-repo
     - get: census-rm-deploy
     - task: "Run Helm"
@@ -558,7 +603,6 @@ jobs:
         ENV: performance
         KUBERNETES_CLUSTER: rm-k8s-cluster
         RABBITMQ_CONFIG_VALUES_FILE: release/rabbitmq/values_prod.yml
-        PROMETHEUS_CONFIG_VALUES_FILE: release/prometheus/values.yml
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-dependencies-repo}
 
 - name: "Action Scheduler"

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -4,12 +4,13 @@ image_resource:
   source:
     repository: google/cloud-sdk
 params:
-  ENV:
   ADMIN_SERVICE_ACCOUNT_JSON:
+  ENV:
   KUBERNETES_CLUSTER:
-  RABBITMQ_CONFIG_VALUES_FILE:
+  PROMETHEUS_CONFIG_VALUES_FILE:
+  GRAFANA_CONFIG_VALUES_FILE:
 inputs:
-  - name: census-rm-kubernetes-dependencies-repo
+  - name: census-rm-kubernetes-monitoring-repo
 run:
   path: bash
   args:
@@ -28,5 +29,5 @@ run:
       helm init --client-only
       helm plugin install https://github.com/rimusz/helm-tiller
 
-      cd census-rm-kubernetes-dependencies-repo
-      ENV=${ENV} RABBITMQ_CONFIG_VALUES_FILE=${RABBITMQ_CONFIG_VALUES_FILE} ./setup-dependencies.sh
+      cd census-rm-kubernetes-monitoring-repo
+      ENV=${ENV} PROMETHEUS_CONFIG_VALUES_FILE=${PROMETHEUS_CONFIG_VALUES_FILE} GRAFANA_CONFIG_VALUES_FILE=${GRAFANA_CONFIG_VALUES_FILE} ./setup-monitoring.sh


### PR DESCRIPTION
# Motivation and Context
Currently, the job to deploy Grafana and Prometheus is part of the job that also deploys Rabbit.  This means that you cannot make changes to any of the monitoring apps without redeploying Rabbit - dangerous in some envs.  This PR separates out the jobs.

# What has changed
- New task to deploy Grafana and Prometheus
- New job in each pipeline to run the new task

# How to test?
- Run the pipeline against the latest tagged versions of Terraform and Kubernetes
- There shouldn't be any changes to the deployments, apart from Prometheus and Grafana being deployed separately from Rabbit.

# Links
- https://github.com/ONSdigital/census-rm-kubernetes/pull/236
- https://github.com/ONSdigital/census-rm-terraform/pull/166
- https://trello.com/c/G5vFgDP4

# Screenshots (if appropriate):