### PR TITLE
Block jobs in ci whitelodge better

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ If you'd like to deploy a pipeline to the RM Sandbox concourse:
 - To run terraform you'll need to whitelist the `census-rm-concourse` ip from the Cloud Nat section in GCP
 - You'll need to give the `census-rm-concourse` service account owner permission in your environment. This can be done in the IAM section in GCP.
 - A terraform branch will need to be created with a `.tfvars` file for the GCP project you're using. You then reference that branch in the secrets yaml with the `terraform-branch` secret.
-- For the CI/WL pipeline, you'll need a secrets file similar to the example CI/WL secrets. You'll have to change some of the `ENV` params in the pipeline itself to point towards your own project as they're hard-coded in the yaml. 
+- For the CI/WL pipeline, you'll need a secrets file similar to the example CI/WL secrets. You'll have to change some of the `ENV` params in the pipeline itself to point towards your own project as they're hard-coded in the yaml.

--- a/README.md
+++ b/README.md
@@ -87,3 +87,10 @@ Presently there are three tests which can be run, by running these selection job
 
  Once you have run one of the selection jobs, you can then run Trigger Selected Test to run the test.
 
+## RM sandbox environment
+If you'd like to deploy a pipeline to the RM Sandbox concourse:
+- You'll need to set your fly target to the sandbox environment e.g `fly login -t main -c <sandbox-url>`
+- To run terraform you'll need to whitelist the `census-rm-concourse` ip from the Cloud Nat section in GCP
+- You'll need to give the `census-rm-concourse` service account owner permission in your environment. This can be done in the IAM section in GCP.
+- A terraform branch will need to be created with a `.tfvars` file for the GCP project you're using. You then reference that branch in the secrets yaml with the `terraform-branch` secret.
+- For the CI/WL pipeline, you'll need a secrets file similar to the example CI/WL secrets. You'll have to change some of the `ENV` params in the pipeline itself to point towards your own project as they're hard-coded in the yaml.

--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ If you'd like to deploy a pipeline to the RM Sandbox concourse:
 - To run terraform you'll need to whitelist the `census-rm-concourse` ip from the Cloud Nat section in GCP
 - You'll need to give the `census-rm-concourse` service account owner permission in your environment. This can be done in the IAM section in GCP.
 - A terraform branch will need to be created with a `.tfvars` file for the GCP project you're using. You then reference that branch in the secrets yaml with the `terraform-branch` secret.
