### PR TITLE
Removal of Master Branch for K8s and Terraform Resources

### DIFF
--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -103,7 +103,6 @@ resources:
     owner: ONSdigital
     repository: census-rm-terraform
     access_token: ((github.access_token))
-    branch: *
 
 - name: census-rm-kubernetes-release
   type: github-release
@@ -111,7 +110,6 @@ resources:
     owner: ONSdigital
     repository: census-rm-kubernetes
     access_token: ((github.access_token))
-    branch: *
 
 - name: whitelist-master
   type: git

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -90,6 +90,7 @@ resources:
   source:
     uri: git@github.com:ONSdigital/census-rm-deploy.git
     private_key: ((github.service_account_private_key))
+    tag_filter: v*.*.*
 
 - name: census-rm-terraform-release
   type: git
@@ -97,7 +98,6 @@ resources:
     uri: git@github.com:ONSdigital/census-rm-terraform.git
     private_key: ((github.service_account_private_key))
     tag_filter: v*.*.*
-    branch: master
 
 - name: census-rm-kubernetes-release
   type: git
@@ -106,13 +106,13 @@ resources:
     private_key: ((github.service_account_private_key))
     paths: [release/*]
     tag_filter: v*.*.*
-    branch: master
 
 - name: whitelist-master
   type: git
   source:
     uri: git@github.com:ONSdigital/census-rm-whitelist.git
     private_key: ((github.service_account_private_key))
+    tag_filter: v*.*.*
 
 - name: every-minute
   type: time

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -90,7 +90,6 @@ resources:
   source:
     uri: git@github.com:ONSdigital/census-rm-deploy.git
     private_key: ((github.service_account_private_key))
-    tag_filter: v*.*.*
 
 - name: census-rm-terraform-release
   type: git
@@ -98,6 +97,7 @@ resources:
     uri: git@github.com:ONSdigital/census-rm-terraform.git
     private_key: ((github.service_account_private_key))
     tag_filter: v*.*.*
+    branch: .*
 
 - name: census-rm-kubernetes-release
   type: git
@@ -106,13 +106,13 @@ resources:
     private_key: ((github.service_account_private_key))
     paths: [release/*]
     tag_filter: v*.*.*
+    branch: .*
 
 - name: whitelist-master
   type: git
   source:
     uri: git@github.com:ONSdigital/census-rm-whitelist.git
     private_key: ((github.service_account_private_key))
-    tag_filter: v*.*.*
 
 - name: every-minute
   type: time

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -97,7 +97,7 @@ resources:
     uri: git@github.com:ONSdigital/census-rm-terraform.git
     private_key: ((github.service_account_private_key))
     tag_filter: v*.*.*
-    branch: .*
+    branch: *
 
 - name: census-rm-kubernetes-release
   type: git
@@ -106,7 +106,7 @@ resources:
     private_key: ((github.service_account_private_key))
     paths: [release/*]
     tag_filter: v*.*.*
-    branch: .*
+    branch: *
 
 - name: whitelist-master
   type: git

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -92,7 +92,7 @@ resources:
     private_key: ((github.service_account_private_key))
 
 - name: census-rm-terraform-release
-  type: git
+  type: github-release
   source:
     uri: git@github.com:ONSdigital/census-rm-terraform.git
     private_key: ((github.service_account_private_key))
@@ -100,7 +100,7 @@ resources:
     branch: *
 
 - name: census-rm-kubernetes-release
-  type: git
+  type: github-release
   source:
     uri: git@github.com:ONSdigital/census-rm-kubernetes.git
     private_key: ((github.service_account_private_key))

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -37,12 +37,12 @@ resources:
     password: ((gcp.service_account_json))
 
 - name: census-rm-terraform
-  type: github-release
+  type: git
   source:
-    owner: ONSdigital
-    repository: census-rm-terraform
-    access_token: ((github.access_token))
     branch: perf-resource-workaround # TO DO: use github release resource when this temporary branch is finished (remove branch option)
+    uri: git@github.com:ONSdigital/census-rm-terraform.git
+    private_key: ((github.service_account_private_key))
+    tag_filter: v*.*.*
 
 - name: census-rm-kubernetes-dependencies-repo
   type: git

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -42,7 +42,7 @@ resources:
     owner: ONSdigital
     repository: census-rm-terraform
     access_token: ((github.access_token))
-    branch: perf-resource-workaround
+    branch: perf-resource-workaround # TO DO: use github release resource when this temporary branch is finished (remove branch option)
 
 - name: census-rm-kubernetes-dependencies-repo
   type: git
@@ -59,8 +59,8 @@ resources:
     private_key: ((github.service_account_private_key))
     paths: [release/monitoring/*, grafana-dashboards/*, setup-monitoring.sh]
     tag_filter: v*.*.*
-    
-- name: census-rm-kubernetes-release	
+
+- name: census-rm-kubernetes-release
   type: github-release
   source:
     owner: ONSdigital
@@ -1176,7 +1176,7 @@ jobs:
             kubectl delete pvc data-rabbitmq-0
             kubectl delete pvc data-rabbitmq-1
             kubectl delete pvc data-rabbitmq-2
-            
+
   - task: "Remove node-pools"
     config:
       platform: linux
@@ -1200,7 +1200,7 @@ jobs:
             # Use gcloud service account to configure kubectl
             gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
             gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
-            
+
             # Legacy workaround for 403 access denied when doing node pool work
             gcloud services enable container.googleapis.com --project ${GCP_PROJECT_NAME}
             gcloud config set container/use_client_certificate True --project ${GCP_PROJECT_NAME}

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -66,7 +66,6 @@ resources:
     owner: ONSdigital
     repository: census-rm-kubernetes
     access_token: ((github.access_token))
-    branch: *
 
 templating:
 

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -42,7 +42,6 @@ resources:
     branch: perf-resource-workaround # TO DO: use github release resource when this temporary branch is finished (remove branch option)
     uri: git@github.com:ONSdigital/census-rm-terraform.git
     private_key: ((github.service_account_private_key))
-    tag_filter: v*.*.*
 
 - name: census-rm-kubernetes-dependencies-repo
   type: git

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -37,9 +37,9 @@ resources:
     password: ((gcp.service_account_json))
 
 - name: census-rm-terraform
-  type: git
+  type: github-release
   source:
-    branch: ((terraform-branch))
+    branch: *
     uri: git@github.com:ONSdigital/census-rm-terraform.git
     private_key: ((github.service_account_private_key))
     tag_filter: v*.*.*
@@ -61,12 +61,12 @@ resources:
     tag_filter: v*.*.*
     
 - name: census-rm-kubernetes-release	
-  type: git	
+  type: github-release
   source:
     uri: git@github.com:ONSdigital/census-rm-kubernetes.git	
     private_key: ((github.service_account_private_key))	
     paths: [release/*]
-    branch: master
+    branch: *
     tag_filter: v*.*.*
 
 templating:


### PR DESCRIPTION
# Motivation and Context
Currently, you can only pin releases of terraform and kubernetes that have been tagged off the master branch
This is no good for hot fixes, where you may want to tag and release from a non-master branch

# What has changed
Followed layout from https://github.com/concourse/github-release-resource
Removed branch option except for one in performance pipeline that @davidmort created

# Links
https://trello.com/c/mY5FrHcv/1007-bl-pipeline-remove-master-branch-tag-for-k8s-and-terraform-resources-3