### PR TITLE
Added new pubsub service to performance pipeline.

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -3178,7 +3178,7 @@ jobs:
 
 - name: "WL Deploy PubSub Adapter"
   serial: true
-  serial_groups: [wl-pubsubsvc]
+  serial_groups: [wl-pubsub-adapter]
   plan:
   - get: census-rm-terraform
     trigger: true

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -410,7 +410,7 @@ jobs:
     fieldwork-adapter,
     notify-processor,
     uac-qid-service,
-    pubsub-adaptersvc,
+    pubsub-adapter,
     print-file-service,
     exception-manager,
     toolbox,
@@ -439,7 +439,7 @@ jobs:
                   fieldwork-adapter,
                   notify-processor,
                   uac-qid-service,
-                  pubsub-adaptersvc,
+                  pubsub-adapter,
                   print-file-service,
                   exception-manager,
                   toolbox,
@@ -473,7 +473,7 @@ jobs:
     fieldwork-adapter,
     notify-processor,
     uac-qid-service,
-    pubsub-adaptersvc,
+    pubsub-adapter,
     print-file-service,
     exception-manager,
     toolbox,
@@ -546,7 +546,7 @@ jobs:
                   fieldwork-adapter,
                   notify-processor,
                   uac-qid-service,
-                  pubsub-adaptersvc,
+                  pubsub-adapter,
                   print-file-service,
                   exception-manager,
                   toolbox,
@@ -584,7 +584,7 @@ jobs:
                   fieldwork-adapter,
                   notify-processor,
                   uac-qid-service,
-                  pubsub-adaptersvc,
+                  pubsub-adapter,
                   print-file-service,
                   exception-manager,
                   toolbox,
@@ -733,7 +733,7 @@ jobs:
 - name: "PubSub Adapter Service"
   disable_manual_trigger: true
   serial: true
-  serial_groups: [pubsub-adaptersvc]
+  serial_groups: [pubsub-adapter]
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
@@ -943,7 +943,7 @@ jobs:
     fieldwork-adapter,
     notify-processor,
     uac-qid-service,
-    pubsub-adaptersvc,
+    pubsub-adapter,
     print-file-service,
     exception-manager,
     toolbox,
@@ -1028,7 +1028,7 @@ jobs:
     fieldwork-adapter,
     notify-processor,
     uac-qid-service,
-    pubsub-adaptersvc,
+    pubsub-adapter,
     print-file-service,
     exception-manager,
     toolbox,
@@ -1066,7 +1066,7 @@ jobs:
     fieldwork-adapter,
     notify-processor,
     uac-qid-service,
-    pubsub-adaptersvc,
+    pubsub-adapter,
     print-file-service,
     exception-manager,
     toolbox,

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -372,7 +372,7 @@ jobs:
 
               echo "\"@case-receipt-test\"" | gsutil cp - gs://census-rm-performance-sample-files/target-scenario-tag.txt || true
 
-- name: "Select Test - PubSub"
+- name: "Select Test - PubSub Adapter"
   plan:
   - task: "Select test scenario"
     config:
@@ -410,7 +410,7 @@ jobs:
     fieldwork-adapter,
     notify-processor,
     uac-qid-service,
-    pubsubsvc,
+    pubsub-adaptersvc,
     print-file-service,
     exception-manager,
     toolbox,
@@ -439,7 +439,7 @@ jobs:
                   fieldwork-adapter,
                   notify-processor,
                   uac-qid-service,
-                  pubsubsvc,
+                  pubsub-adaptersvc,
                   print-file-service,
                   exception-manager,
                   toolbox,
@@ -473,7 +473,7 @@ jobs:
     fieldwork-adapter,
     notify-processor,
     uac-qid-service,
-    pubsubsvc,
+    pubsub-adaptersvc,
     print-file-service,
     exception-manager,
     toolbox,
@@ -546,7 +546,7 @@ jobs:
                   fieldwork-adapter,
                   notify-processor,
                   uac-qid-service,
-                  pubsubsvc,
+                  pubsub-adaptersvc,
                   print-file-service,
                   exception-manager,
                   toolbox,
@@ -584,7 +584,7 @@ jobs:
                   fieldwork-adapter,
                   notify-processor,
                   uac-qid-service,
-                  pubsubsvc,
+                  pubsub-adaptersvc,
                   print-file-service,
                   exception-manager,
                   toolbox,
@@ -730,10 +730,10 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
-- name: "PubSub Service"
+- name: "PubSub Adapter Service"
   disable_manual_trigger: true
   serial: true
-  serial_groups: [pubsubsvc]
+  serial_groups: [pubsub-adaptersvc]
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
@@ -748,10 +748,10 @@ jobs:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
       KUBERNETES_CLUSTER: ((performance-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: pubsubsvc
-      KUBERNETES_SELECTOR: app=pubsubsvc
+      KUBERNETES_DEPLOYMENT_NAME: pubsub-adapter
+      KUBERNETES_SELECTOR: app=pubsub-adapter
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
-      KUBERNETES_FILE_PREFIX: pubsub
+      KUBERNETES_FILE_PREFIX: pubsub-adapter
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
@@ -943,7 +943,7 @@ jobs:
     fieldwork-adapter,
     notify-processor,
     uac-qid-service,
-    pubsubsvc,
+    pubsub-adaptersvc,
     print-file-service,
     exception-manager,
     toolbox,
@@ -962,7 +962,7 @@ jobs:
       "Case API",
       "Case Processor",
       "UAC QID Service",
-      "PubSub Service",
+      "PubSub Adapter Service",
       "Print File Service",
       "Fieldwork Adapter",
       "Notify Processor",
@@ -1028,7 +1028,7 @@ jobs:
     fieldwork-adapter,
     notify-processor,
     uac-qid-service,
-    pubsubsvc,
+    pubsub-adaptersvc,
     print-file-service,
     exception-manager,
     toolbox,
@@ -1066,7 +1066,7 @@ jobs:
     fieldwork-adapter,
     notify-processor,
     uac-qid-service,
-    pubsubsvc,
+    pubsub-adaptersvc,
     print-file-service,
     exception-manager,
     toolbox,

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -730,7 +730,7 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
 
-- name: "PubSub Adapter Service"
+- name: "PubSub Adapter"
   disable_manual_trigger: true
   serial: true
   serial_groups: [pubsub-adapter]
@@ -962,7 +962,7 @@ jobs:
       "Case API",
       "Case Processor",
       "UAC QID Service",
-      "PubSub Adapter Service",
+      "PubSub Adapter",
       "Print File Service",
       "Fieldwork Adapter",
       "Notify Processor",


### PR DESCRIPTION
# Motivation and Context
Adding the new pubsub service to the performance test pipeloine.

# What has changed
The naming of the performance tests. The more significant changes are in the kubernetes repo which has the queue definitions.

# How to test?
Run the performance test pipeline in gcloud and view the grafana dashboard for anomalies and compare the results to what is tentatively expected.
