### PR TITLE
Remove disabling of manual trigger on monitoring job

### DIFF
--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -815,7 +815,6 @@ jobs:
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release}
 
 - name: "Deploy Monitoring"
-  disable_manual_trigger: true
   serial: true
   serial_groups: [action-scheduler,
                   action-worker,


### PR DESCRIPTION
# Motivation and Context
We want to be able to run the monitoring deployments whenever, as they're completely unconnected to the the app and infrastructure deployments.  This removes the disabled manual trigger.