### PR TITLE
Attempt to stop concourse breaking the command with quotes

### DIFF
--- a/tasks/unpack-release.yml
+++ b/tasks/unpack-release.yml
@@ -12,5 +12,4 @@ run:
   path: sh
   args: 
     - -exc
-    - |
-      tar -xvf release/*.tar.gz -C unpacked-release --strip-components=1
+    - tar -xvf release/*.tar.gz -C unpacked-release --strip-components=1


### PR DESCRIPTION
# Motivation and Context
For some reason concourse is turning `tar -xvf release/*.tar.gz -C unpacked-release --strip-components=1` into `tar -xvf 'release/*.tar.gz' -C unpacked-release '--strip-components=1'` which breaks the globbing. Hopefully removing the unnecessary multi-lining will stop this.

# What has changed
* Remove unnecessary string multi-lining

# How to test?
I have tested the tar command locally, it works fine. It just needs concourse not to break the glob pattern.

# Links
https://trello.com/c/gcD0LwRL/1114-concourse-pipeline-doesnt-clone-git-repos-correctly-since-change-to-use-github-release-resource-type