### PR TITLE
using pubsub adapter service

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2202,7 +2202,7 @@ jobs:
 
 - name: "CI Deploy PubSub Service"
   serial: true
-  serial_groups: [pubsub-build,
+  serial_groups: [pubsub-adapter-build,
                   pubsub-deploy]
   plan:
   - get: census-rm-terraform
@@ -2216,10 +2216,10 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
-  - get: pubsub-master
+  - get: pubsub-adapter
     trigger: true
-    passed: ["Build PubSub Latest"]
-  - get: pubsub-docker-image-gcr
+    passed: ["Build PubSub Adapter Latest"]
+  - get: pubsub-adapter-docker-image-gcr
     params:
       skip_download: true
   - get: census-rm-deploy
@@ -2237,7 +2237,7 @@ jobs:
       KUBERNETES_FILE_PREFIX: pubsub
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
-      docker-image-resource: pubsub-docker-image-gcr,
+      docker-image-resource: pubsub-adapter-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
 - name: "CI Deploy Ops Tool"
@@ -2656,7 +2656,7 @@ jobs:
                   case-processor-deploy,
                   uac-qid-service-build,
                   uac-qid-service-deploy,
-                  pubsub-build,
+                  pubsub-adapter-build,
                   pubsub-deploy,
                   print-file-service-build,
                   print-file-service-deploy,
@@ -2747,7 +2747,7 @@ jobs:
   - get: uac-qid-service-master
     trigger: true
     passed: ["CI Deploy UAC QID Service"]
-  - get: pubsub-master
+  - get: pubsub-adapter
     trigger: true
     passed: ["CI Deploy PubSub Service"]
   - get: qid-batch-runner-master
@@ -3192,10 +3192,10 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
     passed: ["CI Acceptance Tests"]
-  - get: pubsub-master
+  - get: pubsub-adapter
     trigger: true
     passed: ["CI Acceptance Tests"]
-  - get: pubsub-docker-image-gcr
+  - get: pubsub-adapter-docker-image-gcr
     params:
       skip_download: true
   - get: census-rm-deploy
@@ -3213,7 +3213,7 @@ jobs:
       KUBERNETES_FILE_PREFIX: pubsub
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
-      docker-image-resource: pubsub-docker-image-gcr,
+      docker-image-resource: pubsub-adapter-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
 - name: "WL Deploy Ops Tool"

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -33,7 +33,7 @@ groups:
   - "CI Deploy Case-API"
   - "CI Deploy Case-Processor"
   - "CI Deploy UAC QID Service"
-  - "CI Deploy PubSub Service"
+  - "CI Deploy PubSub Adapter"
   - "CI Deploy Ops Tool"
   - "CI Deploy Print File Service"
   - "CI Deploy Fieldwork Adapter"
@@ -54,7 +54,7 @@ groups:
   - "WL Deploy Case-API"
   - "WL Deploy Case-Processor"
   - "WL Deploy UAC QID Service"
-  - "WL Deploy PubSub Service"
+  - "WL Deploy PubSub Adapter"
   - "WL Deploy Ops Tool"
   - "WL Deploy Print File Service"
   - "WL Deploy Fieldwork Adapter"
@@ -103,7 +103,7 @@ groups:
   - "CI Deploy Case-API"
   - "CI Deploy Case-Processor"
   - "CI Deploy UAC QID Service"
-  - "CI Deploy PubSub Service"
+  - "CI Deploy PubSub Adapter"
   - "CI Deploy Ops Tool"
   - "CI Deploy Print File Service"
   - "CI Deploy Fieldwork Adapter"
@@ -127,7 +127,7 @@ groups:
   - "WL Deploy Case-API"
   - "WL Deploy Case-Processor"
   - "WL Deploy UAC QID Service"
-  - "WL Deploy PubSub Service"
+  - "WL Deploy PubSub Adapter"
   - "WL Deploy Ops Tool"
   - "WL Deploy Print File Service"
   - "WL Deploy Fieldwork Adapter"
@@ -1855,7 +1855,7 @@ jobs:
                   case-api-deploy,
                   case-processor-deploy,
                   uac-qid-service-deploy,
-                  pubsub-deploy,
+                  pubsub-adapter-deploy,
                   print-file-service-deploy,
                   fieldwork-adapter-deploy,
                   notify-processor-deploy,
@@ -1891,7 +1891,7 @@ jobs:
                   case-api-deploy,
                   case-processor-deploy,
                   uac-qid-service-deploy,
-                  pubsub-deploy,
+                  pubsub-adapter-deploy,
                   print-file-service-deploy,
                   fieldwork-adapter-deploy,
                   notify-processor-deploy,
@@ -1929,7 +1929,7 @@ jobs:
                   case-api-deploy,
                   case-processor-deploy,
                   uac-qid-service-deploy,
-                  pubsub-deploy,
+                  pubsub-adapter-deploy,
                   print-file-service-deploy,
                   fieldwork-adapter-deploy,
                   notify-processor-deploy,
@@ -1967,7 +1967,7 @@ jobs:
                   case-api-deploy,
                   case-processor-deploy,
                   uac-qid-service-deploy,
-                  pubsub-deploy,
+                  pubsub-adapter-deploy,
                   print-file-service-deploy,
                   fieldwork-adapter-deploy,
                   notify-processor-deploy,
@@ -2200,10 +2200,10 @@ jobs:
       docker-image-resource: uac-qid-service-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
-- name: "CI Deploy PubSub Service"
+- name: "CI Deploy PubSub Adapter"
   serial: true
   serial_groups: [pubsub-adapter-build,
-                  pubsub-deploy]
+                  pubsub-adapter-deploy]
   plan:
   - get: census-rm-terraform
     trigger: true
