### PR TITLE
Remove accidental regression tests trigger on monitoring repo

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -3392,7 +3392,6 @@ jobs:
   - get: toolbox-master
     passed: ["CI Deploy Toolbox"]
   - get: monitoring-master
-    trigger: true
     passed: ["CI Deploy Database Monitor",
              "CI Deploy Rabbit Monitor",
              "CI Deploy Regional Counts"]


### PR DESCRIPTION
# Motivation and Context
Trigger shouldn't be there

# What has changed
* Remove trigger

# How to test?
Unnecessary
 
# Links
https://trello.com/c/XHfzQUze/1257-split-cloudshell-utilities-and-monitoring-tools-out-of-census-rm-toolbox