### PR TITLE
Preview Changes Before Terraform

### DIFF
--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -22,6 +22,7 @@ groups:
   - "Regional Counts"
   - "Report Deployment Success"
   - "Trigger Terraform"
+  - "Preview Terraform Changes"
   - "Run Terraform"
   - "Run Helm"
   - "Deploy Monitoring"
@@ -778,6 +779,33 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
     - get: every-minute
+
+- name: "Preview Terraform Changes"
+  serial: true
+  serial_groups: [action-scheduler,
+                  action-worker,
+                  case-api,
+                  case-processor,
+                  fieldwork-adapter,
+                  notify-processor,
+                  uac-qid-service,
+                  pubsub-adapter,
+                  print-file-service,
+                  exception-manager,
+                  toolbox,
+                  rabbitmonitor]
+  plan:
+    - get: census-rm-terraform-release
+    - get: census-rm-deploy
+    - task: "Preview Terraform Changes"
+      file: census-rm-deploy/tasks/preview-changes-terraform-env.yml
+      params:
+        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+        ENV: ((gcp-environment-name))
+        VAR_FILE: ./tfvars/((gcp-project-name)).tfvars
+        KUBERNETES_CLUSTER: rm-k8s-cluster
+      input_mapping: {census-rm-terraform: census-rm-terraform-release}
+
 
 - name: "Run Terraform"
   disable_manual_trigger: true

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -33,6 +33,7 @@ groups:
 - name: "Infrastructure"
   jobs:
   - "Trigger Terraform"
+  - "Preview Terraform Changes"
   - "Run Terraform"
   - "Run Helm"
   - "Deploy Monitoring"

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -781,19 +781,6 @@ jobs:
     - get: every-minute
 
 - name: "Preview Terraform Changes"
-  serial: true
-  serial_groups: [action-scheduler,
-                  action-worker,
-                  case-api,
-                  case-processor,
-                  fieldwork-adapter,
-                  notify-processor,
-                  uac-qid-service,
-                  pubsub-adapter,
-                  print-file-service,
-                  exception-manager,
-                  toolbox,
-                  rabbitmonitor]
   plan:
     - get: census-rm-terraform-release
     - get: census-rm-deploy

--- a/tasks/preview-changes-terraform-env.yml
+++ b/tasks/preview-changes-terraform-env.yml
@@ -1,0 +1,35 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: google/cloud-sdk
+params:
+  ENV:
+  ADMIN_SERVICE_ACCOUNT_JSON:
+  VAR_FILE:
+  KUBERNETES_CLUSTER:
+inputs:
+  - name: census-rm-terraform
+run:
+  path: bash
+  args:
+    - -exc
+    - |
+      export GOOGLE_APPLICATION_CREDENTIALS=/root/gcloud-service-key.json
+      export GCP_PROJECT=census-rm-$ENV
+      apt-get install -y unzip
+      git clone https://github.com/kamatama41/tfenv.git ~/.tfenv
+      ln -s /root/.tfenv/bin/* /usr/local/bin
+      cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
+      $ADMIN_SERVICE_ACCOUNT_JSON
+      EOL
+      gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+      gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT}
+      cd census-rm-terraform
+      tfenv install
+
+      set +x
+      echo "db_user_password = \"$(kubectl get secret db-credentials -o=jsonpath='{.data.password}' | base64 --decode)\"" >> secret.tfvars
+      set -x
+
+      SECRETS_VAR_FILE=./secret.tfvars ./preview_changes.sh


### PR DESCRIPTION
# Motivation and Context
New job to allow us to see what changes will be integrated before they happen

# What has changed
New job to preview changes
New task

# How to test?
Merge and check that the job runs when activated

# Links
https://trello.com/c/cE2BcGFu/886-add-a-job-to-the-release-pipelines-to-run-a-terraform-plan-so-we-can-preview-the-exact-terraform-changes-before-deployments-3