### PR TITLE
Toolbox split

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -4472,9 +4472,6 @@ jobs:
   - get: toolbox-master
     passed: ["WL Terraform"]
     trigger: true
-  - get: dev-tools-master
-    passed: ["WL Terraform"]
-    trigger: true
   - get: qid-batch-runner-master
     passed: ["WL Terraform"]
     trigger: true

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2057,6 +2057,7 @@ jobs:
                   exception-manager-deploy,
                   toolbox-build,
                   toolbox-deploy,
+                  monitoring-build,
                   database-monitor-deploy,
                   rabbitmonitor-deploy,
                   regional-counts-deploy,
@@ -2144,6 +2145,9 @@ jobs:
   - get: toolbox-master
     trigger: true
     passed: ["Build Toolbox Latest"]
+  - get: monitoring-master
+    trigger: true
+    passed: ["Build Monitoring Latest"]
   - get: census-rm-ddl-master
     trigger: true
     passed: ["Build DDL Latest"]
@@ -2233,6 +2237,7 @@ jobs:
                   exception-manager-deploy,
                   toolbox-build,
                   toolbox-deploy,
+                  monitoring-build,
                   database-monitor-deploy,
                   rabbitmonitor-deploy,
                   regional-counts-deploy]
@@ -2287,6 +2292,9 @@ jobs:
     - get: toolbox-master
       passed: ["CI Terraform"]
       trigger: true
+    - get: monitoring-master
+      passed: ["CI Terraform"]
+      trigger: true
     - get: census-rm-ddl-master
       trigger: true
       passed: ["CI Terraform"]
@@ -2334,6 +2342,7 @@ jobs:
                   exception-manager-deploy,
                   toolbox-build,
                   toolbox-deploy,
+                  monitoring-build,
                   database-monitor-deploy,
                   rabbitmonitor-deploy,
                   regional-counts-deploy]
@@ -2388,6 +2397,9 @@ jobs:
     passed: ["CI Helm"]
     trigger: true
   - get: toolbox-master
+    passed: ["CI Helm"]
+    trigger: true
+  - get: monitoring-master
     passed: ["CI Helm"]
     trigger: true
   - get: census-rm-terraform
@@ -2982,7 +2994,7 @@ jobs:
 
 - name: "CI Deploy Database Monitor"
   serial: true
-  serial_groups: [toolbox-build,
+  serial_groups: [monitoring-build,
                   database-monitor-deploy]
   plan:
   - get: census-rm-terraform
@@ -2996,10 +3008,10 @@ jobs:
   - get: census-rm-ddl-master
     trigger: true
     passed: ["CI Apply Database Patches"]
-  - get: toolbox-master
+  - get: monitoring-master
     passed: ["CI Apply Database Patches"]
     trigger: true
-  - get: toolbox-docker-image-gcr
+  - get: monitoring-docker-image-gcr
     params:
       skip_download: true
   - get: census-rm-deploy
@@ -3017,12 +3029,12 @@ jobs:
       KUBERNETES_FILE_PREFIX: database-monitor-dev
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
-      docker-image-resource: toolbox-docker-image-gcr,
+      docker-image-resource: monitoring-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-optional-repo}
 
 - name: "CI Deploy Rabbit Monitor"
   serial: true
-  serial_groups: [toolbox-build,
+  serial_groups: [monitoring-build,
                   rabbitmonitor-deploy]
   plan:
   - get: census-rm-terraform
@@ -3036,10 +3048,10 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
-  - get: toolbox-master
+  - get: monitoring-master
     passed: ["CI Apply Database Patches"]
     trigger: true
-  - get: toolbox-docker-image-gcr
+  - get: monitoring-docker-image-gcr
     params:
       skip_download: true
   - get: census-rm-deploy
@@ -3057,12 +3069,12 @@ jobs:
       KUBERNETES_FILE_PREFIX: rabbitmonitor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
-      docker-image-resource: toolbox-docker-image-gcr,
+      docker-image-resource: monitoring-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-optional-repo}
 
 - name: "CI Deploy Regional Counts"
   serial: true
-  serial_groups: [toolbox-build,
+  serial_groups: [monitoring-build,
                   regional-counts-deploy]
   plan:
   - get: census-rm-terraform
@@ -3076,10 +3088,10 @@ jobs:
     passed: ["CI Apply Database Patches"]
   - get: census-rm-kubernetes-optional-repo
     trigger: true
-  - get: toolbox-master
+  - get: monitoring-master
     passed: ["CI Apply Database Patches"]
     trigger: true
-  - get: toolbox-docker-image-gcr
+  - get: monitoring-docker-image-gcr
     params:
       skip_download: true
   - get: census-rm-deploy
@@ -3097,7 +3109,7 @@ jobs:
       KUBERNETES_FILE_PREFIX: regional-counts-dev
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
-      docker-image-resource: toolbox-docker-image-gcr,
+      docker-image-resource: monitoring-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-optional-repo}
 
 - name: "CI Deploy QID Batch Runner"
