### PR TITLE
Unpack release resources

### DIFF
--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -296,10 +296,10 @@ jobs:
     trigger: true
     passed: ["Trigger Deployment"]
   - get: census-rm-deploy
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
-    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}     
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-database-patches
     file: census-rm-deploy/tasks/kubectl-apply-ddl-patches.yml
     params:
@@ -324,7 +324,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked} 
@@ -355,7 +355,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -386,7 +386,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -417,7 +417,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -448,7 +448,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -479,7 +479,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -510,7 +510,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -541,7 +541,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}   
@@ -572,7 +572,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -603,7 +603,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -634,7 +634,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -665,7 +665,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -696,7 +696,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -727,7 +727,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -758,7 +758,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -789,7 +789,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -820,7 +820,7 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -287,6 +287,7 @@ jobs:
                   database-monitor,
                   rabbitmonitor,
                   regionalcounts]
+  on_failure: *slack_failure_alert
   plan:
   - get: every-minute
     trigger: true
@@ -295,21 +296,26 @@ jobs:
     trigger: true
     passed: ["Trigger Deployment"]
   - get: census-rm-deploy
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}     
   - task: apply-database-patches
     file: census-rm-deploy/tasks/kubectl-apply-ddl-patches.yml
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
       KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Action Scheduler"
   disable_manual_trigger: true
   serial: true
   serial_groups: [action-scheduler]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -318,10 +324,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked} 
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -331,12 +339,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: action-scheduler
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Action Worker"
   disable_manual_trigger: true
   serial: true
   serial_groups: [action-worker]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -345,10 +355,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -358,12 +370,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: action-worker
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Action Processor"
   disable_manual_trigger: true
   serial: true
   serial_groups: [action-processor]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -372,10 +386,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -385,12 +401,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: action-processor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Case API"
   disable_manual_trigger: true
   serial: true
   serial_groups: [case-api]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -399,10 +417,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -412,12 +432,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: case-api
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Case Processor"
   disable_manual_trigger: true
   serial: true
   serial_groups: [case-processor]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -426,10 +448,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -439,12 +463,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: case-processor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "UAC QID Service"
   disable_manual_trigger: true
   serial: true
   serial_groups: [uac-qid-service]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -453,10 +479,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -466,12 +494,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: uac-qid-service
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "PubSub Adapter"
   disable_manual_trigger: true
   serial: true
   serial_groups: [pubsub-adapter]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -480,10 +510,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -493,12 +525,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: pubsub-adapter
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Ops Tool"
   disable_manual_trigger: true
   serial: true
   serial_groups: [ops]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -507,10 +541,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}   
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -520,12 +556,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       KUBERNETES_FILE_PREFIX: ops
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Print File Service"
   disable_manual_trigger: true
   serial: true
   serial_groups: [print-file-service]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -534,10 +572,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -547,12 +587,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: print-file-service
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Fieldwork Adapter"
   disable_manual_trigger: true
   serial: true
   serial_groups: [fieldwork-adapter]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -561,10 +603,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -574,12 +618,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: fieldwork-adapter
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Notify Processor"
   disable_manual_trigger: true
   serial: true
   serial_groups: [notify-processor]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -588,10 +634,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -601,12 +649,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: notify-processor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "QID Batch Runner"
   disable_manual_trigger: true
   serial: true
   serial_groups: [qid-batch-runner]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -615,10 +665,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -628,12 +680,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       KUBERNETES_FILE_PREFIX: qid-batch-runner
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Exception Manager"
   disable_manual_trigger: true
   serial: true
   serial_groups: [exception-manager]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -642,10 +696,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -655,12 +711,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: exception-manager
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Toolbox"
   disable_manual_trigger: true
   serial: true
   serial_groups: [toolbox]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -669,10 +727,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -682,12 +742,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       KUBERNETES_FILE_PREFIX: census-rm-toolbox
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Database Monitor"
   disable_manual_trigger: true
   serial: true
   serial_groups: [database-monitor]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -696,10 +758,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -709,12 +773,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       KUBERNETES_FILE_PREFIX: database-monitor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Rabbit Monitor"
   disable_manual_trigger: true
   serial: true
   serial_groups: [rabbitmonitor]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -723,10 +789,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -736,12 +804,14 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       KUBERNETES_FILE_PREFIX: rabbitmonitor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Regional Counts"
   disable_manual_trigger: true
   serial: true
   serial_groups: [regionalcounts]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
     trigger: true