-- For the CI/WL pipeline, you'll need a secrets file similar to the example CI/WL secrets. You'll have to change some of the `ENV` params in the pipeline itself to point towards your own project as they're hard-coded in the yaml.
+- For the CI/WL pipeline, you'll need a secrets file similar to the example CI/WL secrets. You'll have to change some of the `ENV` params in the pipeline itself to point towards your own project as they're hard-coded in the yaml. 

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -1932,6 +1932,7 @@ jobs:
   serial: true
   serial_groups: [ci-terraform,
                   ci-acceptance-tests,
+                  acceptance-tests-build,
                   action-scheduler-build,
                   action-scheduler-deploy,
                   action-worker-build,
@@ -2108,6 +2109,9 @@ jobs:
   serial: true
   serial_groups: [ci-terraform,
                   ci-acceptance-tests,
+                  ci-helm,
+                  ci-patch,
+                  acceptance-tests-build,
                   ci-monitoring,
                   action-scheduler-build,
                   action-scheduler-deploy,
@@ -2207,6 +2211,9 @@ jobs:
   serial: true
   serial_groups: [ci-monitoring,
                   ci-acceptance-tests,
+                  ci-helm,
+                  ci-patch,
+                  acceptance-tests-build,
                   action-scheduler-build,
                   action-scheduler-deploy,
                   action-worker-build,
@@ -3044,6 +3051,8 @@ jobs:
   serial: true
   serial_groups: [ci-deploy-infrastructure,
                   ci-acceptance-tests,
+                  ci-helm,
+                  ci-patch,
                   action-scheduler-build,
                   action-scheduler-deploy,
                   action-processor-build,

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -3103,6 +3103,19 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Deploy Action-Scheduler",
+              "CI Deploy Action-Worker",
+              "CI Deploy Action-Processor",
+              "CI Deploy Case-API",
+              "CI Deploy Case-Processor",
+              "CI Deploy UAC QID Service",
+              "CI Deploy PubSub Adapter",
+              "CI Deploy Print File Service",
+              "CI Deploy Fieldwork Adapter",
+              "CI Deploy Notify Processor",
+              "CI Deploy Notify Stub",
+              "CI Deploy Exception Manager"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Deploy Action-Scheduler",
@@ -3305,6 +3318,15 @@ jobs:
   - get: census-rm-terraform
     trigger: true
     passed: ["CI Acceptance Tests"]
+  - get: census-rm-kubernetes-microservices-repo
+    trigger: true
+    passed: ["CI Acceptance Tests"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Acceptance Tests"]
+  - get: census-rm-kubernetes-optional-repo
+    trigger: true
+    passed: ["CI Acceptance Tests"]
   - get: action-scheduler-master
     passed: ["CI Acceptance Tests"]
     trigger: true
@@ -3417,7 +3439,13 @@ jobs:
   plan:
     - get: census-rm-kubernetes-dependencies-repo
       trigger: true
-      passed: ["CI Acceptance Tests"]
+      passed: ["WL Terraform"]
+    - get: census-rm-kubernetes-microservices-repo
+      trigger: true
+      passed: ["WL Terraform"]
+    - get: census-rm-kubernetes-optional-repo
+      trigger: true
+      passed: ["WL Terraform"]
     - get: census-rm-terraform
       passed: ["WL Terraform"]
       trigger: true
@@ -3493,52 +3521,60 @@ jobs:
   on_failure: *slack_failure_alert_wl
   on_error: *slack_error_alert_wl
   plan:
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["WL Helm"]
+  - get: census-rm-kubernetes-microservices-repo
+    trigger: true
+    passed: ["WL Helm"]
   - get: census-rm-kubernetes-optional-repo
+    trigger: true
+    passed: ["WL Helm"]
   - get: census-rm-deploy
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Acceptance Tests"]
   - get: census-rm-terraform
-    passed: ["WL Terraform"]
+    passed: ["WL Helm"]
     trigger: true
   - get: action-scheduler-master
-    passed: ["WL Terraform"]
+    passed: ["WL Helm"]
     trigger: true
   - get: action-worker-master
-    passed: ["WL Terraform"]
+    passed: ["WL Helm"]
     trigger: true
   - get: action-processor-master
-    passed: ["WL Terraform"]
+    passed: ["WL Helm"]
     trigger: true
   - get: case-api-master
-    passed: ["WL Terraform"]
+    passed: ["WL Helm"]
     trigger: true
   - get: case-processor-master
-    passed: ["WL Terraform"]
+    passed: ["WL Helm"]
     trigger: true
   - get: uac-qid-service-master
-    passed: ["WL Terraform"]
+    passed: ["WL Helm"]
     trigger: true
   - get: pubsub-adapter
-    passed: ["WL Terraform"]
+    passed: ["WL Helm"]
     trigger: true
   - get: print-file-service-master
-    passed: ["WL Terraform"]
+    passed: ["WL Helm"]
     trigger: true
   - get: fieldwork-adapter-master
-    passed: ["WL Terraform"]
+    passed: ["WL Helm"]
     trigger: true
   - get: notify-processor-master
-    passed: ["WL Terraform"]
+    passed: ["WL Helm"]
     trigger: true
   - get: notify-stub-master
-    passed: ["WL Terraform"]
+    passed: ["WL Helm"]
     trigger: true
   - get: exception-manager-master
-    passed: ["WL Terraform"]
+    passed: ["WL Helm"]
     trigger: true
   - get: toolbox-master
-    passed: ["WL Terraform"]
+    passed: ["WL Helm"]
     trigger: true
   - get: ddl-docker-image-gcr
     params:
@@ -3561,15 +3597,18 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
-    passed: ["WL Helm"]
+    trigger: true
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: action-scheduler-master
-    passed: ["WL Helm", "WL Apply Database Patches"]
+    passed: ["WL Apply Database Patches"]
     trigger: true
   - get: action-scheduler-docker-image-gcr
     params:
@@ -3598,15 +3637,18 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
-    passed: ["WL Helm"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-kubernetes-microservices-repo
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: action-worker-master
-    passed: ["WL Helm", "WL Apply Database Patches"]
+    passed: ["WL Apply Database Patches"]
     trigger: true
   - get: action-worker-docker-image-gcr
     params:
@@ -3635,16 +3677,19 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
-    passed: ["WL Helm"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-kubernetes-microservices-repo
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: action-processor-master
     trigger: true
-    passed: ["WL Helm", "WL Apply Database Patches"]
+    passed: ["WL Apply Database Patches"]
   - get: action-processor-docker-image-gcr
     params:
       skip_download: true
@@ -3672,15 +3717,18 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
-    passed: ["WL Helm"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-kubernetes-microservices-repo
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: print-file-service-master
-    passed: ["WL Helm", "WL Apply Database Patches"]
+    passed: ["WL Apply Database Patches"]
     trigger: true
   - get: print-file-service-docker-image-gcr
     params:
@@ -3709,15 +3757,18 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
-    passed: ["WL Helm"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-kubernetes-microservices-repo
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: case-api-master
-    passed: ["WL Helm", "WL Apply Database Patches"]
+    passed: ["WL Apply Database Patches"]
     trigger: true
   - get: case-api-docker-image-gcr
     params:
@@ -3746,15 +3797,18 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
-    passed: ["WL Helm"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-kubernetes-microservices-repo
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: case-processor-master
-    passed: ["WL Helm", "WL Apply Database Patches"]
+    passed: ["WL Apply Database Patches"]
     trigger: true
   - get: case-processor-docker-image-gcr
     params:
@@ -3783,15 +3837,18 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
-    passed: ["WL Helm"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-kubernetes-microservices-repo
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: uac-qid-service-master
-    passed: ["WL Helm", "WL Apply Database Patches"]
+    passed: ["WL Apply Database Patches"]
     trigger: true
   - get: uac-qid-service-docker-image-gcr
     params:
@@ -3820,15 +3877,18 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
-    passed: ["WL Helm"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-kubernetes-microservices-repo
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: pubsub-adapter
-    passed: ["WL Helm", "WL Apply Database Patches"]
+    passed: ["WL Apply Database Patches"]
     trigger: true
   - get: pubsub-adapter-docker-image-gcr
     params:
@@ -3857,13 +3917,14 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
-    passed: ["WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-ops-repo
   - get: ops-master
+    trigger: true
   - get: ops-docker-image-gcr
     params:
       skip_download: true
@@ -3891,15 +3952,18 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
-    passed: ["WL Helm"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-kubernetes-microservices-repo
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: fieldwork-adapter-master
-    passed: ["WL Helm", "WL Apply Database Patches"]
+    passed: ["WL Apply Database Patches"]
     trigger: true
   - get: fieldwork-adapter-docker-image-gcr
     params:
@@ -3928,15 +3992,18 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
-    passed: ["WL Helm"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-kubernetes-microservices-repo
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: notify-processor-master
-    passed: ["WL Helm", "WL Apply Database Patches"]
+    passed: ["WL Apply Database Patches"]
     trigger: true
   - get: notify-processor-docker-image-gcr
     params:
@@ -3965,15 +4032,18 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
-    passed: ["WL Helm"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-kubernetes-microservices-repo
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: exception-manager-master
-    passed: ["WL Helm", "WL Apply Database Patches"]
+    passed: ["WL Apply Database Patches"]
     trigger: true
   - get: exception-manager-docker-image-gcr
     params:
@@ -4002,15 +4072,18 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
-    passed: ["WL Helm"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-kubernetes-optional-repo
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: toolbox-master
-    passed: ["WL Helm", "WL Apply Database Patches"]
+    passed: ["WL Apply Database Patches"]
     trigger: true
   - get: toolbox-docker-image-gcr
     params:
@@ -4039,15 +4112,18 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
-    passed: ["WL Helm"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-kubernetes-optional-repo
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: toolbox-master
-    passed: ["WL Helm", "WL Apply Database Patches"]
+    passed: ["WL Apply Database Patches"]
     trigger: true
   - get: toolbox-docker-image-gcr
     params:
@@ -4076,15 +4152,18 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
-    passed: ["WL Helm"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: census-rm-kubernetes-optional-repo
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: toolbox-master
-    passed: ["WL Helm", "WL Apply Database Patches"]
+    passed: ["WL Apply Database Patches"]
     trigger: true
   - get: toolbox-docker-image-gcr
     params:
@@ -4113,15 +4192,16 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Apply Database Patches", "WL Helm"]
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
   - get: census-rm-ddl-master
     trigger: true
     passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Apply Database Patches"]
+    trigger: true
   - get: toolbox-master
-    passed: ["WL Helm", "WL Apply Database Patches"]
+    passed: ["WL Apply Database Patches"]
     trigger: true
   - get: toolbox-docker-image-gcr
     params:

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2067,9 +2067,7 @@ jobs:
 - name: "CI Monitoring"
   serial: true
   serial_groups: [ci-terraform,
-                  ci-helm,
                   ci-monitoring,
-                  ci-database-patches,
                   ci-acceptance-tests,
                   action-scheduler-deploy,
                   action-worker-deploy,

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -3371,8 +3371,8 @@ jobs:
     file: census-rm-deploy/tasks/terraform-env.yml
     params:
       ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      ENV: ryangrundy
-      VAR_FILE: ./tfvars/census-rm-ryangrundy.tfvars
+      ENV: whitelodge
+      VAR_FILE: ./tfvars/census-rm-whitelodge.tfvars
       KUBERNETES_CLUSTER: rm-k8s-cluster
     input_mapping: {census-rm-terraform: census-rm-terraform}
 

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -44,7 +44,6 @@ groups:
   - "CI Deploy Database Monitor"
   - "CI Deploy Rabbit Monitor"
   - "CI Deploy Regional Counts"
-  - "CI Deploy QID Batch Runner"
   - "CI Acceptance Tests"
   - "CI Nightly Regression ATs"
   - "WL Terraform"
@@ -66,7 +65,6 @@ groups:
   - "WL Deploy Database Monitor"
   - "WL Deploy Rabbit Monitor"
   - "WL Deploy Regional Counts"
-  - "WL Deploy QID Batch Runner"
   - "WL Whitelist"
   - "WL Whitelist Nightly"
 
@@ -117,7 +115,6 @@ groups:
   - "CI Deploy Database Monitor"
   - "CI Deploy Rabbit Monitor"
   - "CI Deploy Regional Counts"
-  - "CI Deploy QID Batch Runner"
   - "CI Acceptance Tests"
   - "CI Nightly Regression ATs"
 
@@ -142,7 +139,6 @@ groups:
   - "WL Deploy Database Monitor"
   - "WL Deploy Rabbit Monitor"
   - "WL Deploy Regional Counts"
-  - "WL Deploy QID Batch Runner"
   - "WL Whitelist"
   - "WL Whitelist Nightly"
 
@@ -1878,6 +1874,84 @@ jobs:
   - get: census-rm-terraform
     trigger: true
   - get: census-rm-deploy
+  - get: action-scheduler-master
+    trigger: true
+    passed: ["Build Action Scheduler Latest"]  
+  - get: action-worker-master
+    trigger: true
+    passed: ["Build Action Worker Latest"]
+  - get: action-worker-docker-image-gcr
+    params:
+      skip_download: true
+  - get: action-scheduler-docker-image-gcr
+    params:
+      skip_download: true
+  - get: case-api-master
+    trigger: true
+    passed: ["Build Case API Latest"]
+  - get: case-api-docker-image-gcr
+    params:
+      skip_download: true  
+  - get: case-processor-master
+    trigger: true
+    passed: ["Build Case Processor Latest"]
+  - get: case-processor-docker-image-gcr
+    params:
+      skip_download: true
+  - get: uac-qid-service-master
+    trigger: true
+    passed: ["Build UAC QID Service Latest"]
+  - get: uac-qid-service-docker-image-gcr
+    params:
+      skip_download: true
+  - get: pubsub-adapter
+    trigger: true
+    passed: ["Build PubSub Adapter Latest"]
+  - get: pubsub-adapter-docker-image-gcr
+    params:
+      skip_download: true
+  - get: ops-master
+    trigger: true
+    passed: ["Build Ops Latest"]
+  - get: ops-docker-image-gcr
+    params:
+      skip_download: true
+  - get: print-file-service-master
+    trigger: true
+    passed: ["Build Print File Service Latest"]
+  - get: print-file-service-docker-image-gcr
+    params:
+      skip_download: true
+  - get: fieldwork-adapter-master
+    trigger: true
+    passed: ["Build Fieldwork Adapter Latest"]
+  - get: fieldwork-adapter-docker-image-gcr
+    params:
+      skip_download: true
+  - get: notify-processor-master
+    trigger: true
+    passed: ["Build Notify Processor Latest"]
+  - get: notify-processor-docker-image-gcr
+    params:
+      skip_download: true
+  - get: notify-stub-master
+    trigger: true
+    passed: ["Build Notify Stub Latest"]
+  - get: notify-stub-docker-image-gcr
+    params:
+      skip_download: true
+  - get: exception-manager-master
+    trigger: true
+    passed: ["Build Exception Manager Latest"]
+  - get: exception-manager-docker-image-gcr
+    params:
+      skip_download: true
+  - get: toolbox-master
+    trigger: true
+    passed: ["Build Toolbox Latest"]
+  - get: toolbox-docker-image-gcr
+    params:
+      skip_download: true
   - task: "CI Terraform"
     file: census-rm-deploy/tasks/terraform-env.yml
     params:
@@ -1891,6 +1965,9 @@ jobs:
 - name: "CI Monitoring"
   serial: true
   serial_groups: [ci-terraform,
+                  ci-helm,
+                  ci-monitoring,
+                  ci-database-patches,
                   ci-acceptance-tests,
                   action-scheduler-deploy,
                   action-worker-deploy,
@@ -1915,6 +1992,7 @@ jobs:
     - get: census-rm-deploy
     - get: census-rm-terraform
       passed: ["CI Terraform"]
+      trigger: true
     - task: "CI Monitoring"
       file: census-rm-deploy/tasks/monitoring.yml
       params:
@@ -1930,6 +2008,9 @@ jobs:
   serial: true
   serial_groups: [ci-terraform,
                   ci-acceptance-tests,
+                  ci-helm,
+                  ci-monitoring,
+                  ci-database-patches,
                   action-scheduler-deploy,
                   action-worker-deploy,
                   case-api-deploy,
@@ -1953,6 +2034,7 @@ jobs:
     - get: census-rm-deploy
     - get: census-rm-terraform
       passed: ["CI Terraform"]
+      trigger: true
     - task: "CI Helm"
       file: census-rm-deploy/tasks/helm.yml
       params:
@@ -1967,6 +2049,9 @@ jobs:
 - name: "CI Apply Database Patches"
   serial: true
   serial_groups: [ci-database-patches,
+                  ci-helm,
+                  ci-monitoring,
+                  ci-database-patches,
                   ci-acceptance-tests,
                   action-scheduler-deploy,
                   action-worker-deploy,
@@ -2013,15 +2098,13 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: action-scheduler-master
-    trigger: true
-    passed: ["Build Action Scheduler Latest"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2053,7 +2136,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2063,8 +2146,6 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: action-worker-master
-    trigger: true
-    passed: ["Build Action Worker Latest"]
   - get: action-worker-docker-image-gcr
     params:
       skip_download: true
@@ -2093,7 +2174,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2103,8 +2184,6 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: case-api-master
-    trigger: true
-    passed: ["Build Case API Latest"]
   - get: case-api-docker-image-gcr
     params:
       skip_download: true
@@ -2133,7 +2212,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2143,8 +2222,6 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: case-processor-master
-    trigger: true
-    passed: ["Build Case Processor Latest"]
   - get: case-processor-docker-image-gcr
     params:
       skip_download: true
@@ -2173,7 +2250,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2183,8 +2260,6 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: uac-qid-service-master
-    trigger: true
-    passed: ["Build UAC QID Service Latest"]
   - get: uac-qid-service-docker-image-gcr
     params:
       skip_download: true
@@ -2213,7 +2288,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2223,8 +2298,6 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: pubsub-adapter
-    trigger: true
-    passed: ["Build PubSub Adapter Latest"]
   - get: pubsub-adapter-docker-image-gcr
     params:
       skip_download: true
@@ -2253,7 +2326,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2263,8 +2336,6 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: ops-master
-    trigger: true
-    passed: ["Build Ops Latest"]
   - get: ops-docker-image-gcr
     params:
       skip_download: true
@@ -2293,7 +2364,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2303,8 +2374,6 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: print-file-service-master
-    trigger: true
-    passed: ["Build Print File Service Latest"]
   - get: print-file-service-docker-image-gcr
     params:
       skip_download: true
@@ -2333,7 +2402,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2343,8 +2412,6 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: fieldwork-adapter-master
-    trigger: true
-    passed: ["Build Fieldwork Adapter Latest"]
   - get: fieldwork-adapter-docker-image-gcr
     params:
       skip_download: true
@@ -2373,7 +2440,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2383,8 +2450,6 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: notify-processor-master
-    trigger: true
-    passed: ["Build Notify Processor Latest"]
   - get: notify-processor-docker-image-gcr
     params:
       skip_download: true
@@ -2413,7 +2478,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2423,8 +2488,6 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: notify-stub-master
-    trigger: true
-    passed: ["Build Notify Stub Latest"]
   - get: notify-stub-docker-image-gcr
     params:
       skip_download: true
@@ -2453,7 +2516,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2463,8 +2526,6 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: exception-manager-master
-    trigger: true
-    passed: ["Build Exception Manager Latest"]
   - get: exception-manager-docker-image-gcr
     params:
       skip_download: true
@@ -2493,15 +2554,13 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
-    trigger: true
-    passed: ["Build Toolbox Latest"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2533,7 +2592,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2543,8 +2602,6 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: toolbox-master
-    trigger: true
-    passed: ["Build Toolbox Latest"]
   - get: toolbox-docker-image-gcr
     params:
       skip_download: true
@@ -2573,7 +2630,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2583,8 +2640,6 @@ jobs:
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
-    trigger: true
-    passed: ["Build Toolbox Latest"]
   - get: toolbox-docker-image-gcr
     params:
       skip_download: true
@@ -2613,7 +2668,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm","CI Monitoring"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2623,8 +2678,6 @@ jobs:
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
-    trigger: true
-    passed: ["Build Toolbox Latest"]
   - get: toolbox-docker-image-gcr
     params:
       skip_download: true
@@ -2646,45 +2699,6 @@ jobs:
       docker-image-resource: toolbox-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-optional-repo}
 
-- name: "CI Deploy QID Batch Runner"
-  serial: true
-  serial_groups: [qid-batch-runner-build,
-                  qid-batch-runner-deploy]
-  plan:
-  - get: census-rm-terraform
-    trigger: true
-    passed: ["CI Terraform"]
-  - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
-    passed: ["CI Helm"]
-  - get: census-rm-kubernetes-optional-repo
-    trigger: true
-  - get: qid-batch-runner-master
-    trigger: true
-    passed: ["Build QID Batch Runner Latest"]
-  - get: census-rm-ddl-master
-    trigger: true
-    passed: ["CI Apply Database Patches"]
-  - get: qid-batch-runner-docker-image-gcr
-    params:
-      skip_download: true
-  - get: census-rm-deploy
-  - task: apply-deployment
-    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
-    on_failure: *slack_failure_alert_ci
-    on_error: *slack_error_alert_ci
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((ci-gcp-project-name))
-      KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: qid-batch-runner
-      KUBERNETES_SELECTOR: app=qid-batch-runner
-      KUBERNETES_FILE_PATH: kubernetes-repo/optional
-      KUBERNETES_FILE_PREFIX: qid-batch-runner
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {
-      docker-image-resource: qid-batch-runner-docker-image-gcr,
-      kubernetes-repo: census-rm-kubernetes-optional-repo}
 
 
 - name: "CI Acceptance Tests"
@@ -2972,6 +2986,7 @@ jobs:
     - get: census-rm-deploy
     - get: census-rm-terraform
       passed: ["WL Terraform"]
+      trigger: true
     - task: "WL Monitoring"
       file: census-rm-deploy/tasks/monitoring.yml
       params:
@@ -3007,6 +3022,9 @@ jobs:
     - get: census-rm-kubernetes-dependencies-repo
       trigger: true
       passed: ["CI Acceptance Tests"]
+    - get: census-rm-terraform
+      passed: ["WL Terraform"]
+      trigger: true
     - get: census-rm-deploy
     - *slack_started_alert_wl
     - task: "WL Helm"
@@ -3045,6 +3063,9 @@ jobs:
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Acceptance Tests"]
+  - get: census-rm-terraform
+    passed: ["WL Terraform"]
+    trigger: true
   - get: ddl-docker-image-gcr
     params:
       skip_download: true
@@ -3066,18 +3087,14 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
     passed: ["WL Helm"]
   - get: census-rm-kubernetes-microservices-repo
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: census-rm-ddl-master
-    trigger: true
     passed: ["WL Apply Database Patches"]
   - get: action-scheduler-master
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: action-scheduler-docker-image-gcr
     params:
@@ -3106,18 +3123,14 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
     passed: ["WL Helm"]
   - get: census-rm-ddl-master
-    trigger: true
     passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: action-worker-master
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: action-worker-docker-image-gcr
     params:
@@ -3146,18 +3159,14 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
     passed: ["WL Helm"]
   - get: census-rm-kubernetes-microservices-repo
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: census-rm-ddl-master
-    trigger: true
     passed: ["WL Apply Database Patches"]
   - get: print-file-service-master
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: print-file-service-docker-image-gcr
     params:
@@ -3186,18 +3195,14 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
     passed: ["WL Helm"]
   - get: census-rm-kubernetes-microservices-repo
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: census-rm-ddl-master
-    trigger: true
     passed: ["WL Apply Database Patches"]
   - get: case-api-master
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: case-api-docker-image-gcr
     params:
@@ -3226,18 +3231,14 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
     passed: ["WL Helm"]
   - get: census-rm-ddl-master
-    trigger: true
     passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: case-processor-master
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: case-processor-docker-image-gcr
     params:
@@ -3266,18 +3267,14 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
     passed: ["WL Helm"]
   - get: census-rm-ddl-master
-    trigger: true
     passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: uac-qid-service-master
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: uac-qid-service-docker-image-gcr
     params:
@@ -3306,18 +3303,14 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
     passed: ["WL Helm"]
   - get: census-rm-ddl-master
-    trigger: true
     passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: pubsub-adapter
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: pubsub-adapter-docker-image-gcr
     params:
@@ -3346,17 +3339,13 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
     passed: ["WL Helm"]
   - get: census-rm-ddl-master
-    trigger: true
     passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-ops-repo
-    trigger: true
   - get: ops-master
-    trigger: true
   - get: ops-docker-image-gcr
     params:
       skip_download: true
@@ -3384,18 +3373,14 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
     passed: ["WL Helm"]
   - get: census-rm-ddl-master
-    trigger: true
     passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: fieldwork-adapter-master
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: fieldwork-adapter-docker-image-gcr
     params:
@@ -3424,18 +3409,14 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
     passed: ["WL Helm"]
   - get: census-rm-ddl-master
-    trigger: true
     passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: notify-processor-master
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: notify-processor-docker-image-gcr
     params:
@@ -3464,18 +3445,14 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
     passed: ["WL Helm"]
   - get: census-rm-ddl-master
-    trigger: true
     passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: exception-manager-master
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: exception-manager-docker-image-gcr
     params:
@@ -3504,18 +3481,14 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
     passed: ["WL Helm"]
   - get: census-rm-ddl-master
-    trigger: true
     passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: toolbox-master
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: toolbox-docker-image-gcr
     params:
@@ -3544,18 +3517,14 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
     passed: ["WL Helm"]
   - get: census-rm-ddl-master
-    trigger: true
     passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: toolbox-master
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: toolbox-docker-image-gcr
     params:
@@ -3584,18 +3553,14 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
     passed: ["WL Helm"]
   - get: census-rm-ddl-master
-    trigger: true
     passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: toolbox-master
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: toolbox-docker-image-gcr
     params:
@@ -3624,18 +3589,14 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
-    passed: ["WL Helm"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: toolbox-master
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: toolbox-docker-image-gcr
     params:
@@ -3656,46 +3617,6 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
       docker-image-resource: toolbox-docker-image-gcr,
-      kubernetes-repo: census-rm-kubernetes-optional-repo}
-
-- name: "WL Deploy QID Batch Runner"
-  serial: true
-  serial_groups: [wl-qid-batch-runner]
-  plan:
-  - get: census-rm-terraform
-    trigger: true
-    passed: ["WL Terraform"]
-  - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
-    passed: ["WL Helm"]
-  - get: census-rm-ddl-master
-    trigger: true
-    passed: ["WL Apply Database Patches"]
-  - get: census-rm-kubernetes-optional-repo
-    trigger: true
-    passed: ["CI Acceptance Tests"]
-  - get: qid-batch-runner-master
-    trigger: true
-    passed: ["CI Acceptance Tests"]
-  - get: qid-batch-runner-docker-image-gcr
-    params:
-      skip_download: true
-  - get: census-rm-deploy
-  - task: apply-deployment
-    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
-    on_failure: *slack_failure_alert_wl
-    on_error: *slack_error_alert_wl
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((wl-gcp-project-name))
-      KUBERNETES_CLUSTER: ((wl-kubernetes-cluster-name))
-      KUBERNETES_DEPLOYMENT_NAME: qid-batch-runner
-      KUBERNETES_SELECTOR: app=qid-batch-runner
-      KUBERNETES_FILE_PATH: kubernetes-repo/optional
-      KUBERNETES_FILE_PREFIX: qid-batch-runner
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
-    input_mapping: {
-      docker-image-resource: qid-batch-runner-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-optional-repo}
 
 - name: "WL Whitelist"

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -3412,7 +3412,6 @@ jobs:
     - get: census-rm-deploy
     - get: census-rm-terraform
       passed: ["WL Terraform"]
-      trigger: true
     - task: "WL Monitoring"
       file: census-rm-deploy/tasks/monitoring.yml
       params:

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -173,6 +173,11 @@ resources:
   source:
     url: ((slack.webhook))
 
+- name: every-minute
+  type: time
+  source:
+    interval: 1m
+
 - name: census-rm-deploy
   type: git
   source:
@@ -1928,18 +1933,33 @@ jobs:
   serial: true
   serial_groups: [ci-terraform,
                   ci-acceptance-tests,
+                  action-scheduler-build,
                   action-scheduler-deploy,
+                  action-worker-build,
                   action-worker-deploy,
+                  action-processor-build,
                   action-processor-deploy,
+                  case-api-build,
                   case-api-deploy,
+                  case-processor-build,
                   case-processor-deploy,
+                  uac-qid-service-build,
                   uac-qid-service-deploy,
+                  pubsub-adapter-build,
                   pubsub-adapter-deploy,
+                  print-file-service-build,
                   print-file-service-deploy,
+                  fieldwork-adapter-build,
                   fieldwork-adapter-deploy,
+                  notify-processor-build,
                   notify-processor-deploy,
+                  notify-stub-build,
                   notify-stub-deploy,
+                  ops-build,
+                  ops-deploy,
+                  exception-manager-build,
                   exception-manager-deploy,
+                  toolbox-build,
                   toolbox-deploy,
                   database-monitor-deploy,
                   rabbitmonitor-deploy,
@@ -1953,10 +1973,16 @@ jobs:
   - get: census-rm-deploy
   - get: action-scheduler-master
     trigger: true
-    passed: ["Build Action Scheduler Latest"]  
+    passed: ["Build Action Scheduler Latest"]
   - get: action-worker-master
     trigger: true
     passed: ["Build Action Worker Latest"]
+  - get: action-processor-master
+    trigger: true
+    passed: ["Build Action Processor Latest"]
+  - get: action-processor-docker-image-gcr
+    params:
+      skip_download: true
   - get: action-worker-docker-image-gcr
     params:
       skip_download: true
@@ -1985,12 +2011,6 @@ jobs:
     trigger: true
     passed: ["Build PubSub Adapter Latest"]
   - get: pubsub-adapter-docker-image-gcr
-    params:
-      skip_download: true
-  - get: ops-master
-    trigger: true
-    passed: ["Build Ops Latest"]
-  - get: ops-docker-image-gcr
     params:
       skip_download: true
   - get: print-file-service-master
@@ -2084,21 +2104,32 @@ jobs:
   serial: true
   serial_groups: [ci-terraform,
                   ci-acceptance-tests,
-                  ci-helm,
                   ci-monitoring,
-                  ci-database-patches,
+                  action-scheduler-build,
                   action-scheduler-deploy,
+                  action-worker-build,
                   action-worker-deploy,
+                  action-processor-build,
                   action-processor-deploy,
+                  case-api-build,
                   case-api-deploy,
+                  case-processor-build,
                   case-processor-deploy,
+                  uac-qid-service-build,
                   uac-qid-service-deploy,
+                  pubsub-adapter-build,
                   pubsub-adapter-deploy,
+                  print-file-service-build,
                   print-file-service-deploy,
+                  fieldwork-adapter-build,
                   fieldwork-adapter-deploy,
+                  notify-processor-build,
                   notify-processor-deploy,
+                  notify-stub-build,
                   notify-stub-deploy,
+                  exception-manager-build,
                   exception-manager-deploy,
+                  toolbox-build,
                   toolbox-deploy,
                   database-monitor-deploy,
                   rabbitmonitor-deploy,
@@ -2109,7 +2140,47 @@ jobs:
     - get: census-rm-kubernetes-dependencies-repo
       trigger: true
     - get: census-rm-deploy
+    - get: every-minute
     - get: census-rm-terraform
+      passed: ["CI Terraform"]
+      trigger: true
+    - get: action-scheduler-master
+      passed: ["CI Terraform"]
+      trigger: true
+    - get: action-worker-master
+      passed: ["CI Terraform"]
+      trigger: true
+    - get: action-processor-master
+      passed: ["CI Terraform"]
+      trigger: true
+    - get: case-api-master
+      passed: ["CI Terraform"]
+      trigger: true
+    - get: case-processor-master
+      passed: ["CI Terraform"]
+      trigger: true
+    - get: uac-qid-service-master
+      passed: ["CI Terraform"]
+      trigger: true
+    - get: pubsub-adapter
+      passed: ["CI Terraform"]
+      trigger: true
+    - get: print-file-service-master
+      passed: ["CI Terraform"]
+      trigger: true
+    - get: fieldwork-adapter-master
+      passed: ["CI Terraform"]
+      trigger: true
+    - get: notify-processor-master
+      passed: ["CI Terraform"]
+      trigger: true
+    - get: notify-stub-master
+      passed: ["CI Terraform"]
+      trigger: true
+    - get: exception-manager-master
+      passed: ["CI Terraform"]
+      trigger: true
+    - get: toolbox-master
       passed: ["CI Terraform"]
       trigger: true
     - task: "CI Helm"
@@ -2125,23 +2196,33 @@ jobs:
   # Apply Database Patches
 - name: "CI Apply Database Patches"
   serial: true
-  serial_groups: [ci-database-patches,
-                  ci-helm,
-                  ci-monitoring,
-                  ci-database-patches,
+  serial_groups: [ci-monitoring,
                   ci-acceptance-tests,
+                  action-scheduler-build,
                   action-scheduler-deploy,
+                  action-worker-build,
                   action-worker-deploy,
+                  action-processor-build,
                   action-processor-deploy,
+                  case-api-build,
                   case-api-deploy,
+                  case-processor-build,
                   case-processor-deploy,
+                  uac-qid-service-build,
                   uac-qid-service-deploy,
+                  pubsub-adapter-build,
                   pubsub-adapter-deploy,
+                  print-file-service-build,
                   print-file-service-deploy,
+                  fieldwork-adapter-build,
                   fieldwork-adapter-deploy,
+                  notify-processor-build,
                   notify-processor-deploy,
+                  notify-stub-build,
                   notify-stub-deploy,
+                  exception-manager-build,
                   exception-manager-deploy,
+                  toolbox-build,
                   toolbox-deploy,
                   database-monitor-deploy,
                   rabbitmonitor-deploy,
@@ -2150,10 +2231,51 @@ jobs:
   on_error: *slack_error_alert_ci
   plan:
   - get: census-rm-ddl-master
-    trigger: true
-    passed: ["Build DDL Latest"]
   - get: census-rm-kubernetes-optional-repo
   - get: census-rm-deploy
+  - get: every-minute
+  - get: action-scheduler-master
+    passed: ["CI Terraform"]
+    trigger: true
+  - get: action-worker-master
+    passed: ["CI Terraform"]
+    trigger: true
+  - get: action-processor-master
+    passed: ["CI Terraform"]
+    trigger: true
+  - get: case-api-master
+    passed: ["CI Terraform"]
+    trigger: true
+  - get: case-processor-master
+    passed: ["CI Terraform"]
+    trigger: true
+  - get: uac-qid-service-master
+    passed: ["CI Terraform"]
+    trigger: true
+  - get: pubsub-adapter
+    passed: ["CI Terraform"]
+    trigger: true
+  - get: print-file-service-master
+    passed: ["CI Terraform"]
+    trigger: true
+  - get: fieldwork-adapter-master
+    passed: ["CI Terraform"]
+    trigger: true
+  - get: notify-processor-master
+    passed: ["CI Terraform"]
+    trigger: true
+  - get: notify-stub-master
+    passed: ["CI Terraform"]
+    trigger: true
+  - get: exception-manager-master
+    passed: ["CI Terraform"]
+    trigger: true
+  - get: toolbox-master
+    passed: ["CI Terraform"]
+    trigger: true
+  - get: census-rm-terraform
+    passed: ["CI Terraform"]
+    trigger: true
   - get: ddl-docker-image-gcr
     params:
       skip_download: true
@@ -2176,13 +2298,17 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: action-scheduler-master
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2214,7 +2340,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2224,6 +2353,7 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: action-worker-master
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: action-worker-docker-image-gcr
     params:
       skip_download: true
@@ -2252,15 +2382,17 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Terraform"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: action-processor-master
-    trigger: true
-    passed: ["Build Action Processor Latest"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2292,7 +2424,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2302,6 +2437,7 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: case-api-master
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: case-api-docker-image-gcr
     params:
       skip_download: true
@@ -2330,7 +2466,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2340,6 +2479,7 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: case-processor-master
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: case-processor-docker-image-gcr
     params:
       skip_download: true
@@ -2368,7 +2508,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2378,6 +2521,7 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: uac-qid-service-master
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: uac-qid-service-docker-image-gcr
     params:
       skip_download: true
@@ -2406,7 +2550,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2416,6 +2563,7 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: pubsub-adapter
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: pubsub-adapter-docker-image-gcr
     params:
       skip_download: true
@@ -2444,7 +2592,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2454,6 +2605,8 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: ops-master
+    trigger: true
+    passed: ["Build Ops Latest"]
   - get: ops-docker-image-gcr
     params:
       skip_download: true
@@ -2482,7 +2635,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2492,6 +2648,7 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: print-file-service-master
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: print-file-service-docker-image-gcr
     params:
       skip_download: true
@@ -2520,7 +2677,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2530,6 +2690,7 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: fieldwork-adapter-master
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: fieldwork-adapter-docker-image-gcr
     params:
       skip_download: true
@@ -2558,7 +2719,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2568,6 +2732,7 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     trigger: true
   - get: notify-processor-master
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: notify-processor-docker-image-gcr
     params:
       skip_download: true
@@ -2596,7 +2761,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2606,6 +2774,7 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: notify-stub-master
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: notify-stub-docker-image-gcr
     params:
       skip_download: true
@@ -2634,7 +2803,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2644,6 +2816,7 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: exception-manager-master
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: exception-manager-docker-image-gcr
     params:
       skip_download: true
@@ -2672,13 +2845,17 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2710,7 +2887,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2720,6 +2900,7 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: toolbox-master
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: toolbox-docker-image-gcr
     params:
       skip_download: true
@@ -2748,7 +2929,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2758,6 +2942,7 @@ jobs:
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: toolbox-docker-image-gcr
     params:
       skip_download: true
@@ -2786,7 +2971,10 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm", "CI Apply Database Patches"]
+  - get: every-minute
+    trigger: true
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2796,6 +2984,7 @@ jobs:
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
+    passed: ["CI Helm", "CI Apply Database Patches"]
   - get: toolbox-docker-image-gcr
     params:
       skip_download: true
@@ -2826,6 +3015,7 @@ jobs:
                   action-scheduler-build,
                   action-scheduler-deploy,
                   action-processor-build,
+                  action-processor-deploy,
                   action-worker-build,
                   action-worker-deploy,
                   case-api-build,
@@ -2974,9 +3164,10 @@ jobs:
                   ci-acceptance-tests,
                   action-scheduler-build,
                   action-scheduler-deploy,
-                  action-processor-build,
                   action-worker-build,
                   action-worker-deploy,
+                  action-processor-build,
+                  action-processor-deploy,
                   case-api-build,
                   case-api-deploy,
                   case-processor-build,
@@ -3075,19 +3266,57 @@ jobs:
   on_failure: *slack_failure_alert_wl
   on_error: *slack_error_alert_wl
   plan:
-    - get: census-rm-terraform
-      trigger: true
-      passed: ["CI Acceptance Tests"]
-    - get: census-rm-deploy
-    - *slack_started_alert_wl
-    - task: "WL Terraform"
-      file: census-rm-deploy/tasks/terraform-env.yml
-      params:
-        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-        ENV: whitelodge
-        VAR_FILE: ./tfvars/census-rm-whitelodge.tfvars
-        KUBERNETES_CLUSTER: rm-k8s-cluster
-      input_mapping: {census-rm-terraform: census-rm-terraform}
+  - get: census-rm-terraform
+    trigger: true
+    passed: ["CI Acceptance Tests"]
+  - get: action-scheduler-master
+    passed: ["CI Acceptance Tests"]
+    trigger: true
+  - get: action-worker-master
+    passed: ["CI Acceptance Tests"]
+    trigger: true
+  - get: action-processor-master
+    passed: ["CI Acceptance Tests"]
+    trigger: true
+  - get: case-api-master
+    passed: ["CI Acceptance Tests"]
+    trigger: true
+  - get: case-processor-master
+    passed: ["CI Acceptance Tests"]
+    trigger: true
+  - get: uac-qid-service-master
+    passed: ["CI Acceptance Tests"]
+    trigger: true
+  - get: pubsub-adapter
+    passed: ["CI Acceptance Tests"]
+    trigger: true
+  - get: print-file-service-master
+    passed: ["CI Acceptance Tests"]
+    trigger: true
+  - get: fieldwork-adapter-master
+    passed: ["CI Acceptance Tests"]
+    trigger: true
+  - get: notify-processor-master
+    passed: ["CI Acceptance Tests"]
+    trigger: true
+  - get: notify-stub-master
+    passed: ["CI Acceptance Tests"]
+    trigger: true
+  - get: exception-manager-master
+    passed: ["CI Acceptance Tests"]
+    trigger: true
+  - get: toolbox-master
+    passed: ["CI Acceptance Tests"]
+    trigger: true
+  - get: census-rm-deploy
+  - task: "WL Terraform"
+    file: census-rm-deploy/tasks/terraform-env.yml
+    params:
+      ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      ENV: ryangrundy
+      VAR_FILE: ./tfvars/census-rm-ryangrundy.tfvars
+      KUBERNETES_CLUSTER: rm-k8s-cluster
+    input_mapping: {census-rm-terraform: census-rm-terraform}
 
 # Deploy monitoring apps
 - name: "WL Monitoring"
@@ -3157,7 +3386,45 @@ jobs:
       passed: ["WL Terraform"]
       trigger: true
     - get: census-rm-deploy
-    - *slack_started_alert_wl
+    - get: action-scheduler-master
+      passed: ["WL Terraform"]
+      trigger: true
+    - get: action-worker-master
+      passed: ["WL Terraform"]
+      trigger: true
+    - get: action-processor-master
+      passed: ["WL Terraform"]
+      trigger: true
+    - get: case-api-master
+      passed: ["WL Terraform"]
+      trigger: true
+    - get: case-processor-master
+      passed: ["WL Terraform"]
+      trigger: true
+    - get: uac-qid-service-master
+      passed: ["WL Terraform"]
+      trigger: true
+    - get: pubsub-adapter
+      passed: ["WL Terraform"]
+      trigger: true
+    - get: print-file-service-master
+      passed: ["WL Terraform"]
+      trigger: true
+    - get: fieldwork-adapter-master
+      passed: ["WL Terraform"]
+      trigger: true
+    - get: notify-processor-master
+      passed: ["WL Terraform"]
+      trigger: true
+    - get: notify-stub-master
+      passed: ["WL Terraform"]
+      trigger: true
+    - get: exception-manager-master
+      passed: ["WL Terraform"]
+      trigger: true
+    - get: toolbox-master
+      passed: ["WL Terraform"]
+      trigger: true
     - task: "WL Helm"
       file: census-rm-deploy/tasks/helm.yml
       params:
@@ -3198,6 +3465,45 @@ jobs:
   - get: census-rm-terraform
     passed: ["WL Terraform"]
     trigger: true
+  - get: action-scheduler-master
+    passed: ["WL Terraform"]
+    trigger: true
+  - get: action-worker-master
+    passed: ["WL Terraform"]
+    trigger: true
+  - get: action-processor-master
+    passed: ["WL Terraform"]
+    trigger: true
+  - get: case-api-master
+    passed: ["WL Terraform"]
+    trigger: true
+  - get: case-processor-master
+    passed: ["WL Terraform"]
+    trigger: true
+  - get: uac-qid-service-master
+    passed: ["WL Terraform"]
+    trigger: true
+  - get: pubsub-adapter
+    passed: ["WL Terraform"]
+    trigger: true
+  - get: print-file-service-master
+    passed: ["WL Terraform"]
+    trigger: true
+  - get: fieldwork-adapter-master
+    passed: ["WL Terraform"]
+    trigger: true
+  - get: notify-processor-master
+    passed: ["WL Terraform"]
+    trigger: true
+  - get: notify-stub-master
+    passed: ["WL Terraform"]
+    trigger: true
+  - get: exception-manager-master
+    passed: ["WL Terraform"]
+    trigger: true
+  - get: toolbox-master
+    passed: ["WL Terraform"]
+    trigger: true
   - get: ddl-docker-image-gcr
     params:
       skip_download: true
@@ -3227,7 +3533,8 @@ jobs:
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
   - get: action-scheduler-master
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm", "WL Apply Database Patches"]
+    trigger: true
   - get: action-scheduler-docker-image-gcr
     params:
       skip_download: true
@@ -3263,7 +3570,8 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     passed: ["CI Acceptance Tests"]
   - get: action-worker-master
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm", "WL Apply Database Patches"]
+    trigger: true
   - get: action-worker-docker-image-gcr
     params:
       skip_download: true
@@ -3291,19 +3599,16 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["WL Terraform"]
+    passed: ["WL Apply Database Patches", "WL Helm"]
   - get: census-rm-kubernetes-dependencies-repo
-    trigger: true
     passed: ["WL Helm"]
   - get: census-rm-kubernetes-microservices-repo
-    trigger: true
     passed: ["CI Acceptance Tests"]
   - get: census-rm-ddl-master
-    trigger: true
     passed: ["WL Apply Database Patches"]
   - get: action-processor-master
     trigger: true
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm", "WL Apply Database Patches"]
   - get: action-processor-docker-image-gcr
     params:
       skip_download: true
@@ -3339,7 +3644,8 @@ jobs:
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
   - get: print-file-service-master
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm", "WL Apply Database Patches"]
+    trigger: true
   - get: print-file-service-docker-image-gcr
     params:
       skip_download: true
@@ -3375,7 +3681,8 @@ jobs:
   - get: census-rm-ddl-master
     passed: ["WL Apply Database Patches"]
   - get: case-api-master
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm", "WL Apply Database Patches"]
+    trigger: true
   - get: case-api-docker-image-gcr
     params:
       skip_download: true
@@ -3411,7 +3718,8 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     passed: ["CI Acceptance Tests"]
   - get: case-processor-master
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm", "WL Apply Database Patches"]
+    trigger: true
   - get: case-processor-docker-image-gcr
     params:
       skip_download: true
@@ -3447,7 +3755,8 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     passed: ["CI Acceptance Tests"]
   - get: uac-qid-service-master
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm", "WL Apply Database Patches"]
+    trigger: true
   - get: uac-qid-service-docker-image-gcr
     params:
       skip_download: true
@@ -3483,7 +3792,8 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     passed: ["CI Acceptance Tests"]
   - get: pubsub-adapter
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm", "WL Apply Database Patches"]
+    trigger: true
   - get: pubsub-adapter-docker-image-gcr
     params:
       skip_download: true
@@ -3553,7 +3863,8 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     passed: ["CI Acceptance Tests"]
   - get: fieldwork-adapter-master
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm", "WL Apply Database Patches"]
+    trigger: true
   - get: fieldwork-adapter-docker-image-gcr
     params:
       skip_download: true
@@ -3589,7 +3900,8 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     passed: ["CI Acceptance Tests"]
   - get: notify-processor-master
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm", "WL Apply Database Patches"]
+    trigger: true
   - get: notify-processor-docker-image-gcr
     params:
       skip_download: true
@@ -3625,7 +3937,8 @@ jobs:
   - get: census-rm-kubernetes-microservices-repo
     passed: ["CI Acceptance Tests"]
   - get: exception-manager-master
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm", "WL Apply Database Patches"]
+    trigger: true
   - get: exception-manager-docker-image-gcr
     params:
       skip_download: true
@@ -3661,7 +3974,8 @@ jobs:
   - get: census-rm-kubernetes-optional-repo
     passed: ["CI Acceptance Tests"]
   - get: toolbox-master
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm", "WL Apply Database Patches"]
+    trigger: true
   - get: toolbox-docker-image-gcr
     params:
       skip_download: true
@@ -3697,7 +4011,8 @@ jobs:
   - get: census-rm-kubernetes-optional-repo
     passed: ["CI Acceptance Tests"]
   - get: toolbox-master
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm", "WL Apply Database Patches"]
+    trigger: true
   - get: toolbox-docker-image-gcr
     params:
       skip_download: true
@@ -3733,7 +4048,8 @@ jobs:
   - get: census-rm-kubernetes-optional-repo
     passed: ["CI Acceptance Tests"]
   - get: toolbox-master
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm", "WL Apply Database Patches"]
+    trigger: true
   - get: toolbox-docker-image-gcr
     params:
       skip_download: true
@@ -3769,7 +4085,8 @@ jobs:
   - get: census-rm-kubernetes-optional-repo
     passed: ["CI Acceptance Tests"]
   - get: toolbox-master
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm", "WL Apply Database Patches"]
+    trigger: true
   - get: toolbox-docker-image-gcr
     params:
       skip_download: true

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -46,6 +46,7 @@ groups:
   - "CI Deploy Database Monitor"
   - "CI Deploy Rabbit Monitor"
   - "CI Deploy Regional Counts"
+  - "CI Deploy QID Batch Runner"
   - "CI Acceptance Tests"
   - "CI Nightly Regression ATs"
   - "WL Terraform"
@@ -120,6 +121,7 @@ groups:
   - "CI Deploy Database Monitor"
   - "CI Deploy Rabbit Monitor"
   - "CI Deploy Regional Counts"
+  - "CI Deploy QID Batch Runner"
   - "CI Acceptance Tests"
   - "CI Nightly Regression ATs"
 
@@ -1971,6 +1973,8 @@ jobs:
   - get: census-rm-terraform
     trigger: true
   - get: census-rm-deploy
+  - get: census-rm-kubernetes-microservices-repo
+    trigger: true
   - get: action-scheduler-master
     trigger: true
     passed: ["Build Action Scheduler Latest"]
@@ -2046,6 +2050,9 @@ jobs:
   - get: toolbox-master
     trigger: true
     passed: ["Build Toolbox Latest"]
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["Build DDL Latest"]
   - get: toolbox-docker-image-gcr
     params:
       skip_download: true
@@ -2141,6 +2148,9 @@ jobs:
       trigger: true
     - get: census-rm-deploy
     - get: every-minute
+    - get: census-rm-kubernetes-microservices-repo
+      passed: ["CI Terraform"]
+      trigger: true
     - get: census-rm-terraform
       passed: ["CI Terraform"]
       trigger: true
@@ -2183,6 +2193,9 @@ jobs:
     - get: toolbox-master
       passed: ["CI Terraform"]
       trigger: true
+    - get: census-rm-ddl-master
+      trigger: true
+      passed: ["CI Terraform"]
     - task: "CI Helm"
       file: census-rm-deploy/tasks/helm.yml
       params:
@@ -2231,50 +2244,56 @@ jobs:
   on_error: *slack_error_alert_ci
   plan:
   - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-optional-repo
   - get: census-rm-deploy
   - get: every-minute
+    passed: ["CI Helm"]
+  - get: census-rm-kubernetes-microservices-repo
+    passed: ["CI Helm"]
+    trigger: true
   - get: action-scheduler-master
-    passed: ["CI Terraform"]
+    passed: ["CI Helm"]
     trigger: true
   - get: action-worker-master
-    passed: ["CI Terraform"]
+    passed: ["CI Helm"]
     trigger: true
   - get: action-processor-master
-    passed: ["CI Terraform"]
+    passed: ["CI Helm"]
     trigger: true
   - get: case-api-master
-    passed: ["CI Terraform"]
+    passed: ["CI Helm"]
     trigger: true
   - get: case-processor-master
-    passed: ["CI Terraform"]
+    passed: ["CI Helm"]
     trigger: true
   - get: uac-qid-service-master
-    passed: ["CI Terraform"]
+    passed: ["CI Helm"]
     trigger: true
   - get: pubsub-adapter
-    passed: ["CI Terraform"]
+    passed: ["CI Helm"]
     trigger: true
   - get: print-file-service-master
-    passed: ["CI Terraform"]
+    passed: ["CI Helm"]
     trigger: true
   - get: fieldwork-adapter-master
-    passed: ["CI Terraform"]
+    passed: ["CI Helm"]
     trigger: true
   - get: notify-processor-master
-    passed: ["CI Terraform"]
+    passed: ["CI Helm"]
     trigger: true
   - get: notify-stub-master
-    passed: ["CI Terraform"]
+    passed: ["CI Helm"]
     trigger: true
   - get: exception-manager-master
-    passed: ["CI Terraform"]
+    passed: ["CI Helm"]
     trigger: true
   - get: toolbox-master
-    passed: ["CI Terraform"]
+    passed: ["CI Helm"]
     trigger: true
   - get: census-rm-terraform
-    passed: ["CI Terraform"]
+    passed: ["CI Helm"]
     trigger: true
   - get: ddl-docker-image-gcr
     params:
@@ -2298,17 +2317,16 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
+    passed: ["CI Apply Database Patches"]
     trigger: true
   - get: action-scheduler-master
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2340,10 +2358,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2351,9 +2366,11 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
+    passed: ["CI Apply Database Patches"]
     trigger: true
   - get: action-worker-master
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: action-worker-docker-image-gcr
     params:
       skip_download: true
@@ -2382,17 +2399,16 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
+    passed: ["CI Apply Database Patches"]
     trigger: true
   - get: action-processor-master
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2424,10 +2440,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2435,9 +2448,11 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
+    passed: ["CI Apply Database Patches"]
     trigger: true
   - get: case-api-master
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: case-api-docker-image-gcr
     params:
       skip_download: true
@@ -2466,10 +2481,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2477,9 +2489,11 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
+    passed: ["CI Apply Database Patches"]
     trigger: true
   - get: case-processor-master
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: case-processor-docker-image-gcr
     params:
       skip_download: true
@@ -2508,10 +2522,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2519,9 +2530,11 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
+    passed: ["CI Apply Database Patches"]
     trigger: true
   - get: uac-qid-service-master
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: uac-qid-service-docker-image-gcr
     params:
       skip_download: true
@@ -2550,10 +2563,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2561,9 +2571,11 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
+    passed: ["CI Apply Database Patches"]
     trigger: true
   - get: pubsub-adapter
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: pubsub-adapter-docker-image-gcr
     params:
       skip_download: true
@@ -2592,10 +2604,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2635,20 +2644,19 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
+    passed: ["CI Apply Database Patches"]
     trigger: true
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: print-file-service-master
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: print-file-service-docker-image-gcr
     params:
       skip_download: true
@@ -2677,10 +2685,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2688,9 +2693,11 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
+    passed: ["CI Apply Database Patches"]
     trigger: true
   - get: fieldwork-adapter-master
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: fieldwork-adapter-docker-image-gcr
     params:
       skip_download: true
@@ -2719,10 +2726,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2730,9 +2734,11 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
+    passed: ["CI Apply Database Patches"]
     trigger: true
   - get: notify-processor-master
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: notify-processor-docker-image-gcr
     params:
       skip_download: true
@@ -2761,20 +2767,19 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
+    passed: ["CI Apply Database Patches"]
     trigger: true
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: notify-stub-master
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: notify-stub-docker-image-gcr
     params:
       skip_download: true
@@ -2803,20 +2808,19 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
+    passed: ["CI Apply Database Patches"]
     trigger: true
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: exception-manager-master
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: exception-manager-docker-image-gcr
     params:
       skip_download: true
@@ -2845,17 +2849,15 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2887,10 +2889,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2900,7 +2899,8 @@ jobs:
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: toolbox-master
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: toolbox-docker-image-gcr
     params:
       skip_download: true
@@ -2929,10 +2929,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2942,7 +2939,8 @@ jobs:
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: toolbox-docker-image-gcr
     params:
       skip_download: true
@@ -2971,10 +2969,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
-  - get: every-minute
-    trigger: true
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]
@@ -2984,7 +2979,8 @@ jobs:
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
-    passed: ["CI Helm", "CI Apply Database Patches"]
+    passed: ["CI Apply Database Patches"]
+    trigger: true
   - get: toolbox-docker-image-gcr
     params:
       skip_download: true
@@ -3004,6 +3000,46 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
       docker-image-resource: toolbox-docker-image-gcr,
+      kubernetes-repo: census-rm-kubernetes-optional-repo}
+
+- name: "CI Deploy QID Batch Runner"	
+  serial: true	
+  serial_groups: [qid-batch-runner-build,	
+                  qid-batch-runner-deploy]	
+  plan:	
+  - get: census-rm-terraform
+    trigger: true
+    passed: ["CI Apply Database Patches"]
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
+    passed: ["CI Helm"]
+  - get: census-rm-kubernetes-optional-repo	
+    trigger: true	
+  - get: qid-batch-runner-master
+    trigger: true
+    passed: ["Build QID Batch Runner Latest"]
+  - get: census-rm-ddl-master	
+    trigger: true	
+    passed: ["CI Apply Database Patches"]	
+  - get: qid-batch-runner-docker-image-gcr	
+    params:	
+      skip_download: true	
+  - get: census-rm-deploy	
+  - task: apply-deployment	
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml	
+    on_failure: *slack_failure_alert_ci	
+    on_error: *slack_error_alert_ci	
+    params:	
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))	
+      GCP_PROJECT_NAME: ((ci-gcp-project-name))	
+      KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))	
+      KUBERNETES_DEPLOYMENT_NAME: qid-batch-runner	
+      KUBERNETES_SELECTOR: app=qid-batch-runner	
+      KUBERNETES_FILE_PATH: kubernetes-repo/optional	
+      KUBERNETES_FILE_PREFIX: qid-batch-runner	
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s	
+    input_mapping: {	
+      docker-image-resource: qid-batch-runner-docker-image-gcr,	
       kubernetes-repo: census-rm-kubernetes-optional-repo}
 
 

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2247,8 +2247,6 @@ jobs:
     trigger: true
     passed: ["CI Helm"]
   - get: census-rm-deploy
-  - get: every-minute
-    passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     passed: ["CI Helm"]
     trigger: true

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2247,6 +2247,8 @@ jobs:
     trigger: true
     passed: ["CI Helm"]
   - get: census-rm-deploy
+  - get: every-minute
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-microservices-repo
     passed: ["CI Helm"]
     trigger: true
@@ -2999,46 +3001,45 @@ jobs:
       docker-image-resource: toolbox-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-optional-repo}
 
-- name: "CI Deploy QID Batch Runner"	
-  serial: true	
-  serial_groups: [qid-batch-runner-build,	
-                  qid-batch-runner-deploy]	
-  plan:	
+- name: "CI Deploy QID Batch Runner"
+  serial: true
+  serial_groups: [qid-batch-runner-build,
+                  qid-batch-runner-deploy]
+  plan:
   - get: census-rm-terraform
     trigger: true
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Apply Database Patches"]
-  - get: census-rm-kubernetes-optional-repo	
-    trigger: true	
+  - get: census-rm-kubernetes-optional-repo
+    trigger: true
   - get: qid-batch-runner-master
     trigger: true
     passed: ["Build QID Batch Runner Latest"]
-  - get: census-rm-ddl-master	
-    trigger: true	
-    passed: ["CI Apply Database Patches"]	
-  - get: qid-batch-runner-docker-image-gcr	
-    params:	
-      skip_download: true	
-  - get: census-rm-deploy	
-  - task: apply-deployment	
-    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml	
-    on_failure: *slack_failure_alert_ci	
-    on_error: *slack_error_alert_ci	
-    params:	
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))	
-      GCP_PROJECT_NAME: ((ci-gcp-project-name))	
-      KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))	
-      KUBERNETES_DEPLOYMENT_NAME: qid-batch-runner	
-      KUBERNETES_SELECTOR: app=qid-batch-runner	
-      KUBERNETES_FILE_PATH: kubernetes-repo/optional	
-      KUBERNETES_FILE_PREFIX: qid-batch-runner	
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s	
-    input_mapping: {	
-      docker-image-resource: qid-batch-runner-docker-image-gcr,	
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Apply Database Patches"]
+  - get: qid-batch-runner-docker-image-gcr
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
+    on_failure: *slack_failure_alert_ci
+    on_error: *slack_error_alert_ci
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((ci-gcp-project-name))
+      KUBERNETES_CLUSTER: ((ci-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: qid-batch-runner
+      KUBERNETES_SELECTOR: app=qid-batch-runner
+      KUBERNETES_FILE_PATH: kubernetes-repo/optional
+      KUBERNETES_FILE_PREFIX: qid-batch-runner
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {
+      docker-image-resource: qid-batch-runner-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-optional-repo}
-
 
 
 - name: "CI Acceptance Tests"

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -69,6 +69,7 @@ groups:
   - "WL Deploy Database Monitor"
   - "WL Deploy Rabbit Monitor"
   - "WL Deploy Regional Counts"
+  - "WL Deploy QID Batch Runner"
   - "WL Whitelist"
   - "WL Whitelist Nightly"
 
@@ -147,6 +148,7 @@ groups:
   - "WL Deploy Database Monitor"
   - "WL Deploy Rabbit Monitor"
   - "WL Deploy Regional Counts"
+  - "WL Deploy QID Batch Runner"
   - "WL Whitelist"
   - "WL Whitelist Nightly"
 
@@ -174,11 +176,6 @@ resources:
   type: slack-notification
   source:
     url: ((slack.webhook))
-
-- name: every-minute
-  type: time
-  source:
-    interval: 1m
 
 - name: census-rm-deploy
   type: git
@@ -2147,7 +2144,6 @@ jobs:
     - get: census-rm-kubernetes-dependencies-repo
       trigger: true
     - get: census-rm-deploy
-    - get: every-minute
     - get: census-rm-kubernetes-microservices-repo
       passed: ["CI Terraform"]
       trigger: true
@@ -2247,9 +2243,10 @@ jobs:
     trigger: true
     passed: ["CI Helm"]
   - get: census-rm-kubernetes-optional-repo
-  - get: census-rm-deploy
-  - get: every-minute
+  - get: census-rm-kubernetes-dependencies-repo
+    trigger: true
     passed: ["CI Helm"]
+  - get: census-rm-deploy
   - get: census-rm-kubernetes-microservices-repo
     passed: ["CI Helm"]
     trigger: true
@@ -2320,7 +2317,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     passed: ["CI Apply Database Patches"]
     trigger: true
@@ -2361,7 +2358,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2402,7 +2399,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     passed: ["CI Apply Database Patches"]
     trigger: true
@@ -2443,7 +2440,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2484,7 +2481,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2525,7 +2522,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2566,7 +2563,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2607,7 +2604,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-ops-repo
     trigger: true
   - get: census-rm-ddl-master
@@ -2647,7 +2644,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     passed: ["CI Apply Database Patches"]
     trigger: true
@@ -2688,7 +2685,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2729,7 +2726,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2770,7 +2767,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     passed: ["CI Apply Database Patches"]
     trigger: true
@@ -2811,7 +2808,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     passed: ["CI Apply Database Patches"]
     trigger: true
@@ -2852,7 +2849,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: toolbox-master
@@ -2892,7 +2889,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
   - get: census-rm-ddl-master
@@ -2932,7 +2929,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -2972,7 +2969,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
@@ -3012,7 +3009,7 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
-    passed: ["CI Helm"]
+    passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo	
     trigger: true	
   - get: qid-batch-runner-master
@@ -3366,6 +3363,12 @@ jobs:
   - get: toolbox-master
     passed: ["CI Acceptance Tests"]
     trigger: true
+  - get: qid-batch-runner-master
+    passed: ["CI Acceptance Tests"]
+    trigger: true
+  - get: census-rm-ddl-master
+    trigger: true
+    passed: ["CI Acceptance Tests"]
   - get: census-rm-deploy
   - task: "WL Terraform"
     file: census-rm-deploy/tasks/terraform-env.yml
@@ -3489,6 +3492,12 @@ jobs:
     - get: toolbox-master
       passed: ["WL Terraform"]
       trigger: true
+    - get: qid-batch-runner-master
+      passed: ["WL Terraform"]
+      trigger: true
+    - get: census-rm-ddl-master
+      trigger: true
+      passed: ["WL Terraform"]
     - task: "WL Helm"
       file: census-rm-deploy/tasks/helm.yml
       params:
@@ -3533,7 +3542,7 @@ jobs:
   - get: census-rm-deploy
   - get: census-rm-ddl-master
     trigger: true
-    passed: ["CI Acceptance Tests"]
+    passed: ["WL Helm"]
   - get: census-rm-terraform
     passed: ["WL Helm"]
     trigger: true
@@ -3574,6 +3583,9 @@ jobs:
     passed: ["WL Helm"]
     trigger: true
   - get: toolbox-master
+    passed: ["WL Helm"]
+    trigger: true
+  - get: qid-batch-runner-master
     passed: ["WL Helm"]
     trigger: true
   - get: ddl-docker-image-gcr
@@ -4222,6 +4234,49 @@ jobs:
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
       docker-image-resource: toolbox-docker-image-gcr,
+      kubernetes-repo: census-rm-kubernetes-optional-repo}
+
+- name: "WL Deploy QID Batch Runner"	
+  serial: true	
+  serial_groups: [wl-qid-batch-runner]	
+  plan:	
+  - get: census-rm-terraform	
+    trigger: true	
+    passed: ["WL Apply Database Patches"]	
+  - get: census-rm-kubernetes-dependencies-repo	
+    trigger: true	
+    passed: ["WL Apply Database Patches"]	
+  - get: census-rm-ddl-master	
+    trigger: true	
+    passed: ["WL Apply Database Patches"]	
+  - get: census-rm-kubernetes-optional-repo	
+    trigger: true	
+    passed: ["WL Apply Database Patches"]	
+  - get: qid-batch-runner-master	
+    trigger: true	
+    passed: ["WL Apply Database Patches"]	
+  - get: census-rm-kubernetes-microservices-repo
+    passed: ["WL Apply Database Patches"]
+    trigger: true
+  - get: qid-batch-runner-docker-image-gcr	
+    params:	
+      skip_download: true	
+  - get: census-rm-deploy	
+  - task: apply-deployment	
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml	
+    on_failure: *slack_failure_alert_wl	
+    on_error: *slack_error_alert_wl	
+    params:	
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))	
+      GCP_PROJECT_NAME: ((wl-gcp-project-name))	
+      KUBERNETES_CLUSTER: ((wl-kubernetes-cluster-name))	
+      KUBERNETES_DEPLOYMENT_NAME: qid-batch-runner	
+      KUBERNETES_SELECTOR: app=qid-batch-runner	
+      KUBERNETES_FILE_PATH: kubernetes-repo/optional	
+      KUBERNETES_FILE_PREFIX: qid-batch-runner	
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s	
+    input_mapping: {	
+      docker-image-resource: qid-batch-runner-docker-image-gcr,	
       kubernetes-repo: census-rm-kubernetes-optional-repo}
 
 - name: "WL Whitelist"

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -1991,8 +1991,6 @@ jobs:
       trigger: true
     - get: census-rm-deploy
     - get: census-rm-terraform
-      passed: ["CI Terraform"]
-      trigger: true
     - task: "CI Monitoring"
       file: census-rm-deploy/tasks/monitoring.yml
       params:
@@ -2098,7 +2096,7 @@ jobs:
   plan:
   - get: census-rm-terraform
     trigger: true
-    passed: ["CI Helm","CI Monitoring"]
+    passed: ["CI Helm"]
   - get: census-rm-kubernetes-dependencies-repo
     trigger: true
     passed: ["CI Helm"]

--- a/tasks/helm.yml
+++ b/tasks/helm.yml
@@ -29,9 +29,8 @@ run:
       helm plugin install https://github.com/rimusz/helm-tiller
 
       cd census-rm-kubernetes-dependencies-repo
+      touch secret.tfvars
       set +x
-      echo "Testing I shouldn't see this"
-      echo ${KUBERNETES_CLUSTER}
-      
-      ENV=${ENV} RABBITMQ_CONFIG_VALUES_FILE=${RABBITMQ_CONFIG_VALUES_FILE} ./setup-dependencies.sh
+      echo "db_user_password" >> secret.tfvars
       set -x
+      ENV=${ENV} RABBITMQ_CONFIG_VALUES_FILE=${RABBITMQ_CONFIG_VALUES_FILE} ./setup-dependencies.sh

--- a/tasks/helm.yml
+++ b/tasks/helm.yml
@@ -29,4 +29,6 @@ run:
       helm plugin install https://github.com/rimusz/helm-tiller
 
       cd census-rm-kubernetes-dependencies-repo
+      set +x
       ENV=${ENV} RABBITMQ_CONFIG_VALUES_FILE=${RABBITMQ_CONFIG_VALUES_FILE} ./setup-dependencies.sh
+      set -x

--- a/tasks/helm.yml
+++ b/tasks/helm.yml
@@ -29,6 +29,5 @@ run:
       helm plugin install https://github.com/rimusz/helm-tiller
 
       cd census-rm-kubernetes-dependencies-repo
-      set +x
+
       ENV=${ENV} RABBITMQ_CONFIG_VALUES_FILE=${RABBITMQ_CONFIG_VALUES_FILE} ./setup-dependencies.sh
-      set -x

--- a/tasks/helm.yml
+++ b/tasks/helm.yml
@@ -29,5 +29,9 @@ run:
       helm plugin install https://github.com/rimusz/helm-tiller
 
       cd census-rm-kubernetes-dependencies-repo
-
+      set +x
+      echo "Testing I shouldn't see this"
+      echo ${KUBERNETES_CLUSTER}
+      
       ENV=${ENV} RABBITMQ_CONFIG_VALUES_FILE=${RABBITMQ_CONFIG_VALUES_FILE} ./setup-dependencies.sh
+      set -x

--- a/tasks/helm.yml
+++ b/tasks/helm.yml
@@ -29,10 +29,6 @@ run:
       helm plugin install https://github.com/rimusz/helm-tiller
 
       cd census-rm-kubernetes-dependencies-repo
-      touch secret.tfvars
-      set +x
-      echo "db_user_password" >> secret.tfvars
-      echo "Testing logging"
-      echo "Shouldn't output logging"
+      export HELM_TILLER_SILENT=true
+      
       ENV=${ENV} RABBITMQ_CONFIG_VALUES_FILE=${RABBITMQ_CONFIG_VALUES_FILE} ./setup-dependencies.sh
-      set -x

--- a/tasks/helm.yml
+++ b/tasks/helm.yml
@@ -32,5 +32,7 @@ run:
       touch secret.tfvars
       set +x
       echo "db_user_password" >> secret.tfvars
-      set -x
+      echo "Testing logging"
+      echo "Shouldn't output logging"
       ENV=${ENV} RABBITMQ_CONFIG_VALUES_FILE=${RABBITMQ_CONFIG_VALUES_FILE} ./setup-dependencies.sh
+      set -x


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The CI/WL pipeline sometimes needs more dev time to fix because of the ordering things get merged. This means app deployments get done before infrastructure changes which end up causing unnecessary errors in the pipeline. I've attempted to improve this by trying to block the jobs better in the pipeline. I've done this by making it go through the infrastructure changes always, making sure it doesn't run unless all builds have been completed. I've also changed the setup-dependencies script in helm now so we shouldn't see rabbit restarting every time it runs. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Altered CI/WL pipeline to block on jobs and wait until everything has been built and gone through infrastructure changes before app deployments.
- Added `HELM_TILLER_QUIET` flag to helm script so helm doesn't output rabbitmq passwords.
- Added a readme on how to deploy to the concourse sandbox environment.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- I've got a pipeline set up in the [Sandbox Environment](https://concourse.rm.census-gcp.onsdigital.uk/teams/main/pipelines/CI-WL-look-at-test) so you can take a look at what it'll look like. Action scheduler/Worker, Terraform and Kubernetes are all on test branches so feel free to push readme changes to those branches to kick off some jobs. Branch name is `test-branch-for-concourse`

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/wFiwUTrP/)
[Test pipeline](https://concourse.rm.census-gcp.onsdigital.uk/teams/main/pipelines/CI-WL-look-at-test)
[Kubernetes PR](https://github.com/ONSdigital/census-rm-kubernetes/pull/278)