### PR TITLE
Fix unpacking task script format

### DIFF
--- a/tasks/unpack-release.yml
+++ b/tasks/unpack-release.yml
@@ -10,4 +10,7 @@ outputs:
   name: unpacked-release
 run:
   path: bash
-  args: [-c, tar -xvf release/*.tar.gz -C unpacked-release --strip-components=1]
+  args: 
+    - -exc
+    - |
+      tar -xvf release/*.tar.gz -C unpacked-release --strip-components=1]

--- a/tasks/unpack-release.yml
+++ b/tasks/unpack-release.yml
@@ -13,4 +13,4 @@ run:
   args: 
     - -exc
     - |
-      tar -xvf release/*.tar.gz -C unpacked-release --strip-components=1]
+      tar -xvf release/*.tar.gz -C unpacked-release --strip-components=1


### PR DESCRIPTION
# Motivation and Context
The task format wasn't correct.

# What has changed
* Fix task format

# How to test?
Check against task spec

# Links
https://trello.com/c/gcD0LwRL/1114-concourse-pipeline-doesnt-clone-git-repos-correctly-since-change-to-use-github-release-resource-type