@@ -750,10 +820,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Apply Database Patches"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_error: *slack_error_alert
-    on_failure: *slack_failure_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -763,7 +835,7 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       KUBERNETES_FILE_PREFIX: regional-counts
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Report Deployment Success"
   disable_manual_trigger: true
@@ -813,16 +885,20 @@ jobs:
 
 - name: "Preview Terraform Changes"
   plan:
-    - get: census-rm-terraform-release
-    - get: census-rm-deploy
-    - task: "Preview Terraform Changes"
-      file: census-rm-deploy/tasks/preview-changes-terraform-env.yml
-      params:
-        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-        ENV: ((gcp-environment-name))
-        VAR_FILE: ./tfvars/((gcp-project-name)).tfvars
-        KUBERNETES_CLUSTER: rm-k8s-cluster
-      input_mapping: {census-rm-terraform: census-rm-terraform-release}
+  - get: census-rm-terraform-release
+  - get: census-rm-deploy
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-terraform-release}
+    output_mapping: {unpacked-release: census-rm-terraform-release-unpacked}
+  - task: "Preview Terraform Changes"
+    file: census-rm-deploy/tasks/preview-changes-terraform-env.yml
+    params:
+      ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      ENV: ((gcp-environment-name))
+      VAR_FILE: ./tfvars/((gcp-project-name)).tfvars
+      KUBERNETES_CLUSTER: rm-k8s-cluster
+    input_mapping: {census-rm-terraform: census-rm-terraform-release-unpacked}
 
 
 - name: "Run Terraform"
@@ -844,19 +920,22 @@ jobs:
   on_error: *slack_error_alert
   on_failure: *slack_failure_alert
   plan:
-    - get: every-minute
-      trigger: true
-      passed: ["Trigger Terraform"]
-    - get: census-rm-terraform-release
-    - get: census-rm-deploy
-    - task: "Run Terraform"
-      file: census-rm-deploy/tasks/terraform-env.yml
-      params:
-        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-        ENV: ((gcp-environment-name))
-        VAR_FILE: ./tfvars/((gcp-project-name)).tfvars
-        KUBERNETES_CLUSTER: rm-k8s-cluster
-      input_mapping: {census-rm-terraform: census-rm-terraform-release}
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger Terraform"]
+  - get: census-rm-terraform-release
+  - get: census-rm-deploy
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-terraform-release}
+    output_mapping: {unpacked-release: census-rm-terraform-release-unpacked} 
+  - task: "Run Terraform"
+    file: census-rm-deploy/tasks/terraform-env.yml
+    params:
+      ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      ENV: ((gcp-environment-name))
+      VAR_FILE: ./tfvars/((gcp-project-name)).tfvars
+      KUBERNETES_CLUSTER: rm-k8s-cluster
 
 - name: "Run Helm"
   disable_manual_trigger: true
@@ -877,19 +956,28 @@ jobs:
   on_error: *slack_error_alert
   on_failure: *slack_failure_alert
   plan:
