### PR TITLE
667 fix acceptance test data build up issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,9 @@ Presently there are three tests which can be run, by running these selection job
  - Select Test - PubSub
 
  Once you have run one of the selection jobs, you can then run Trigger Selected Test to run the test.
+
+## RM sandbox
+If you'd like to deploy a pipeline to the RM Sandbox concourse:
+- You'll need to set your fly target to the sandbox environment e.g `fly login -t main -c https://concourse.rm.census-gcp.onsdigital.uk/`
+- To run terraform you'll need to whitelist the `census-rm-concourse` ip from the Cloud Nat section in GCP
+- You'll need to give the `census-rm-concourse` service account owner permission in your environment. This can be done in the IAM section in GCP.

--- a/README.md
+++ b/README.md
@@ -86,8 +86,3 @@ Presently there are three tests which can be run, by running these selection job
 
  Once you have run one of the selection jobs, you can then run Trigger Selected Test to run the test.
 
-## RM sandbox
-If you'd like to deploy a pipeline to the RM Sandbox concourse:
-- You'll need to set your fly target to the sandbox environment e.g `fly login -t main -c https://concourse.rm.census-gcp.onsdigital.uk/`
-- To run terraform you'll need to whitelist the `census-rm-concourse` ip from the Cloud Nat section in GCP
-- You'll need to give the `census-rm-concourse` service account owner permission in your environment. This can be done in the IAM section in GCP.

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -1041,7 +1041,7 @@ jobs:
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
-      GCP_PROJECT_NAME: ((gcp-project-name))
+      GCP_PROJECT_NAME: ((ci-gcp-project-name))
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
       input_mapping: {kubernetes-repo: census-rm-kubernetes-repo}
@@ -2541,6 +2541,7 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-kubernetes-dependencies-repo
+  - get: census-rm-ddl-master
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Deploy Action-Scheduler",
@@ -2710,10 +2711,10 @@ jobs:
                   wl-regional-counts]
   plan:
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
-    passed: ["WL Helm"]
   - get: census-rm-kubernetes-repo
   - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Acceptance Tests"]
   - get: ddl-docker-image-gcr
     params:
       skip_download: true

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -165,12 +165,6 @@ resources:
     private_key: ((github.service_account_private_key))
     paths: [optional/census-rm-ddl-pod.yml]
 
-- name: midnight
-  type: time
-  source:
-    start: 12:00 AM
-    stop: 12:01 AM
-
 - name: slack-alert
   type: slack-notification
   source:
@@ -1106,7 +1100,7 @@ jobs:
 - name: "Reset DB"
   disable_manual_trigger: true
   plan:
-  - get: midnight
+  - get: every-midnight
     trigger: true
   - get: census-rm-kubernetes-repo-ddl
   - get: census-rm-deploy

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -158,12 +158,12 @@ resources:
     expression: "0 0 * * *"
     fire_immediately: true
 
-- name: census-rm-kubernetes-repo
+- name: census-rm-kubernetes-repo-ddl
   type: git
   source:
     uri: git@github.com:ONSdigital/census-rm-kubernetes.git
     private_key: ((github.service_account_private_key))
-    tag_filter:
+    paths: [optional/census-rm-ddl-pod.yml]
 
 - name: midnight
   type: time
@@ -1108,7 +1108,7 @@ jobs:
   plan:
   - get: midnight
     trigger: true
-  - get: census-rm-kubernetes-repo
+  - get: census-rm-kubernetes-repo-ddl
   - get: census-rm-deploy
   - task: "Run ground zero"
     file: census-rm-deploy/tasks/kubectl-run-groundzero-script.yml
@@ -1118,7 +1118,7 @@ jobs:
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-      input_mapping: {kubernetes-repo: census-rm-kubernetes-repo}
+      input_mapping: {kubernetes-repo: census-rm-kubernetes-repo-ddl}
 
 # Docker Builds
 - name: "Build Action Scheduler Latest"
