### PR TITLE
Fix dodgy output/input mappings

### DIFF
--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -1023,7 +1023,7 @@ jobs:
     - task: unpack-kubernetes-release
       file: census-rm-deploy/tasks/unpack-release.yml
       input_mapping: {release: census-rm-kubernetes-release}
-      output_mapping: {unpacked-release: census-rm-terraform-kubernetes-unpacked}
+      output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
     - task: "Deploy Monitoring"
       file: census-rm-deploy/tasks/monitoring.yml
       params:

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -491,7 +491,7 @@ jobs:
   - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
-    output_mapping: {unpacked-release: census-rm-terraform-kubernetes-unpacked}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: "Scale down apps"
     config:
       platform: linux
@@ -629,7 +629,7 @@ jobs:
   - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
-    output_mapping: {unpacked-release: census-rm-terraform-kubernetes-unpacked}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
     params:
@@ -659,7 +659,7 @@ jobs:
   - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
-    output_mapping: {unpacked-release: census-rm-terraform-kubernetes-unpacked}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-service-and-deploy
     file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
     params:


### PR DESCRIPTION
# Motivation and Context
Fix dodgy output/input mappings

# What has changed
* Fix dodgy output/input mappings

# Links
https://trello.com/c/gcD0LwRL/1114-concourse-pipeline-doesnt-clone-git-repos-correctly-since-change-to-use-github-release-resource-type