### PR TITLE
change the perf terraform task to db certs dont get re-created

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -451,7 +451,7 @@ jobs:
     - get: census-rm-terraform
     - get: census-rm-deploy
     - task: "Run Terraform"
-      file: census-rm-deploy/tasks/terraform-db-ssl-create-env.yml
+      file: census-rm-deploy/tasks/terraform-env.yml
       params:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: performance


### PR DESCRIPTION
# Motivation and Context
the gcloud db ssl cert creation gets stuck in the perf concourse pipeline because it waits for a y/n input

# What has changed
point to terraform task so db certs creation doesn't execute