@@ -1991,7 +1991,8 @@ jobs:
   - get: census-rm-ddl-master
     trigger: true
     passed: ["Build DDL Latest"]
-  - get: census-rm-kubernetes-repo
+  - get: census-rm-kubernetes-repo-ddl
+    trigger: true
   - get: ddl-docker-image-gcr
     params:
       skip_download: true
@@ -2003,7 +2004,7 @@ jobs:
       KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-repo}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-repo-ddl}
 
 
 # CI Deployments
@@ -2030,6 +2031,9 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-deploy
+  - get: census-rm-kubernetes-repo-ddl
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_ci
@@ -2070,6 +2074,9 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-deploy
+  - get: census-rm-kubernetes-repo-ddl
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_ci
@@ -2110,6 +2117,9 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-deploy
+  - get: census-rm-kubernetes-repo-ddl
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_ci
@@ -2150,6 +2160,9 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-deploy
+  - get: census-rm-kubernetes-repo-ddl
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_ci
@@ -2190,6 +2203,9 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-deploy
+  - get: census-rm-kubernetes-repo-ddl
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_ci
@@ -2725,6 +2741,13 @@ jobs:
              "CI Deploy Database Monitor",
              "CI Deploy Rabbit Monitor",
              "CI Deploy Regional Counts"]
+  - get: census-rm-kubernetes-repo-ddl
+    trigger: true
+    passed: ["CI Deploy Action-Scheduler",
+             "CI Deploy Action-Worker",
+             "CI Deploy Case-API",
+             "CI Deploy Case-Processor",
+             "CI Deploy UAC QID Service"]
   - get: action-scheduler-master
     trigger: true
     passed: ["CI Deploy Action-Scheduler"]
@@ -2910,7 +2933,7 @@ jobs:
                   wl-regional-counts]
   plan:
   - get: census-rm-kubernetes-dependencies-repo
-  - get: census-rm-kubernetes-repo
+  - get: census-rm-kubernetes-repo-ddl
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2925,7 +2948,7 @@ jobs:
       KUBERNETES_CLUSTER: ((wl-kubernetes-cluster-name))
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-repo}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-repo-ddl}
 
 
 # WL Deployments

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -160,12 +160,6 @@ resources:
     expression: "0 0 * * *"
     fire_immediately: true
 
-- name: census-rm-kubernetes-repo
-  type: git
-  source:
-    uri: git@github.com:ONSdigital/census-rm-kubernetes.git
-    private_key: ((github.service_account_private_key))
-
 - name: slack-alert
   type: slack-notification
   source:
@@ -1840,7 +1834,7 @@ jobs:
   plan:
   - get: every-midnight
     trigger: true
-  - get: census-rm-kubernetes-repo
+  - get: census-rm-kubernetes-optional-repo
   - get: census-rm-deploy
   - task: "Run ground zero"
     file: census-rm-deploy/tasks/kubectl-run-groundzero-script.yml
@@ -1850,7 +1844,7 @@ jobs:
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-      input_mapping: {kubernetes-repo: census-rm-kubernetes-repo}
+      input_mapping: {kubernetes-repo: census-rm-kubernetes-optional-repo}
 
 - name: "CI Terraform"
   serial: true
@@ -1989,7 +1983,7 @@ jobs:
   - get: census-rm-ddl-master
     trigger: true
     passed: ["Build DDL Latest"]
-  - get: census-rm-kubernetes-repo
+  - get: census-rm-kubernetes-optional-repo
   - get: ddl-docker-image-gcr
     params:
       skip_download: true
@@ -2001,7 +1995,7 @@ jobs:
       KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-repo}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-optional-repo}
 
 
 # CI Deployments
@@ -2921,8 +2915,7 @@ jobs:
   on_failure: *slack_failure_alert_wl
   on_error: *slack_error_alert_wl
   plan:
