### PR TITLE
point the perf terraform resource to point at the perf-resource-workaround branch

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -39,10 +39,9 @@ resources:
 - name: census-rm-terraform
   type: git
   source:
-    branch: ((terraform-branch))
+    branch: perf-resource-workaround
     uri: git@github.com:ONSdigital/census-rm-terraform.git
     private_key: ((github.service_account_private_key))
-    tag_filter: v*.*.*
     
 - name: census-rm-kubernetes-dependencies-repo
   type: git


### PR DESCRIPTION
# Motivation and Context
we're currently experiencing some zonal resource issues in our perf environment so we need to explore some workarounds

# What has changed
change the terraform git resource of the perf env to point at the perf-resource-workaround branch instead of master releases