### PR TITLE
Amend bash to sh for use in alpine

### DIFF
--- a/tasks/unpack-release.yml
+++ b/tasks/unpack-release.yml
@@ -9,7 +9,7 @@ inputs:
 outputs: 
   - name: unpacked-release
 run:
-  path: bash
+  path: sh
   args: 
     - -exc
     - |


### PR DESCRIPTION
# Motivation and Context
Alpine linux doesn't have bash, use sh

# What has changed
* use sh instead of bash

# Links
https://trello.com/c/gcD0LwRL/1114-concourse-pipeline-doesnt-clone-git-repos-correctly-since-change-to-use-github-release-resource-type