-  - get: census-rm-kubernetes-dependencies-repo
-  - get: census-rm-kubernetes-repo
+  - get: census-rm-kubernetes-optional-repo
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2937,7 +2930,7 @@ jobs:
       KUBERNETES_CLUSTER: ((wl-kubernetes-cluster-name))
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-repo}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-optional-repo}
 
 
 # WL Deployments

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2722,6 +2722,18 @@ jobs:
       skip_download: true
   - get: census-rm-kubernetes-dependencies-repo
   - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Deploy Action-Scheduler",
+             "CI Deploy Action-Worker",
+             "CI Deploy Case-API",
+             "CI Deploy Case-Processor",
+             "CI Deploy UAC QID Service",
+             "CI Deploy PubSub Service",
+             "CI Deploy Print File Service",
+             "CI Deploy Fieldwork Adapter",
+             "CI Deploy Notify Processor",
+             "CI Deploy Notify Stub",
+             "CI Deploy Exception Manager"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Deploy Action-Scheduler",

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2,6 +2,7 @@
 groups:
 - name: "Overview"
   jobs:
+  - "Reset DB"
   - "Build Acceptance Tests Latest"
   - "Build Action Scheduler Latest"
   - "Build Action Worker Latest"
@@ -9,6 +10,7 @@ groups:
   - "Build Case API Latest"
   - "Build Case Processor Latest"
   - "Build Data Exporter Latest"
+  - "Build DDL Latest"
   - "Build Exception Manager Latest"
   - "Build Fieldwork Adapter Latest"
   - "Build Notify Processor Latest"
@@ -22,6 +24,7 @@ groups:
   - "Build UAC QID Service Latest"
   - "CI Terraform"
   - "CI Helm"
+  - "CI Apply Database Patches"
   - "CI Deploy Action-Scheduler"
   - "CI Deploy Action-Worker"
   - "CI Deploy Case-API"
@@ -41,6 +44,7 @@ groups:
   - "CI Acceptance Tests"
   - "WL Terraform"
   - "WL Helm"
+  - "WL Apply Database Patches"
   - "WL Deploy Action-Scheduler"
   - "WL Deploy Action-Worker"
   - "WL Deploy Case-API"
@@ -66,6 +70,7 @@ groups:
   - "Build Case API Latest"
   - "Build Case Processor Latest"
   - "Build Data Exporter Latest"
+  - "Build DDL Latest"
   - "Build Exception Manager Latest"
   - "Build Fieldwork Adapter Latest"
   - "Build Notify Processor Latest"
@@ -82,6 +87,7 @@ groups:
   jobs:
   - "CI Terraform"
   - "CI Helm"
+  - "CI Apply Database Patches"
   - "CI Deploy Action-Scheduler"
   - "CI Deploy Action-Worker"
   - "CI Deploy Case-API"
@@ -104,6 +110,7 @@ groups:
   jobs:
   - "WL Terraform"
   - "WL Helm"
+  - "WL Apply Database Patches"
   - "WL Deploy Action-Scheduler"
   - "WL Deploy Action-Worker"
   - "WL Deploy Case-API"
@@ -1033,7 +1040,7 @@ jobs:
     file: census-rm-deploy/tasks/kubectl-run-groundzero-script.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
       GCP_PROJECT_NAME: ((gcp-project-name))
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
@@ -1799,22 +1806,23 @@ jobs:
   # Apply Database Patches
 - name: "CI Apply Database Patches"
   serial: true
