### PR TITLE
Update README instructions for logging into fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,10 @@ Expect that all files in the pipelines folder reportedly look good.
 
 
 #### How to fly manually
-To access fly locally, you'll now need to access it through a bastion.  Run the following at the start of a session then log into your Google account when prompted:
+To access Concourse via a proxy, follow the instructions [here](https://github.com/ONSdigital/census-terraform/blob/master/DEVELOPERS.md#using-fly-with-the-proxy).
+
+Login to fly:
 ```bash
-gcloud compute start-iap-tunnel bastion 8118 --local-host-port=localhost:8118 --project census-ci --zone europe-west2-a
-```
-Then in a new window:
-```bash
-export HTTPS_PROXY=localhost:8118
 fly login -t <target> -c <concourse URL> --team-name <team name>
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,12 @@ Expect that all files in the pipelines folder reportedly look good.
 #### How to fly manually
 To access fly locally, you'll now need to access it through a bastion.  Run the following at the start of a session then log into your Google account when prompted:
 ```bash
-gcloud compute ssh bastion --project census-ci --zone europe-west2-a -- -D 1080 -f -N
-export HTTPS_PROXY=socks5://localhost:1080
+gcloud compute start-iap-tunnel bastion 8118 --local-host-port=localhost:8118 --project census-ci --zone europe-west2-a
+```
+Then in a new window:
+```bash
+export HTTPS_PROXY=localhost:8118
+fly login -t <target> -c <concourse URL> --team-name <team name>
 ```
 
 Run the fly command:


### PR DESCRIPTION
# Motivation and Context
Old method of logging into fly will be taken out of support this week (according to CATD) so this updates the instructions to make sure we're using the latest command.

# What has changed
Amended instructions for logging into fly

# How to test?
Check you can log in and see teams and pipelines.  No need to fly anything, just check you can still log in.
