### PR TITLE
Added cron for nightly performance tests

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -4,12 +4,29 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
 
+- name: cron-resource
+  type: docker-image
+  source:
+    repository: cftoolsmiths/cron-resource
+
 resources:
 
 - name: slack-alert
   type: slack-notification
   source:
     url: ((slack.webhook))
+
+- name: every-weekday-midnight
+  type: cron-resource
+  source:
+    expression: "0 0 * * 1-5"
+    fire_immediately: true
+
+- name: every-weekend
+  type: cron-resource
+  source:
+    expression: "0 0 * * 0"
+    fire_immediately: true
 
 - name: census-rm-deploy
   type: git
@@ -243,6 +260,8 @@ jobs:
 
 - name: "Select Test - 30 million"
   plan:
+  - get: every-weekend
+    trigger: true
   - task: "Select test scenario"
     config:
         platform: linux
@@ -271,6 +290,8 @@ jobs:
 
 - name: "Select Test - 3.5 million"
   plan:
+  - get: every-weekday-midnight
+    trigger: true
   - task: "Select test scenario"
     config:
         platform: linux
@@ -405,6 +426,12 @@ jobs:
     params:
       skip_download: true
   - get: every-minute
+  - get: every-weekday-midnight
+    trigger: true
+    passed: ["Select Test - 3.5 million"]
+  - get: every-weekend
+    trigger: true
+    passed: ["Select Test - 30 million"]
 
 # Run Terraform
 - name: "Run Terraform"


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sometimes we can go weeks without running the performance tests so we've decided to make it a nightly job to run the 3.5 million performance test. On the weekend then we'll run the 30 million sample file through to make sure there hasn't been any degradation in RM.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added two cron resources for weekday nightly jobs and weekend performance tests
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Can't really test
- Check that the cron looks correct.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/X1VN2vKJ/1156-performance-test-nightly-run-automate-in-pipeline-8)
