### PR TITLE
Further unpack release job fixes

### DIFF
--- a/tasks/unpack-release.yml
+++ b/tasks/unpack-release.yml
@@ -5,9 +5,9 @@ image_resource:
   source: 
     repository: alpine
 inputs: 
-  name: release
+  - name: release
 outputs: 
-  name: unpacked-release
+  - name: unpacked-release
 run:
   path: bash
   args: 


### PR DESCRIPTION
# Motivation and Context
Hopefully solve the error unmarshalling issue

# What has changed
* It didn't quite match the spec, the input output names must be in sub objects 

# How to test?
Validate with your eyes

# Links
https://trello.com/c/gcD0LwRL/1114-concourse-pipeline-doesnt-clone-git-repos-correctly-since-change-to-use-github-release-resource-type