-  serial_groups: [apply-database-patches,
-                  action-scheduler,
-                  action-worker,
-                  case-api,
-                  case-processor,
-                  uac-qid-service,
-                  pubsubsvc,
-                  ops,
-                  print-file-service,
-                  fieldwork-adapter,
-                  notify-processor,
-                  exception-manager,
-                  toolbox,
-                  database-monitor,
-                  rabbitmonitor,
-                  regionalcounts]
+  serial_groups: [ci-database-patches,
+                  ci-acceptance-tests,
+                  action-scheduler-deploy,
+                  action-worker-deploy,
+                  case-api-deploy,
+                  case-processor-deploy,
+                  uac-qid-service-deploy,
+                  pubsub-deploy,
+                  print-file-service-deploy,
+                  fieldwork-adapter-deploy,
+                  notify-processor-deploy,
+                  notify-stub-deploy,
+                  exception-manager-deploy,
+                  toolbox-deploy,
+                  database-monitor-deploy,
+                  rabbitmonitor-deploy,
+                  regional-counts-deploy]
   plan:
   - get: census-rm-ddl-master
     trigger: true
@@ -1827,8 +1835,8 @@ jobs:
     file: census-rm-deploy/tasks/kubectl-apply-ddl-patches.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      GCP_PROJECT_NAME: ((ci-gcp-project-name))
+      KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-repo}
@@ -2685,6 +2693,7 @@ jobs:
 - name: "WL Apply Database Patches"
   serial: true
   serial_groups: [wl-database-patches,
+                  wl-terraform,
                   wl-action-scheduler,
                   wl-action-worker,
                   wl-case-api,
@@ -2712,8 +2721,8 @@ jobs:
     file: census-rm-deploy/tasks/kubectl-apply-ddl-patches.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((gcp-project-name))
-      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      GCP_PROJECT_NAME: ((wl-gcp-project-name))
+      KUBERNETES_CLUSTER: ((wl-kubernetes-cluster-name))
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-repo}

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2,7 +2,7 @@
 groups:
 - name: "Overview"
   jobs:
-  - "Reset DB"
+  - "Reset CI DB"
   - "Build Acceptance Tests Latest"
   - "Build Action Scheduler Latest"
   - "Build Action Worker Latest"
@@ -94,6 +94,7 @@ groups:
 - name: "CI"
   jobs:
   - "CI Terraform"
+  - "Reset CI DB"
   - "CI Monitoring"
   - "CI Helm"
   - "CI Apply Database Patches"
@@ -1098,8 +1099,10 @@ templating:
 jobs:
 
 # Run DB Teardown
-- name: "Reset DB"
+- name: "Reset CI DB"
   disable_manual_trigger: true
+  on_failure: *slack_failure_alert_ci
+  on_error: *slack_error_alert_ci
   plan:
   - get: every-midnight
     trigger: true
@@ -1982,6 +1985,8 @@ jobs:
                   database-monitor-deploy,
                   rabbitmonitor-deploy,
                   regional-counts-deploy]
+  on_failure: *slack_failure_alert_ci
+  on_error: *slack_error_alert_ci
   plan:
   - get: census-rm-ddl-master
     trigger: true
@@ -2938,6 +2943,8 @@ jobs:
                   wl-database-monitor,
                   wl-rabbitmonitor,
                   wl-regional-counts]
+  on_failure: *slack_failure_alert_wl
+  on_error: *slack_error_alert_wl
   plan:
   - get: census-rm-kubernetes-dependencies-repo
   - get: census-rm-kubernetes-repo-ddl

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -129,6 +129,19 @@ resource_types:
 
 resources:
 
+- name: census-rm-kubernetes-repo
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-kubernetes.git
+    private_key: ((github.service_account_private_key))
+    tag_filter:
+
+- name: midnight
+  type: time
+  source:
+    start: 12:00 AM
+    stop: 12:01 AM
+
 - name: slack-alert
   type: slack-notification
   source:
@@ -173,6 +186,12 @@ resources:
   source:
     branch: ((terraform-branch))
     uri: git@github.com:ONSdigital/census-rm-terraform.git
+    private_key: ((github.service_account_private_key))
+
+- name: census-rm-ddl-master
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-ddl.git
     private_key: ((github.service_account_private_key))
 
 - name: action-scheduler-master
@@ -393,6 +412,20 @@ resources:
   type: docker-image
   source:
     repository: ((docker-registry-gcr))/rm/census-rm-toolbox
