### PR TITLE
Add builds for census-rm-monitoring

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -25,6 +25,7 @@ groups:
   - "Build Sample Loader Latest"
   - "Build Toolbox Latest"
   - "Build Monitoring Latest"
+  - "Build Dev Tools Latest"
   - "Build UAC QID Service Latest"
   - "CI Terraform"
   - "CI Monitoring"
@@ -98,6 +99,7 @@ groups:
   - "Build Sample Loader Latest"
   - "Build Toolbox Latest"
   - "Build Monitoring Latest"
+  - "Build Dev Tools Latest"
   - "Build UAC QID Service Latest"
 
 - name: "CI"
@@ -291,6 +293,12 @@ resources:
   type: git
   source:
     uri: git@github.com:ONSdigital/census-rm-monitoring.git
+    private_key: ((github.service_account_private_key))
+
+- name: dev-tools-master
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-dev-tools.git
     private_key: ((github.service_account_private_key))
 
 - name: pubsub-adapter
@@ -509,6 +517,20 @@ resources:
   type: docker-image
   source:
     repository: ((docker-registry-gcr))/rm/census-rm-monitoring
+    username: _json_key
+    password: ((gcp.service_account_json))
+
+- name: dev-tools-docker-image-ci
+  type: docker-image
+  source:
+    repository: ((docker-registry-ci))/rm/census-rm-dev-tools
+    username: _json_key
+    password: ((gcp.service_account_json))
+
+- name: dev-tools-docker-image-gcr
+  type: docker-image
+  source:
+    repository: ((docker-registry-gcr))/rm/census-rm-dev-tools
     username: _json_key
     password: ((gcp.service_account_json))
 
@@ -1570,6 +1592,32 @@ jobs:
       cache_from:
         - monitoring-docker-image-ci
       tag_file: monitoring-master/.git/ref
+      tag_as_latest: true
+    get_params:
+      skip_download: true
+
+- name: "Build Dev Tools Latest"
+  serial_groups: [dev-tools-build]
+  plan:
+  - get: dev-tools-master
+    trigger: true
+  - put: dev-tools-docker-image-ci
+    on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
+    params:
+      build: dev-tools-master
+      tag_file: dev-tools-master/.git/ref
+      tag_as_latest: true
+    get_params:
+      save: true
+  - put: dev-tools-docker-image-gcr
+    on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
+    params:
+      build: dev-tools-master
+      cache_from:
+        - dev-tools-docker-image-ci
+      tag_file: dev-tools-master/.git/ref
       tag_as_latest: true
     get_params:
       skip_download: true

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -24,6 +24,7 @@ groups:
   - "Build PubSub Adapter Latest"
   - "Build Sample Loader Latest"
   - "Build Toolbox Latest"
+  - "Build Monitoring Latest"
   - "Build UAC QID Service Latest"
   - "CI Terraform"
   - "CI Monitoring"
@@ -96,6 +97,7 @@ groups:
   - "Build PubSub Latest"
   - "Build Sample Loader Latest"
   - "Build Toolbox Latest"
+  - "Build Monitoring Latest"
   - "Build UAC QID Service Latest"
 
 - name: "CI"

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -285,6 +285,12 @@ resources:
     uri: git@github.com:ONSdigital/census-rm-toolbox.git
     private_key: ((github.service_account_private_key))
 
+- name: monitoring-master
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-monitoring.git
+    private_key: ((github.service_account_private_key))
+
 - name: pubsub-adapter
   type: git
   source:
@@ -487,6 +493,20 @@ resources:
   type: docker-image
   source:
     repository: ((docker-registry-gcr))/rm/census-rm-toolbox
+    username: _json_key
+    password: ((gcp.service_account_json))
+
+- name: monitoring-docker-image-ci
+  type: docker-image
+  source:
+    repository: ((docker-registry-ci))/rm/census-rm-monitoring
+    username: _json_key
+    password: ((gcp.service_account_json))
+
+- name: monitoring-docker-image-gcr
+  type: docker-image
+  source:
+    repository: ((docker-registry-gcr))/rm/census-rm-monitoring
     username: _json_key
     password: ((gcp.service_account_json))
 
@@ -1522,6 +1542,32 @@ jobs:
       cache_from:
         - toolbox-docker-image-ci
       tag_file: toolbox-master/.git/ref
+      tag_as_latest: true
+    get_params:
+      skip_download: true
+
+- name: "Build Monitoring Latest"
+  serial_groups: [monitoring-build]
+  plan:
+  - get: monitoring-master
+    trigger: true
+  - put: monitoring-docker-image-ci
+    on_failure: *slack_docker_build_failure_ci
+    on_error: *slack_docker_build_error_ci
+    params:
+      build: monitoring-master
+      tag_file: monitoring-master/.git/ref
+      tag_as_latest: true
+    get_params:
+      save: true
+  - put: monitoring-docker-image-gcr
+    on_failure: *slack_docker_build_failure_gcr
+    on_error: *slack_docker_build_error_gcr
+    params:
+      build: monitoring-master
+      cache_from:
+        - monitoring-docker-image-ci
+      tag_file: monitoring-master/.git/ref
       tag_as_latest: true
     get_params:
       skip_download: true

