### PR TITLE
CI DB Reset Scale Down/Up of Processor Apps

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2,7 +2,7 @@
 groups:
 - name: "Overview"
   jobs:
-  - "CI Reset DB"
+  - "CI Reset Apps and DB"
   - "Build Acceptance Tests Latest"
   - "Build Action Scheduler Latest"
   - "Build Action Worker Latest"
@@ -101,7 +101,7 @@ groups:
 - name: "CI"
   jobs:
   - "CI Terraform"
-  - "CI Reset DB"
+  - "CI Reset Apps and DB"
   - "CI Monitoring"
   - "CI Helm"
   - "CI Apply Database Patches"
@@ -1910,7 +1910,7 @@ jobs:
       skip_download: true
 
 # Run DB Teardown
-- name: "CI Reset DB"
+- name: "CI Reset Apps and DB"
   on_failure: *slack_failure_alert_ci
   on_error: *slack_error_alert_ci
   plan:
@@ -1919,7 +1919,7 @@ jobs:
   - get: census-rm-kubernetes-optional-repo
   - get: census-rm-deploy
   - task: "Run ground zero"
-    file: census-rm-deploy/tasks/kubectl-run-groundzero-script.yml
+    file: census-rm-deploy/tasks/kubectl-run-scale-down-reset-DB-scale-up-script.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
@@ -2991,7 +2991,7 @@ jobs:
   plan:
   - get: every-midnight
     trigger: true
-    passed: ["CI Reset DB"]
+    passed: ["CI Reset Apps and DB"]
   - get: acceptance-tests-master
     passed: ["Build Acceptance Tests Latest"]
   - get: acceptance-tests-docker-image-gcr

--- a/tasks/kubectl-run-scale-down-reset-DB-scale-up-script.yml
+++ b/tasks/kubectl-run-scale-down-reset-DB-scale-up-script.yml
@@ -1,0 +1,52 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-gcr/gcloud-kubectl
+
+params:
+  GCP_PROJECT_NAME:
+  KUBERNETES_CLUSTER:
+  KUBERNETES_FILE_PATH:
+  SERVICE_ACCOUNT_JSON:
+  WAIT_UNTIL_AVAILABLE_TIMEOUT:
+
+inputs:
+  - name: kubernetes-repo
+run:
+  path: sh
+  args:
+    - -exc
+    - |
+      cat >~/gcloud-service-key.json <<EOL
+      $SERVICE_ACCOUNT_JSON
+      EOL
+
+      # Use gcloud service account to configure kubectl
+      gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+      gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
+
+      # Scale down apps
+      kubectl scale deployment action-worker --replicas=0
+      kubectl scale deployment case-processor --replicas=0
+      kubectl scale deployment notify-processor --replicas=0
+
+      # Wipe and rebuild database
+      kubectl apply -f ${KUBERNETES_FILE_PATH}/census-rm-ddl-pod.yml --record
+      kubectl wait --for=condition=Ready pod/census-rm-ddl --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT}
+
+      kubectl exec $(kubectl get pods --selector=app=census-rm-ddl -o jsonpath='{.items[*].metadata.name}') -- /bin/bash groundzero_ddl/rebuild_from_ground_zero.sh
+
+      # Tidy up pod
+      kubectl delete pod census-rm-ddl || true
+
+      # Scale up apps
+      kubectl scale deployment action-worker --replicas=1
+      kubectl scale deployment case-processor --replicas=1
+      kubectl scale deployment notify-processor --replicas=1
+
+      # Wait for rollout to finish
+      kubectl rollout status deploy action-worker --watch=true --timeout=400s
+      kubectl rollout status deploy case-processor --watch=true --timeout=200s
+      kubectl rollout status deploy notify-processor --watch=true --timeout=200s


### PR DESCRIPTION
# Motivation and Context
We are seeing problems with ATs re-using QIDs because the case processor cache is not being wiped out after a DB reset

# What has changed
New kubectl task to run scale down/DB reset/scale up

# How to test?
Run ./validate-pipelines.sh
Deploy and pray

# Links
https://trello.com/c/T05SE924/1094-ci-reset-db-needs-to-stop-restart-processes-5