@@ -3173,6 +3185,7 @@ jobs:
                   exception-manager-deploy,
                   toolbox-build,
                   toolbox-deploy,
+                  monitoring-build,
                   database-monitor-deploy,
                   rabbitmonitor-deploy,
                   regional-counts-deploy]
@@ -3289,8 +3302,10 @@ jobs:
     passed: ["CI Deploy Exception Manager"]
   - get: toolbox-master
     trigger: true
-    passed: ["CI Deploy Toolbox",
-             "CI Deploy Database Monitor",
+    passed: ["CI Deploy Toolbox"]
+  - get: monitoring-master
+    trigger: true
+    passed: ["CI Deploy Database Monitor",
              "CI Deploy Rabbit Monitor",
              "CI Deploy Regional Counts"]
   - task: "Run Acceptance Tests (in K8s)"
@@ -3336,6 +3351,7 @@ jobs:
                   exception-manager-deploy,
                   toolbox-build,
                   toolbox-deploy,
+                  monitoring-build,
                   database-monitor-deploy,
                   rabbitmonitor-deploy,
                   regional-counts-deploy]
@@ -3374,8 +3390,10 @@ jobs:
   - get: exception-manager-master
     passed: ["CI Deploy Exception Manager"]
   - get: toolbox-master
-    passed: ["CI Deploy Toolbox",
-             "CI Deploy Database Monitor",
+    passed: ["CI Deploy Toolbox"]
+  - get: monitoring-master
+    trigger: true
+    passed: ["CI Deploy Database Monitor",
              "CI Deploy Rabbit Monitor",
              "CI Deploy Regional Counts"]
   - task: "Run Regression Acceptance Tests (in K8s)"
@@ -3463,6 +3481,9 @@ jobs:
     passed: ["CI Acceptance Tests"]
     trigger: true
   - get: toolbox-master
+    passed: ["CI Acceptance Tests"]
+    trigger: true
+  - get: monitoring-master
     passed: ["CI Acceptance Tests"]
     trigger: true
   - get: qid-batch-runner-master
@@ -3594,6 +3615,9 @@ jobs:
     - get: toolbox-master
       passed: ["WL Terraform"]
       trigger: true
+    - get: monitoring-master
+      passed: ["WL Terraform"]
+      trigger: true
     - get: qid-batch-runner-master
       passed: ["WL Terraform"]
       trigger: true
@@ -3685,6 +3709,9 @@ jobs:
     passed: ["WL Helm"]
     trigger: true
   - get: toolbox-master
+    passed: ["WL Helm"]
+    trigger: true
+  - get: monitoring-master
     passed: ["WL Helm"]
     trigger: true
   - get: qid-batch-runner-master
@@ -4236,10 +4263,10 @@ jobs:
   - get: census-rm-kubernetes-optional-repo
     passed: ["WL Apply Database Patches"]
     trigger: true
-  - get: toolbox-master
+  - get: monitoring-master
     passed: ["WL Apply Database Patches"]
     trigger: true
-  - get: toolbox-docker-image-gcr
+  - get: monitoring-docker-image-gcr
     params:
       skip_download: true
   - get: census-rm-deploy
@@ -4257,7 +4284,7 @@ jobs:
       KUBERNETES_FILE_PREFIX: database-monitor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
-      docker-image-resource: toolbox-docker-image-gcr,
+      docker-image-resource: monitoring-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-optional-repo}
 
 - name: "WL Deploy Rabbit Monitor"
@@ -4276,10 +4303,10 @@ jobs:
   - get: census-rm-kubernetes-optional-repo
     passed: ["WL Apply Database Patches"]
     trigger: true
-  - get: toolbox-master
+  - get: monitoring-master
     passed: ["WL Apply Database Patches"]
     trigger: true
-  - get: toolbox-docker-image-gcr
+  - get: monitoring-docker-image-gcr
     params:
       skip_download: true
   - get: census-rm-deploy
@@ -4297,7 +4324,7 @@ jobs:
       KUBERNETES_FILE_PREFIX: rabbitmonitor
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
-      docker-image-resource: toolbox-docker-image-gcr,
+      docker-image-resource: monitoring-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-optional-repo}
 
 - name: "WL Deploy Regional Counts"
@@ -4314,10 +4341,10 @@ jobs:
   - get: census-rm-kubernetes-optional-repo
     passed: ["WL Apply Database Patches"]
     trigger: true
-  - get: toolbox-master
+  - get: monitoring-master
     passed: ["WL Apply Database Patches"]
     trigger: true
-  - get: toolbox-docker-image-gcr
+  - get: monitoring-docker-image-gcr
     params:
       skip_download: true
   - get: census-rm-deploy
