### PR TITLE
Regression tests to run on schedule, exclude from other AT runs

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2735,11 +2735,9 @@ jobs:
   - get: action-scheduler-master
     trigger: true
     passed: ["CI Deploy Action-Scheduler"]
-    params:
   - get: action-worker-master
     trigger: true
     passed: ["CI Deploy Action-Worker"]
-    params:
   - get: case-api-master
     trigger: true
     passed: ["CI Deploy Case-API"]
@@ -2825,10 +2823,8 @@ jobs:
     passed: ["CI Reset DB"]
   - get: action-scheduler-master
     passed: ["CI Deploy Action-Scheduler"]
-    params:
   - get: action-worker-master
     passed: ["CI Deploy Action-Worker"]
-    params:
   - get: case-api-master
     passed: ["CI Deploy Case-API"]
   - get: case-processor-master

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -45,6 +45,7 @@ groups:
   - "CI Deploy Rabbit Monitor"
   - "CI Deploy Regional Counts"
   - "CI Acceptance Tests"
+  - "CI Nightly Regression ATs"
   - "WL Terraform"
   - "WL Monitoring"
   - "WL Helm"
@@ -115,6 +116,7 @@ groups:
   - "CI Deploy Rabbit Monitor"
   - "CI Deploy Regional Counts"
   - "CI Acceptance Tests"
+  - "CI Nightly Regression ATs"
 
 - name: "Whitelodge"
   jobs:
@@ -2785,6 +2787,55 @@ jobs:
       BATCH_RUNNER_CONFIG: batch-runner-repo/qid-batch-runner.yml
     input_mapping: {acceptance-tests-repo: acceptance-tests-master,
                     batch-runner-repo: qid-batch-runner-master}
+
+- name: "CI Nightly Regression ATs"
+  serial: true
+  serial_groups: [ci-deploy-infrastructure,
+                  ci-acceptance-tests,
+                  action-scheduler-build,
+                  action-scheduler-deploy,
+                  action-worker-build,
+                  action-worker-deploy,
+                  case-api-build,
+                  case-api-deploy,
+                  case-processor-build,
+                  case-processor-deploy,
+                  uac-qid-service-build,
+                  uac-qid-service-deploy,
+                  pubsub-adapter-build,
+                  pubsub-adapter-deploy,
+                  print-file-service-build,
+                  print-file-service-deploy,
+                  fieldwork-adapter-build,
+                  fieldwork-adapter-deploy,
+                  notify-processor-build,
+                  notify-processor-deploy,
+                  notify-stub-build,
+                  notify-stub-deploy,
+                  exception-manager-build,
+                  exception-manager-deploy,
+                  toolbox-build,
+                  toolbox-deploy,
+                  database-monitor-deploy,
+                  rabbitmonitor-deploy,
+                  regional-counts-deploy]
+  plan:
+  - get: every-midnight
+    trigger: true
+    passed: ["CI Reset DB"]
+  - task: "Run Regression Acceptance Tests (in K8s)"
+    file: acceptance-tests-master/tasks/kubectl-run-regression-acceptance-tests.yml
+    on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((ci-gcp-project-name))
+      KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
+      ACCEPTANCE_TESTS_IMAGE: ((acceptance-tests-image))
+      BATCH_RUNNER_CONFIG: batch-runner-repo/qid-batch-runner.yml
+    input_mapping: {acceptance-tests-repo: acceptance-tests-master,
+                    batch-runner-repo: qid-batch-runner-master}
+
 
 # WL Terraform
 - name: "WL Terraform"

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2823,6 +2823,36 @@ jobs:
   - get: every-midnight
     trigger: true
     passed: ["CI Reset DB"]
+  - get: action-scheduler-master
+    passed: ["CI Deploy Action-Scheduler"]
+    params:
+  - get: action-worker-master
+    passed: ["CI Deploy Action-Worker"]
+    params:
+  - get: case-api-master
+    passed: ["CI Deploy Case-API"]
+  - get: case-processor-master
+    passed: ["CI Deploy Case-Processor"]
+  - get: uac-qid-service-master
+    passed: ["CI Deploy UAC QID Service"]
+  - get: pubsub-adapter
+    passed: ["CI Deploy PubSub Adapter"]
+  - get: qid-batch-runner-master
+  - get: print-file-service-master
+    passed: ["CI Deploy Print File Service"]
+  - get: fieldwork-adapter-master
+    passed: ["CI Deploy Fieldwork Adapter"]
+  - get: notify-processor-master
+    passed: ["CI Deploy Notify Processor"]
+  - get: notify-stub-master
+    passed: ["CI Deploy Notify Stub"]
+  - get: exception-manager-master
+    passed: ["CI Deploy Exception Manager"]
+  - get: toolbox-master
+    passed: ["CI Deploy Toolbox",
+             "CI Deploy Database Monitor",
+             "CI Deploy Rabbit Monitor",
+             "CI Deploy Regional Counts"]
   - task: "Run Regression Acceptance Tests (in K8s)"
     file: acceptance-tests-master/tasks/kubectl-run-regression-acceptance-tests.yml
     on_failure: *slack_failure_alert_ci
@@ -2835,7 +2865,6 @@ jobs:
       BATCH_RUNNER_CONFIG: batch-runner-repo/qid-batch-runner.yml
     input_mapping: {acceptance-tests-repo: acceptance-tests-master,
                     batch-runner-repo: qid-batch-runner-master}
-
 
 # WL Terraform
 - name: "WL Terraform"


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Moving forward we want to add a lot more examples in the acceptance tests, e.g. all the fulfilment codes. These will, however, take a long time to run and don't necessarily need to be run on every merge, just need to be run ~once a day and whenever we manually trigger this larger suite of tests.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Job added to run [ATs with regression](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/257) tests nightly, after the `CI reset DB` job runs at midnight.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Fly the pipeline. You can see where it sits in the pipeline (right of `CI reset DB`) by looking at `hughs-test` on the sandbox concourse.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/3UCxauc3/954-tag-tests-and-add-regression-test-job-to-ci-8
# Screenshots (if appropriate):