### PR TITLE
Pinning the concourse-pipeline-resource to 2.2.0

### DIFF
--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -1,9 +1,12 @@
 resource_types:
 
+  # Recent release 3.0.0 needs the fly version to be 6.1.0 to work. Ours is currently 5.6.0 so we need to pin the resource 
+  # to a previous release instead of using the latest image.
   - name: concourse-pipeline
     type: docker-image
     source:
       repository: concourse/concourse-pipeline-resource
+      tag: 2.2.0
 
   - name: slack-notification
     type: docker-image


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `concourse-pipeline` resource got a new release which expects the fly version to be 6.1.0. We're currently on 5.6.0 so we need to pin the version to previous release to hopefully get it to work.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Pinned concourse-pipeline resource to 2.2.0

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Fly and the resource should work.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/b/yarvSxGu/)
