### PR TITLE
Include source tarballs on release resources

### DIFF
--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -293,6 +293,7 @@ jobs:
     trigger: true
     passed: ["Trigger Deployment"]
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Trigger Deployment"]
   - get: census-rm-deploy
@@ -318,6 +319,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: [ "Apply Database Patches"]
   - get: census-rm-deploy
@@ -349,6 +351,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -380,6 +383,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: [ "Apply Database Patches"]
   - get: census-rm-deploy
@@ -411,6 +415,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -442,6 +447,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -473,6 +479,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -504,6 +511,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -535,6 +543,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -566,6 +575,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -597,6 +607,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -628,6 +639,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -659,6 +671,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -690,6 +703,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -721,6 +735,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -752,6 +767,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -783,6 +799,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -814,6 +831,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -886,8 +904,9 @@ jobs:
 - name: "Preview Terraform Changes"
   plan:
   - get: census-rm-terraform-release
+    include_source_tarball: true
   - get: census-rm-deploy
-  - task: unpack-release
+  - task: unpack-terraform-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-terraform-release}
     output_mapping: {unpacked-release: census-rm-terraform-release-unpacked}
@@ -924,8 +943,9 @@ jobs:
     trigger: true
     passed: ["Trigger Terraform"]
   - get: census-rm-terraform-release
+    include_source_tarball: true
   - get: census-rm-deploy
-  - task: unpack-release
+  - task: unpack-terraform-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-terraform-release}
     output_mapping: {unpacked-release: census-rm-terraform-release-unpacked} 
@@ -960,11 +980,8 @@ jobs:
     trigger: true
     passed: ["Run Terraform"]
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: census-rm-deploy
-  - task: unpack-terraform-release
-    file: census-rm-deploy/tasks/unpack-release.yml
-    input_mapping: {release: census-rm-terraform-release}
-    output_mapping: {unpacked-release: census-rm-terraform-release-unpacked}
   - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
@@ -977,7 +994,6 @@ jobs:
       KUBERNETES_CLUSTER: rm-k8s-cluster
       RABBITMQ_CONFIG_VALUES_FILE: ((rabbit-config))
     input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release-unpacked}
-    input_mapping: {census-rm-terraform: census-rm-terraform-release-unpacked}
 
 - name: "Deploy Monitoring"
   serial: true
@@ -1001,8 +1017,9 @@ jobs:
       trigger: true
       passed: ["Run Helm"]
     - get: census-rm-kubernetes-release
+      include_source_tarball: true
     - get: census-rm-deploy
-    - task: unpack-release
+    - task: unpack-kubernetes-release
       file: census-rm-deploy/tasks/unpack-release.yml
       input_mapping: {release: census-rm-kubernetes-release}
       output_mapping: {unpacked-release: census-rm-terraform-kubernetes-unpacked}

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -484,6 +484,7 @@ jobs:
   - get: performance-tests-docker-image
   - get: census-rm-deploy
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: every-minute
     trigger: true
     passed: ["Run Terraform"]
@@ -620,6 +621,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
@@ -649,6 +651,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
@@ -678,11 +681,12 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -707,11 +711,12 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -736,11 +741,12 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -765,11 +771,12 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -794,11 +801,12 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -823,11 +831,12 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -852,11 +861,12 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -881,11 +891,12 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -910,11 +921,12 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -939,11 +951,12 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -968,11 +981,12 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
@@ -997,11 +1011,12 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
+    include_source_tarball: true
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
     passed: ["Run Helm"]
-  - task: unpack-release
+  - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}


### PR DESCRIPTION
# Motivation and Context
The option needs to be set to true otherwise the source tar is not included in the resource

# What has changed
* Include source tarballs on release resources
* Use consistent task naming

# Links
https://trello.com/c/gcD0LwRL/1114-concourse-pipeline-doesnt-clone-git-repos-correctly-since-change-to-use-github-release-resource-type