### PR TITLE
Remove filtering on performance tests repo

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -26,7 +26,6 @@ resources:
   type: git
   source:
     uri: git@github.com:ONSdigital/census-rm-performance-tests.git
-    paths: [kubernetes.env, tasks/*]
     private_key: ((github.service_account_private_key))
 
 - name: performance-tests-docker-image


### PR DESCRIPTION
# Motivation and Context
Changes to many things in the performance tests were not being picked up by Concourse because of filtering of the git repo.

# What has changed
Removed the filtering.

# How to test?
Fly. Cross fingers.

# Links
Trello: https://trello.com/c/aUATjYjz