-    - get: every-minute
-      trigger: true
-      passed: ["Run Terraform"]
-    - get: census-rm-kubernetes-release
-    - get: census-rm-deploy
-    - task: "Run Helm"
-      file: census-rm-deploy/tasks/helm.yml
-      params:
-        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-        ENV: ((gcp-environment-name))
-        KUBERNETES_CLUSTER: rm-k8s-cluster
-        RABBITMQ_CONFIG_VALUES_FILE: ((rabbit-config))
-      input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release}
+  - get: every-minute
+    trigger: true
+    passed: ["Run Terraform"]
+  - get: census-rm-kubernetes-release
+  - get: census-rm-deploy
+  - task: unpack-terraform-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-terraform-release}
+    output_mapping: {unpacked-release: census-rm-terraform-release-unpacked}
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-terraform-kubernetes-unpacked}
+  - task: "Run Helm"
+    file: census-rm-deploy/tasks/helm.yml
+    params:
+      ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      ENV: ((gcp-environment-name))
+      KUBERNETES_CLUSTER: rm-k8s-cluster
+      RABBITMQ_CONFIG_VALUES_FILE: ((rabbit-config))
+    input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release-unpacked}
+    input_mapping: {census-rm-terraform: census-rm-terraform-release-unpacked}
 
 - name: "Deploy Monitoring"
   serial: true
@@ -914,6 +1002,10 @@ jobs:
       passed: ["Run Helm"]
     - get: census-rm-kubernetes-release
     - get: census-rm-deploy
+    - task: unpack-release
+      file: census-rm-deploy/tasks/unpack-release.yml
+      input_mapping: {release: census-rm-kubernetes-release}
+      output_mapping: {unpacked-release: census-rm-terraform-kubernetes-unpacked}
     - task: "Deploy Monitoring"
       file: census-rm-deploy/tasks/monitoring.yml
       params:
@@ -923,11 +1015,12 @@ jobs:
         RABBITMQ_CONFIG_VALUES_FILE: ((rabbit-config))
         PROMETHEUS_CONFIG_VALUES_FILE: ((prometheus-config))
         GRAFANA_CONFIG_VALUES_FILE: ((grafana-config))
-      input_mapping: {census-rm-kubernetes-monitoring-repo: census-rm-kubernetes-release}
+      input_mapping: {census-rm-kubernetes-monitoring-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Report Terraform Success"
   disable_manual_trigger: true
   serial: true
+  on_success: *slack_success_alert
   plan:
   - get: every-minute
     trigger: true
@@ -937,6 +1030,8 @@ jobs:
 
 - name: "Whitelist"
   serial: true
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: every-minute
     trigger: true
@@ -953,8 +1048,6 @@ jobs:
   - get: census-rm-deploy
   - task: apply-whitelist
     file: census-rm-deploy/tasks/whitelist-env.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -965,6 +1058,8 @@ jobs:
 
 - name: "Whitelist Nightly"
   serial: true
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: every-midnight
     trigger: true
@@ -972,8 +1067,6 @@ jobs:
   - get: census-rm-deploy
   - task: apply-whitelist
     file: census-rm-deploy/tasks/whitelist-env.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -487,6 +487,10 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Run Terraform"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-terraform-kubernetes-unpacked}
   - task: "Scale down apps"
     config:
       platform: linux
@@ -526,7 +530,7 @@ jobs:
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 
   on_failure: *slack_performance_setup_failure
@@ -612,16 +616,20 @@ jobs:
   disable_manual_trigger: true
   serial: true
   serial_groups: [action-scheduler]
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-terraform-kubernetes-unpacked}
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -631,22 +639,26 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: action-scheduler
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Action Worker"
   disable_manual_trigger: true
   serial: true
   serial_groups: [action-worker]
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-terraform-kubernetes-unpacked}
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -656,22 +668,26 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: action-worker
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Action Processor"
   disable_manual_trigger: true
   serial: true
   serial_groups: [action-processor]
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -681,22 +697,26 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: action-processor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Case API"
   disable_manual_trigger: true
   serial: true
   serial_groups: [case-api]
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -706,22 +726,26 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: case-api
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Case Processor"
   disable_manual_trigger: true
   serial: true
   serial_groups: [case-processor]
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -731,22 +755,26 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: case-processor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "UAC QID Service"
   disable_manual_trigger: true
   serial: true
   serial_groups: [uac-qid-service]
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -756,22 +784,26 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: uac-qid-service
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "PubSub Adapter"
   disable_manual_trigger: true
   serial: true
   serial_groups: [pubsub-adapter]
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -781,22 +813,26 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: pubsub-adapter
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Print File Service"
   disable_manual_trigger: true
   serial: true
   serial_groups: [print-file-service]
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -806,22 +842,26 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: print-file-service
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Fieldwork Adapter"
   disable_manual_trigger: true
   serial: true
   serial_groups: [fieldwork-adapter]
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -831,22 +871,26 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: fieldwork-adapter
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Notify Processor"
   disable_manual_trigger: true
   serial: true
   serial_groups: [notify-processor]
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -856,22 +900,26 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: notify-processor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Exception Manager"
   disable_manual_trigger: true
   serial: true
   serial_groups: [exception-manager]
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -881,22 +929,26 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: exception-manager
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Toolbox"
   disable_manual_trigger: true
   serial: true
   serial_groups: [toolbox]
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -906,22 +958,26 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       KUBERNETES_FILE_PREFIX: census-rm-toolbox
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Database Monitor"
   disable_manual_trigger: true
   serial: true
   serial_groups: [database-monitor]
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -931,22 +987,26 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       KUBERNETES_FILE_PREFIX: database-monitor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Rabbit Monitor"
   disable_manual_trigger: true
   serial: true
   serial_groups: [rabbitmonitor]
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
+  - task: unpack-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-deployment
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
-    on_failure: *slack_failure_alert
-    on_error: *slack_error_alert
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -956,7 +1016,7 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       KUBERNETES_FILE_PREFIX: rabbitmonitor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {kubernetes-repo: census-rm-kubernetes-release}
+    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Scale Up Apps"
   disable_manual_trigger: true

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -668,7 +668,7 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: action-worker
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Action Processor"
   disable_manual_trigger: true