--- a/pipelines/build-release-images.yml
+++ b/pipelines/build-release-images.yml
@@ -99,6 +99,14 @@ resources:
       access_token: ((github.access_token))
       order_by: time
 
+  - name: monitoring-release
+    type: github-release-latest
+    source:
+      owner: ONSdigital
+      repository: census-rm-monitoring
+      access_token: ((github.access_token))
+      order_by: time
+
   - name: pubsub-adapter-release
     type: github-release-latest
     source:
@@ -320,6 +328,19 @@ resources:
       username: _json_key
       password: ((gcp.service_account_json))
 
+  - name: monitoring-docker-image-ci
+    type: docker-image
+    source:
+      repository: ((docker-registry-ci))/rm/census-rm-monitoring
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: monitoring-docker-image-gcr
+    type: docker-image
+    source:
+      repository: ((docker-registry-gcr))/rm/census-rm-monitoring
+      username: _json_key
+      password: ((gcp.service_account_json))
 
   - name: pubsub-adapter-docker-image-ci
     type: docker-image
@@ -1103,6 +1124,52 @@ jobs:
       get_params:
         skip_download: true
 
+  - name: build-monitoring-release
+    plan:
+    - get: monitoring-release
+      params:
+        include_source_tarball: true
+      trigger: true
+    - task: Build RM-toolbox Image (release)
+      on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: alpine
+        inputs:
+          - name: monitoring-release
+        outputs:
+          - name: extracted-monitoring
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              cd monitoring-release
+              tar -xzf source.tar.gz -C ../extracted-monitoring --strip-components=1
+    - put: monitoring-docker-image-ci
+      on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
+      params:
+        build: extracted-monitoring
+        tag_file: monitoring-release/tag
+        tag_as_latest: false
+      get_params:
+        save: true
+    - put: monitoring-docker-image-gcr
+      on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
+      params:
+        build: extracted-monitoring
+        cache_from:
+          - monitoring-docker-image-ci
+        tag_file: monitoring-release/tag
+        tag_as_latest: false
+      get_params:
+        skip_download: true
 
   - name: build-pubsub-adapter-release
     plan:

--- a/pipelines/build-release-images.yml
+++ b/pipelines/build-release-images.yml
@@ -107,6 +107,14 @@ resources:
       access_token: ((github.access_token))
       order_by: time
 
+  - name: dev-tools-release
+    type: github-release-latest
+    source:
+      owner: ONSdigital
+      repository: census-rm-dev-tools
+      access_token: ((github.access_token))
+      order_by: time
+
   - name: pubsub-adapter-release
     type: github-release-latest
     source:
@@ -339,6 +347,20 @@ resources:
     type: docker-image
     source:
       repository: ((docker-registry-gcr))/rm/census-rm-monitoring
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: dev-tools-docker-image-ci
+    type: docker-image
+    source:
+      repository: ((docker-registry-ci))/rm/census-rm-dev-tools
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+  - name: dev-tools-docker-image-gcr
+    type: docker-image
+    source:
+      repository: ((docker-registry-gcr))/rm/census-rm-dev-tools
       username: _json_key
       password: ((gcp.service_account_json))
 
@@ -1167,6 +1189,53 @@ jobs:
         cache_from:
           - monitoring-docker-image-ci
         tag_file: monitoring-release/tag
+        tag_as_latest: false
+      get_params:
+        skip_download: true
+
+  - name: build-dev-tools-release
+    plan:
+    - get: dev-tools-release
+      params:
+        include_source_tarball: true
+      trigger: true
+    - task: Build RM-toolbox Image (release)
+      on_failure: *slack_failure_alert_prebuild
+      on_error: *slack_error_alert_prebuild
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: alpine
+        inputs:
+          - name: dev-tools-release
+        outputs:
+          - name: extracted-dev-tools
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              cd dev-tools-release
+              tar -xzf source.tar.gz -C ../extracted-dev-tools --strip-components=1
+    - put: dev-tools-docker-image-ci
+      on_failure: *slack_failure_alert_ci
+      on_error: *slack_error_alert_ci
+      params:
+        build: extracted-dev-tools
+        tag_file: dev-tools-release/tag
+        tag_as_latest: false
+      get_params:
+        save: true
+    - put: dev-tools-docker-image-gcr
+      on_failure: *slack_failure_alert_gcr
+      on_error: *slack_error_alert_gcr
+      params:
+        build: extracted-dev-tools
+        cache_from:
+          - dev-tools-docker-image-ci
+        tag_file: dev-tools-release/tag
         tag_as_latest: false
       get_params:
         skip_download: true


### PR DESCRIPTION
# Motivation and Context
We're splitting the monitoring tools out of toolbox into a separate repo, needs build jobs.

# What has changed
* Add build jobs for census-rm-monitoring latest and release

# How to test?
Check the jobs are valid

# Links
https://trello.com/c/XHfzQUze/1257-split-cloudshell-utilities-and-monitoring-tools-out-of-census-rm-toolbox