+    username: _json_key
+    password: ((gcp.service_account_json))
+
+- name: ddl-docker-image-ci
+  type: docker-image
+  source:
+    repository: ((docker-registry-ci))/rm/census-rm-ddl
+    username: _json_key
+    password: ((gcp.service_account_json))
+
+- name: ddl-docker-image-gcr
+  type: docker-image
+  source:
+    repository: ((docker-registry-gcr))/rm/census-rm-ddl
     username: _json_key
     password: ((gcp.service_account_json))
 
@@ -988,6 +1021,24 @@ templating:
 
 jobs:
 
+# Run DB Teardown
+- name: "Reset DB"
+  disable_manual_trigger: true
+  plan:
+  - get: midnight
+    trigger: true
+  - get: census-rm-kubernetes-repo
+  - get: census-rm-deploy
+  - task: "Run ground zero"
+    file: census-rm-deploy/tasks/kubectl-run-groundzero-script.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_FILE_PATH: kubernetes-repo/optional
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+      input_mapping: {kubernetes-repo: census-rm-kubernetes-repo}
+
 # Docker Builds
 - name: "Build Action Scheduler Latest"
   serial_groups: [action-scheduler-build]
@@ -1210,6 +1261,32 @@ jobs:
       cache_from:
         - print-file-service-docker-image-ci
       tag_file: print-file-service-master/.git/ref
+      tag_as_latest: true
+    get_params:
+      skip_download: true
+
+- name: "Build DDL Latest"
+  serial_groups: [ddl-build]
+  plan:
+  - get: census-rm-ddl-master
+    trigger: true
+  - put: ddl-docker-image-ci
+    on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
+    params:
+      build: census-rm-ddl-master
+      tag_file: census-rm-ddl-master/.git/ref
+      tag_as_latest: true
+    get_params:
+      save: true
+  - put: ddl-docker-image-gcr
+    on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
+    params:
+      build: census-rm-ddl-master
+      cache_from:
+        - ddl-docker-image-ci
+      tag_file: census-rm-ddl-master/.git/ref
       tag_as_latest: true
     get_params:
       skip_download: true
@@ -1718,6 +1795,45 @@ jobs:
         PROMETHEUS_CONFIG_VALUES_FILE: prometheus/values.yml
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-dependencies-repo}
 
+
+  # Apply Database Patches
+- name: "CI Apply Database Patches"
+  serial: true
+  serial_groups: [apply-database-patches,
+                  action-scheduler,
+                  action-worker,
+                  case-api,
+                  case-processor,
+                  uac-qid-service,
+                  pubsubsvc,
+                  ops,
+                  print-file-service,
+                  fieldwork-adapter,
+                  notify-processor,
+                  exception-manager,
+                  toolbox,
+                  database-monitor,
+                  rabbitmonitor,
+                  regionalcounts]
+  plan:
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["Build DDL Latest"]
+  - get: census-rm-kubernetes-repo
+  - get: ddl-docker-image-gcr
+    params:
+      skip_download: true
+  - task: apply-database-patches
+    file: census-rm-deploy/tasks/kubectl-apply-ddl-patches.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_FILE_PATH: kubernetes-repo/optional
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-repo}
+
+
 # CI Deployments
 - name: "CI Deploy Action-Scheduler"
   serial: true