@@ -697,7 +697,7 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: action-processor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Case API"
   disable_manual_trigger: true
@@ -726,7 +726,7 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: case-api
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Case Processor"
   disable_manual_trigger: true
@@ -755,7 +755,7 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: case-processor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "UAC QID Service"
   disable_manual_trigger: true
@@ -784,7 +784,7 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: uac-qid-service
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "PubSub Adapter"
   disable_manual_trigger: true
@@ -813,7 +813,7 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: pubsub-adapter
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Print File Service"
   disable_manual_trigger: true
@@ -842,7 +842,7 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: print-file-service
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Fieldwork Adapter"
   disable_manual_trigger: true
@@ -871,7 +871,7 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: fieldwork-adapter
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Notify Processor"
   disable_manual_trigger: true
@@ -900,7 +900,7 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: notify-processor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Exception Manager"
   disable_manual_trigger: true
@@ -929,7 +929,7 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
       KUBERNETES_FILE_PREFIX: exception-manager
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Toolbox"
   disable_manual_trigger: true
@@ -958,7 +958,7 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       KUBERNETES_FILE_PREFIX: census-rm-toolbox
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Database Monitor"
   disable_manual_trigger: true
@@ -987,7 +987,7 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       KUBERNETES_FILE_PREFIX: database-monitor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Rabbit Monitor"
   disable_manual_trigger: true
@@ -1016,7 +1016,7 @@ jobs:
       KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
       KUBERNETES_FILE_PREFIX: rabbitmonitor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Scale Up Apps"
   disable_manual_trigger: true

--- a/tasks/unpack-release.yml
+++ b/tasks/unpack-release.yml
@@ -1,0 +1,10 @@
+
+platform: linux
+image_resource:
+type: docker-image
+source: {repository:  alpine}
+inputs: [name: release]
+outputs: [name: unpacked-release]
+run:
+path: bash
+args: [-c, tar -xvf release/*.tar.gz -C unpacked-release --strip-components=1]


### PR DESCRIPTION
# Motivation and Context
Turns out the github release resource only provides the release assets, not the repo itself, so we need to unpack the release anywhere we want to use the source.

# What has changed
* Add unpack release task yml
* Unpack releases anywhere the source is used

# How to test?
Give it the old "Stare and hope you spot anything wrong with it"

# Links
https://trello.com/c/gcD0LwRL/1114-concourse-pipeline-doesnt-clone-git-repos-correctly-since-change-to-use-github-release-resource-type