### PR TITLE
Put include source tarball in params, sort out so mismatches mappings

### DIFF
--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -293,7 +293,7 @@ jobs:
     trigger: true
     passed: ["Trigger Deployment"]
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Trigger Deployment"]
   - get: census-rm-deploy
@@ -319,7 +319,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: [ "Apply Database Patches"]
   - get: census-rm-deploy
@@ -351,7 +351,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -383,7 +383,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: [ "Apply Database Patches"]
   - get: census-rm-deploy
@@ -415,7 +415,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -447,7 +447,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -479,7 +479,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -511,7 +511,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -543,7 +543,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -575,7 +575,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -607,7 +607,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -639,7 +639,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -671,7 +671,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -703,7 +703,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -735,7 +735,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -767,7 +767,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -799,7 +799,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -831,7 +831,7 @@ jobs:
   on_failure: *slack_failure_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
     trigger: true
     passed: ["Apply Database Patches"]
   - get: census-rm-deploy
@@ -904,7 +904,7 @@ jobs:
 - name: "Preview Terraform Changes"
   plan:
   - get: census-rm-terraform-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - task: unpack-terraform-release
     file: census-rm-deploy/tasks/unpack-release.yml
@@ -943,7 +943,7 @@ jobs:
     trigger: true
     passed: ["Trigger Terraform"]
   - get: census-rm-terraform-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - task: unpack-terraform-release
     file: census-rm-deploy/tasks/unpack-release.yml
@@ -956,6 +956,7 @@ jobs:
       ENV: ((gcp-environment-name))
       VAR_FILE: ./tfvars/((gcp-project-name)).tfvars
       KUBERNETES_CLUSTER: rm-k8s-cluster
+    input_mapping: {census-rm-terraform: census-rm-terraform-release-unpacked}
 
 - name: "Run Helm"
   disable_manual_trigger: true
@@ -980,12 +981,12 @@ jobs:
     trigger: true
     passed: ["Run Terraform"]
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
-    output_mapping: {unpacked-release: census-rm-terraform-kubernetes-unpacked}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: "Run Helm"
     file: census-rm-deploy/tasks/helm.yml
     params:
@@ -1017,7 +1018,7 @@ jobs:
       trigger: true
       passed: ["Run Helm"]
     - get: census-rm-kubernetes-release
-      include_source_tarball: true
+      params: {include_source_tarball: true}
     - get: census-rm-deploy
     - task: unpack-kubernetes-release
       file: census-rm-deploy/tasks/unpack-release.yml

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -576,7 +576,7 @@ jobs:
       input_mapping: {census-rm-kubernetes-monitoring-repo: census-rm-kubernetes-monitoring-repo}
 
   # Run Helm
-- name: " "
+- name: "Run Helm"
   disable_manual_trigger: true
   serial: true
   on_failure: *slack_failure_alert

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -484,7 +484,7 @@ jobs:
   - get: performance-tests-docker-image
   - get: census-rm-deploy
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: every-minute
     trigger: true
     passed: ["Run Terraform"]
@@ -576,7 +576,7 @@ jobs:
       input_mapping: {census-rm-kubernetes-monitoring-repo: census-rm-kubernetes-monitoring-repo}
 
   # Run Helm
-- name: "Run Helm"
+- name: " "
   disable_manual_trigger: true
   serial: true
   on_failure: *slack_failure_alert
@@ -621,7 +621,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
@@ -651,7 +651,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
@@ -681,7 +681,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
@@ -711,7 +711,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
@@ -741,7 +741,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
@@ -771,7 +771,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
@@ -801,7 +801,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
@@ -831,7 +831,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
@@ -861,7 +861,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
@@ -891,7 +891,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
@@ -921,7 +921,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
@@ -951,7 +951,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
@@ -981,7 +981,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - get: every-minute
     trigger: true
@@ -1011,7 +1011,7 @@ jobs:
   on_error: *slack_error_alert
   plan:
   - get: census-rm-kubernetes-release
-    include_source_tarball: true
+    params: {include_source_tarball: true}
   - get: census-rm-deploy
   - get: every-minute
     trigger: true


### PR DESCRIPTION
# Motivation and Context
`include_source_tarball` is a params field

# What has changed
* Put include source tarball in params
* Sort out some mismatched mappings

# Links
https://trello.com/c/gcD0LwRL/1114-concourse-pipeline-doesnt-clone-git-repos-correctly-since-change-to-use-github-release-resource-type