@@ -4335,50 +4362,50 @@ jobs:
       KUBERNETES_FILE_PREFIX: regional-counts
       WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
     input_mapping: {
-      docker-image-resource: toolbox-docker-image-gcr,
+      docker-image-resource: monitoring-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-optional-repo}
 
-- name: "WL Deploy QID Batch Runner"	
+- name: "WL Deploy QID Batch Runner"
   serial: true	
-  serial_groups: [wl-qid-batch-runner]	
-  plan:	
+  serial_groups: [wl-qid-batch-runner]
+  plan:
   - get: census-rm-terraform	
     trigger: true	
-    passed: ["WL Apply Database Patches"]	
-  - get: census-rm-kubernetes-dependencies-repo	
+    passed: ["WL Apply Database Patches"]
+  - get: census-rm-kubernetes-dependencies-repo
     trigger: true	
-    passed: ["WL Apply Database Patches"]	
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-ddl-master	
     trigger: true	
-    passed: ["WL Apply Database Patches"]	
-  - get: census-rm-kubernetes-optional-repo	
+    passed: ["WL Apply Database Patches"]
+  - get: census-rm-kubernetes-optional-repo
     trigger: true	
-    passed: ["WL Apply Database Patches"]	
+    passed: ["WL Apply Database Patches"]
   - get: qid-batch-runner-master	
     trigger: true	
-    passed: ["WL Apply Database Patches"]	
+    passed: ["WL Apply Database Patches"]
   - get: census-rm-kubernetes-microservices-repo
     passed: ["WL Apply Database Patches"]
     trigger: true
-  - get: qid-batch-runner-docker-image-gcr	
-    params:	
-      skip_download: true	
-  - get: census-rm-deploy	
-  - task: apply-deployment	
-    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml	
-    on_failure: *slack_failure_alert_wl	
-    on_error: *slack_error_alert_wl	
-    params:	
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))	
-      GCP_PROJECT_NAME: ((wl-gcp-project-name))	
-      KUBERNETES_CLUSTER: ((wl-kubernetes-cluster-name))	
-      KUBERNETES_DEPLOYMENT_NAME: qid-batch-runner	
-      KUBERNETES_SELECTOR: app=qid-batch-runner	
-      KUBERNETES_FILE_PATH: kubernetes-repo/optional	
-      KUBERNETES_FILE_PREFIX: qid-batch-runner	
-      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s	
-    input_mapping: {	
-      docker-image-resource: qid-batch-runner-docker-image-gcr,	
+  - get: qid-batch-runner-docker-image-gcr
+    params:
+      skip_download: true
+  - get: census-rm-deploy
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment.yml
+    on_failure: *slack_failure_alert_wl
+    on_error: *slack_error_alert_wl
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((wl-gcp-project-name))
+      KUBERNETES_CLUSTER: ((wl-kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: qid-batch-runner
+      KUBERNETES_SELECTOR: app=qid-batch-runner
+      KUBERNETES_FILE_PATH: kubernetes-repo/optional
+      KUBERNETES_FILE_PREFIX: qid-batch-runner
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {
+      docker-image-resource: qid-batch-runner-docker-image-gcr,
       kubernetes-repo: census-rm-kubernetes-optional-repo}
 
 - name: "WL Whitelist"
@@ -4443,6 +4470,9 @@ jobs:
     passed: ["WL Terraform"]
     trigger: true
   - get: toolbox-master
+    passed: ["WL Terraform"]
+    trigger: true
+  - get: dev-tools-master
     passed: ["WL Terraform"]
     trigger: true
   - get: qid-batch-runner-master

--- a/tasks/whitelist-env.yml
+++ b/tasks/whitelist-env.yml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-toolbox
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-dev-tools
     username: _json_key
     password: ((gcp.service_account_json))
 params:
@@ -16,7 +16,7 @@ run:
   args:
     - -exc
     - |
-      export GOOGLE_APPLICATION_CREDENTIALS=/home/toolbox/gcloud-service-key.json
+      export GOOGLE_APPLICATION_CREDENTIALS=/home/dev-tools/gcloud-service-key.json
       export GCP_PROJECT=$GCP_PROJECT_NAME
       cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
       $SERVICE_ACCOUNT_JSON
@@ -26,5 +26,5 @@ run:
 
       export WORKING_DIRECTORY=`pwd`
       
-      cd /home/toolbox/cloudshell_utilities
+      cd /home/dev-tools
       ./whitelist.sh $GCP_PROJECT $WORKING_DIRECTORY/census-rm-whitelist/environments/$GCP_PROJECT


### PR DESCRIPTION
# Motivation and Context
Now the toolbox has been split out the pipeline needs updating to use the new repos properly

# What has changed
* Update triggers/gets for census-rm-monitoring
* Update whitelist task to use census-rm-dev-tools

# How to test?
Check it looks good

# Links
https://trello.com/c/XHfzQUze/1257-split-cloudshell-utilities-and-monitoring-tools-out-of-census-rm-toolbox