@@ -1735,6 +1851,9 @@ jobs:
   - get: action-scheduler-master
     trigger: true
     passed: ["Build Action Scheduler Latest"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: action-scheduler-docker-image-gcr
     params:
       skip_download: true
@@ -1767,6 +1886,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: action-worker-master
@@ -1804,6 +1926,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: case-api-master
@@ -1841,6 +1966,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: case-processor-master
@@ -1878,6 +2006,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: uac-qid-service-master
@@ -1915,6 +2046,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: pubsub-master
@@ -1954,6 +2088,9 @@ jobs:
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-ops-repo
     trigger: true
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: ops-master
     trigger: true
     passed: ["Build Ops Latest"]
@@ -1991,6 +2128,9 @@ jobs:
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: print-file-service-master
     trigger: true
     passed: ["Build Print File Service Latest"]
@@ -2026,6 +2166,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: fieldwork-adapter-master
@@ -2063,6 +2206,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: notify-processor-master
@@ -2088,7 +2234,7 @@ jobs:
     input_mapping: {
       docker-image-resource: notify-processor-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-microservices-repo}
-  
+
 - name: "CI Deploy Notify Stub"
   serial: true
   serial_groups: [notify-stub-build,
@@ -2102,6 +2248,9 @@ jobs:
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: notify-stub-master
     trigger: true
     passed: ["Build Notify Stub Latest"]
@@ -2125,7 +2274,7 @@ jobs:
     input_mapping: {
       docker-image-resource: notify-stub-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-microservices-repo}
-  
+
 - name: "CI Deploy Exception Manager"
   serial: true
   serial_groups: [exception-manager-build,
@@ -2139,6 +2288,9 @@ jobs:
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: exception-manager-master
     trigger: true
     passed: ["Build Exception Manager Latest"]
@@ -2179,6 +2331,9 @@ jobs:
   - get: toolbox-master
     trigger: true
     passed: ["Build Toolbox Latest"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: toolbox-docker-image-gcr
     params:
       skip_download: true
@@ -2213,6 +2368,9 @@ jobs:
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: toolbox-master
     trigger: true
     passed: ["Build Toolbox Latest"]
@@ -2248,6 +2406,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
@@ -2285,6 +2446,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
@@ -2347,11 +2511,11 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Deploy Action-Scheduler", 
-             "CI Deploy Action-Worker", 
-             "CI Deploy Case-API", 
-             "CI Deploy Case-Processor", 
-             "CI Deploy UAC QID Service", 
+    passed: ["CI Deploy Action-Scheduler",
+             "CI Deploy Action-Worker",
+             "CI Deploy Case-API",
+             "CI Deploy Case-Processor",
+             "CI Deploy UAC QID Service",
              "CI Deploy PubSub Service",
              "CI Deploy Print File Service",
              "CI Deploy Fieldwork Adapter",
@@ -2371,11 +2535,11 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
-    passed: ["CI Deploy Action-Scheduler", 
-             "CI Deploy Action-Worker", 
-             "CI Deploy Case-API", 
-             "CI Deploy Case-Processor", 
-             "CI Deploy UAC QID Service", 
+    passed: ["CI Deploy Action-Scheduler",
+             "CI Deploy Action-Worker",
+             "CI Deploy Case-API",
+             "CI Deploy Case-Processor",
+             "CI Deploy UAC QID Service",
              "CI Deploy PubSub Service",
              "CI Deploy Print File Service",
              "CI Deploy Fieldwork Adapter",
@@ -2448,6 +2612,7 @@ jobs:
 - name: "WL Terraform"
   serial: true
   serial_groups: [wl-terraform,
+                  wl-database-patches,
                   wl-action-scheduler,
                   wl-action-worker,
                   wl-case-api,
@@ -2483,6 +2648,7 @@ jobs:
 - name: "WL Helm"
   serial: true
   serial_groups: [wl-terraform,
+                  wl-database-patches,
                   wl-action-scheduler,
                   wl-action-worker,
                   wl-case-api,
@@ -2515,6 +2681,44 @@ jobs:
         PROMETHEUS_CONFIG_VALUES_FILE: prometheus/values.yml
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-dependencies-repo}
 
+# Apply Database Patches
+- name: "WL Apply Database Patches"
+  serial: true
+  serial_groups: [wl-database-patches,
+                  wl-action-scheduler,
+                  wl-action-worker,
+                  wl-case-api,
+                  wl-case-processor,
+                  wl-uac-qid-service,
+                  wl-pubsub,
+                  wl-print-file-service,
+                  wl-fieldwork-adapter,
+                  wl-notify-processor,
+                  wl-exception-manager,
+                  wl-toolbox,
+                  wl-database-monitor,
+                  wl-rabbitmonitor,
+                  wl-regional-counts]
+  plan:
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["WL Helm"]
+  - get: census-rm-kubernetes-repo
+  - get: census-rm-ddl-master
+  - get: ddl-docker-image-gcr
+    params:
+      skip_download: true
+  - task: apply-database-patches
+    file: census-rm-deploy/tasks/kubectl-apply-ddl-patches.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_FILE_PATH: kubernetes-repo/optional
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-repo}
+
+
 # WL Deployments
 - name: "WL Deploy Action-Scheduler"
   serial: true
@@ -2529,6 +2733,9 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: action-scheduler-master
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2563,6 +2770,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["WL Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2603,6 +2813,9 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: print-file-service-master
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2640,6 +2853,9 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: case-api-master
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2674,6 +2890,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["WL Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2711,6 +2930,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["WL Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2748,6 +2970,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["WL Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2785,6 +3010,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["WL Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-ops-repo
     trigger: true
   - get: ops-master
@@ -2820,6 +3048,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["WL Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2857,6 +3088,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["WL Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2894,6 +3128,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["WL Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2931,6 +3168,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["WL Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2968,6 +3208,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["WL Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -3005,6 +3248,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["WL Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -3042,6 +3288,9 @@ jobs:
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["WL Helm"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
     passed: ["CI Acceptance Tests"]

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2,7 +2,7 @@
 groups:
 - name: "Overview"
   jobs:
-  - "Reset CI DB"
+  - "CI Reset DB"
   - "Build Acceptance Tests Latest"
   - "Build Action Scheduler Latest"
   - "Build Action Worker Latest"
@@ -94,7 +94,7 @@ groups:
 - name: "CI"
   jobs:
   - "CI Terraform"
-  - "Reset CI DB"
+  - "CI Reset DB"
   - "CI Monitoring"
   - "CI Helm"
   - "CI Apply Database Patches"
@@ -160,12 +160,11 @@ resources:
     expression: "0 0 * * *"
     fire_immediately: true
 
-- name: census-rm-kubernetes-repo-ddl
+- name: census-rm-kubernetes-repo
   type: git
   source:
     uri: git@github.com:ONSdigital/census-rm-kubernetes.git
     private_key: ((github.service_account_private_key))
-    paths: [optional/census-rm-ddl-pod.yml]
 
 - name: slack-alert
   type: slack-notification
@@ -1098,26 +1097,6 @@ templating:
 
 jobs:
 
-# Run DB Teardown
-- name: "Reset CI DB"
-  disable_manual_trigger: true
-  on_failure: *slack_failure_alert_ci
-  on_error: *slack_error_alert_ci
-  plan:
-  - get: every-midnight
-    trigger: true
-  - get: census-rm-kubernetes-repo-ddl
-  - get: census-rm-deploy
-  - task: "Run ground zero"
-    file: census-rm-deploy/tasks/kubectl-run-groundzero-script.yml
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
-      GCP_PROJECT_NAME: ((ci-gcp-project-name))
-      KUBERNETES_FILE_PATH: kubernetes-repo/optional
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-      input_mapping: {kubernetes-repo: census-rm-kubernetes-repo-ddl}
-
 # Docker Builds
 - name: "Build Action Scheduler Latest"
   serial_groups: [action-scheduler-build]
@@ -1854,6 +1833,25 @@ jobs:
     get_params:
       skip_download: true
 
+# Run DB Teardown
+- name: "CI Reset DB"
+  on_failure: *slack_failure_alert_ci
+  on_error: *slack_error_alert_ci
+  plan:
+  - get: every-midnight
+    trigger: true
+  - get: census-rm-kubernetes-repo
+  - get: census-rm-deploy
+  - task: "Run ground zero"
+    file: census-rm-deploy/tasks/kubectl-run-groundzero-script.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
+      GCP_PROJECT_NAME: ((ci-gcp-project-name))
+      KUBERNETES_FILE_PATH: kubernetes-repo/optional
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+      input_mapping: {kubernetes-repo: census-rm-kubernetes-repo}
+
 - name: "CI Terraform"
   serial: true
   serial_groups: [ci-terraform,
@@ -1991,8 +1989,7 @@ jobs:
   - get: census-rm-ddl-master
     trigger: true
     passed: ["Build DDL Latest"]
-  - get: census-rm-kubernetes-repo-ddl
-    trigger: true
+  - get: census-rm-kubernetes-repo
   - get: ddl-docker-image-gcr
     params:
       skip_download: true
@@ -2004,7 +2001,7 @@ jobs:
       KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-repo-ddl}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-repo}
 
 
 # CI Deployments
@@ -2031,9 +2028,6 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-deploy
-  - get: census-rm-kubernetes-repo-ddl
-    trigger: true
-    passed: ["CI Apply Database Patches"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_ci
@@ -2074,9 +2068,6 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-deploy
-  - get: census-rm-kubernetes-repo-ddl
-    trigger: true
-    passed: ["CI Apply Database Patches"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_ci
@@ -2117,9 +2108,6 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-deploy
-  - get: census-rm-kubernetes-repo-ddl
-    trigger: true
-    passed: ["CI Apply Database Patches"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_ci
@@ -2160,9 +2148,6 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-deploy
-  - get: census-rm-kubernetes-repo-ddl
-    trigger: true
-    passed: ["CI Apply Database Patches"]
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
     on_failure: *slack_failure_alert_ci
@@ -2203,9 +2188,6 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-deploy
-  - get: census-rm-kubernetes-repo-ddl
-    trigger: true
-    passed: ["CI Apply Database Patches"]
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
     on_failure: *slack_failure_alert_ci
@@ -2753,13 +2735,6 @@ jobs:
              "CI Deploy Database Monitor",
              "CI Deploy Rabbit Monitor",
              "CI Deploy Regional Counts"]
-  - get: census-rm-kubernetes-repo-ddl
-    trigger: true
-    passed: ["CI Deploy Action-Scheduler",
-             "CI Deploy Action-Worker",
-             "CI Deploy Case-API",
-             "CI Deploy Case-Processor",
-             "CI Deploy UAC QID Service"]
   - get: action-scheduler-master
     trigger: true
     passed: ["CI Deploy Action-Scheduler"]
@@ -2947,7 +2922,7 @@ jobs:
   on_error: *slack_error_alert_wl
   plan:
   - get: census-rm-kubernetes-dependencies-repo
-  - get: census-rm-kubernetes-repo-ddl
+  - get: census-rm-kubernetes-repo
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Acceptance Tests"]
@@ -2962,7 +2937,7 @@ jobs:
       KUBERNETES_CLUSTER: ((wl-kubernetes-cluster-name))
       KUBERNETES_FILE_PATH: kubernetes-repo/optional
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-repo-ddl}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-repo}
 
 
 # WL Deployments


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to be able to clear down the CI database every night at midnight and apply any new patches from the ddl to the database. Jobs have been added to try and do this.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added a `Reset DB` job which runs at midnight that will run the groundzero script in the CI Database.
- Added a job to build a latest DDL image for the DDL scripts to use instead of the release images. I've added a optional yaml in kubernetes to use this image. 
- Added a job to CI which will run the DDL apply script if theres been a change to master. This will trigger a build to all the apps and run the ATs.
- Added a job in WL that will run the apply script if theres been any changes to the DDL master and redeploy all the apps.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Hopefully works when it gets merged. I've flown the [pipeline](https://concourse.rm.census-gcp.onsdigital.uk/teams/main/pipelines/CI-WL-look-at?group=Overview) in the sandbox env so people can see what it should look like. 

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/UWyM9NQs/)

# Screenshots (if appropriate):