@@ -2657,7 +2657,7 @@ jobs:
                   uac-qid-service-build,
                   uac-qid-service-deploy,
                   pubsub-adapter-build,
-                  pubsub-deploy,
+                  pubsub-adapter-deploy,
                   print-file-service-build,
                   print-file-service-deploy,
                   fieldwork-adapter-build,
@@ -2681,7 +2681,7 @@ jobs:
              "CI Deploy Case-API",
              "CI Deploy Case-Processor",
              "CI Deploy UAC QID Service",
-             "CI Deploy PubSub Service",
+             "CI Deploy PubSub Adapter",
              "CI Deploy Print File Service",
              "CI Deploy Fieldwork Adapter",
              "CI Deploy Notify Processor",
@@ -2705,7 +2705,7 @@ jobs:
              "CI Deploy Case-API",
              "CI Deploy Case-Processor",
              "CI Deploy UAC QID Service",
-             "CI Deploy PubSub Service",
+             "CI Deploy PubSub Adapter",
              "CI Deploy Print File Service",
              "CI Deploy Fieldwork Adapter",
              "CI Deploy Notify Processor",
@@ -2718,7 +2718,7 @@ jobs:
              "CI Deploy Case-API",
              "CI Deploy Case-Processor",
              "CI Deploy UAC QID Service",
-             "CI Deploy PubSub Service",
+             "CI Deploy PubSub Adapter",
              "CI Deploy Print File Service",
              "CI Deploy Fieldwork Adapter",
              "CI Deploy Notify Processor",
@@ -2749,7 +2749,7 @@ jobs:
     passed: ["CI Deploy UAC QID Service"]
   - get: pubsub-adapter
     trigger: true
-    passed: ["CI Deploy PubSub Service"]
+    passed: ["CI Deploy PubSub Adapter"]
   - get: qid-batch-runner-master
     trigger: true
   - get: print-file-service-master
@@ -2796,7 +2796,7 @@ jobs:
                   wl-case-api,
                   wl-case-processor,
                   wl-uac-qid-service,
-                  wl-pubsub,
+                  wl-pubsub-adapter,
                   wl-print-file-service,
                   wl-fieldwork-adapter,
                   wl-notify-processor,
@@ -2831,7 +2831,7 @@ jobs:
                   wl-case-api,
                   wl-case-processor,
                   wl-uac-qid-service,
-                  wl-pubsub,
+                  wl-pubsub-adapter,
                   wl-print-file-service,
                   wl-fieldwork-adapter,
                   wl-notify-processor,
@@ -2868,7 +2868,7 @@ jobs:
                   wl-case-api,
                   wl-case-processor,
                   wl-uac-qid-service,
-                  wl-pubsub,
+                  wl-pubsub-adapter,
                   wl-print-file-service,
                   wl-fieldwork-adapter,
                   wl-notify-processor,
@@ -2904,7 +2904,7 @@ jobs:
                   wl-case-api,
                   wl-case-processor,
                   wl-uac-qid-service,
-                  wl-pubsub,
+                  wl-pubsub-adapter,
                   wl-print-file-service,
                   wl-fieldwork-adapter,
                   wl-notify-processor,
@@ -3176,7 +3176,7 @@ jobs:
       docker-image-resource: uac-qid-service-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-microservices-repo}
 
-- name: "WL Deploy PubSub Service"
+- name: "WL Deploy PubSub Adapter"
   serial: true
   serial_groups: [wl-pubsubsvc]
   plan:

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2231,10 +2231,10 @@ jobs:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((ci-gcp-project-name))
       KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: pubsubsvc
-      KUBERNETES_SELECTOR: app=pubsubsvc
+      KUBERNETES_DEPLOYMENT_NAME: pubsub-adapter
+      KUBERNETES_SELECTOR: app=pubsub-adapter
       KUBERNETES_FILE_PATH: kubernetes-repo/microservices
-      KUBERNETES_FILE_PREFIX: pubsub
+      KUBERNETES_FILE_PREFIX: pubsub-adapter
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
       docker-image-resource: pubsub-adapter-docker-image-gcr,
@@ -3207,10 +3207,10 @@ jobs:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((wl-gcp-project-name))
       KUBERNETES_CLUSTER: ((wl-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: pubsubsvc
-      KUBERNETES_SELECTOR: app=pubsubsvc
+      KUBERNETES_DEPLOYMENT_NAME: pubsub-adapter
+      KUBERNETES_SELECTOR: app=pubsub-adapter
       KUBERNETES_FILE_PATH: kubernetes-repo/microservices
-      KUBERNETES_FILE_PREFIX: pubsub
+      KUBERNETES_FILE_PREFIX: pubsub-adapter
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
       docker-image-resource: pubsub-adapter-docker-image-gcr,


### PR DESCRIPTION
# Motivation and Context
Changing the deployment of pubsub service to the new one in the CI and the WhiteLodge environments.

# What has changed
The concourse definition file responsible for the deployments. We have already built the docker images - this change is about deploying the new docker image.

Also we are not deleting the old images yet. That will be done in another card.

# How to test?
Test this by
- watching the CI pipeline run
- ensure the acceptance tests execute
- check that the new pubsub adapter service is being used - not the old one
- check in white lodge that new pubsub adapter being used
