### PR TITLE
Feature/pubsub ci build

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Required configuration:
 | wl-gcp-environment-name     | String                                                                              | WL - The name of the GCP project suffix the targeted cluster belongs to                       |
 
 
+#### How to validate the concourse definitions
+
+```
+./validate-pipelines.sh 
+```
+
+Expect that all files in the pipelines folder reportedly look good.
+
+
 #### How to fly manually
 To access fly locally, you'll now need to access it through a bastion.  Run the following at the start of a session then log into your Google account when prompted:
 ```bash

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -18,6 +18,7 @@ groups:
   - "Build Performance Tests Latest"
   - "Build Print File Service Latest"
   - "Build PubSub Latest"
+  - "Build PubSub Adapter Latest"
   - "Build Sample Loader Latest"
   - "Build Toolbox Latest"
   - "Build UAC QID Service Latest"
@@ -75,6 +76,7 @@ groups:
   - "Build Ops Latest"
   - "Build Performance Tests Latest"
   - "Build Print File Service Latest"
+  - "Build PubSub Adapter Latest"
   - "Build PubSub Latest"
   - "Build Sample Loader Latest"
   - "Build Toolbox Latest"
@@ -223,6 +225,12 @@ resources:
   type: git
   source:
     uri: git@github.com:ONSdigital/census-rm-toolbox.git
+    private_key: ((github.service_account_private_key))
+
+- name: pubsub-adapter
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-pubsub-adapter.git
     private_key: ((github.service_account_private_key))
 
 - name: pubsub-master
@@ -401,6 +409,20 @@ resources:
   type: docker-image
   source:
     repository: ((docker-registry-gcr))/rm/census-rm-toolbox
+    username: _json_key
+    password: ((gcp.service_account_json))
+
+- name: pubsub-adapter-docker-image-ci
+  type: docker-image
+  source:
+    repository: ((docker-registry-ci))/rm/census-rm-pubsub-adapter
+    username: _json_key
+    password: ((gcp.service_account_json))
+
+- name: pubsub-adapter-docker-image-gcr
+  type: docker-image
+  source:
+    repository: ((docker-registry-gcr))/rm/census-rm-pubsub-adapter
     username: _json_key
     password: ((gcp.service_account_json))
 
@@ -1332,6 +1354,32 @@ jobs:
       cache_from:
         - toolbox-docker-image-ci
       tag_file: toolbox-master/.git/ref
+      tag_as_latest: true
+    get_params:
+      skip_download: true
+
+- name: "Build PubSub Adapter Latest"
+  serial_groups: [pubsub-adapter-build]
+  plan:
+  - get: pubsub-adapter
+    trigger: true
+  - put: pubsub-adapter-docker-image-ci
+    on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
+    params:
+      build: pubsub-adapter
+      tag_file: pubsub-adapter/.git/ref
+      tag_as_latest: true
+    get_params:
+      save: true
+  - put: pubsub-adapter-docker-image-gcr
+    on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
+    params:
+      build: pubsub-adapter
+      cache_from:
+        - pubsub-adapter-docker-image-ci
+      tag_file: pubsub-adapter/.git/ref
       tag_as_latest: true
     get_params:
       skip_download: true

--- a/pipelines/build-release-images.yml
+++ b/pipelines/build-release-images.yml
@@ -91,6 +91,14 @@ resources:
       access_token: ((github.access_token))
       order_by: time
 
+  - name: pubsub-adapter-release
+    type: github-release-latest
+    source:
+      owner: ONSdigital
+      repository: census-rm-pubsub-adapter
+      access_token: ((github.access_token))
+      order_by: time
+
   - name: pubsub-release
     type: github-release-latest
     source:
@@ -290,6 +298,20 @@ resources:
       username: _json_key
       password: ((gcp.service_account_json))
 
+
+  - name: pubsub-adapter-docker-image-ci
+    type: docker-image
+    source:
+      repository: ((docker-registry-ci))/rm/census-rm-pubsub-adapter
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: pubsub-adapter-docker-image-gcr
+    type: docker-image
+    source:
+      repository: ((docker-registry-gcr))/rm/census-rm-pubsub-adapter
+      username: _json_key
+      password: ((gcp.service_account_json))
 
   - name: pubsub-docker-image-ci
     type: docker-image
@@ -1005,6 +1027,53 @@ jobs:
       get_params:
         skip_download: true
 
+
+  - name: build-pubsub-adapter-release
+    plan:
+    - get: pubsub-adapter-release
+      params:
+        include_source_tarball: true
+      trigger: true
+    - task: Build PubSub Adapter Image (release)
+      on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: alpine
+        inputs:
+          - name: pubsub-adapter-release
+        outputs:
+          - name: extracted-pubsub-adapter
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              cd pubsub-adapter-release
+              tar -xzf source.tar.gz -C ../extracted-pubsub-adapter --strip-components=1
+    - put: pubsub-adapter-docker-image-ci
+      on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
+      params:
+        build: extracted-pubsub-adapter
+        tag_file: pubsub-adapter-release/tag
+        tag_as_latest: false
+      get_params:
+        save: true
+    - put: pubsub-adapter-docker-image-gcr
+      on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
+      params:
+        build: extracted-pubsub-adapter
+        cache_from:
+          - pubsub-adapter-docker-image-ci
+        tag_file: pubsub-adapter-release/tag
+        tag_as_latest: false
+      get_params:
+        skip_download: true
 
   - name: build-pubsub-release
     plan:

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -130,7 +130,7 @@ jobs:
 
         - name: release-images
           team: rm
-          config_file: census-rm-deploy/pipelines/docker-release-pipeline.yml
+          config_file: census-rm-deploy/pipelines/build-release-images.yml
           unpaused: true
           vars:
             docker-registry-ci: eu.gcr.io/census-rm-ci


### PR DESCRIPTION
# Motivation and Context
Supporting introduction of microservice into the continuous integration pipeline.
(Deploying the service to Kubernetes is out of scope and will be picked up in other stories).

# What has changed
YAML definitions that define the
- repository for the new service
- how to build and unit test the service
- how to package the service in a docker image
- pushing the docker image into the two registries

# How to test?
Testing locally or isolation testing not feasible in this case due to dependencies.
You validate the service using the fly validator (and shell script at root).
Validation will happen on the pipeline itself - if it fails we will fix on the fly!
