### PR TITLE
Make exception manager and action scheduler stateful sets

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2512,8 +2512,8 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-deploy
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
+  - task: apply-service-and-statefulset
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-statefulset.yml
     on_failure: *slack_failure_alert_ci
     on_error: *slack_error_alert_ci
     params:
@@ -3044,8 +3044,8 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-deploy
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
+  - task: apply-service-and-statefulset
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-statefulset.yml
     on_failure: *slack_failure_alert_ci
     on_error: *slack_error_alert_ci
     params:
@@ -3885,8 +3885,8 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-deploy
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
+  - task: apply-service-and-statefulset
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-statefulset.yml
     on_failure: *slack_failure_alert_wl
     on_error: *slack_error_alert_wl
     params:
@@ -4356,8 +4356,8 @@ jobs:
     params:
       skip_download: true
   - get: census-rm-deploy
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy.yml
+  - task: apply-service-and-statefulset
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-statefulset.yml
     on_failure: *slack_failure_alert_wl
     on_error: *slack_error_alert_wl
     params:

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -336,8 +336,8 @@ jobs:
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked} 
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+  - task: apply-statefulset
+    file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))
@@ -752,8 +752,8 @@ jobs:
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+  - task: apply-statefulset-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-statefulset-and-deploy-no-patch.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -753,7 +753,7 @@ jobs:
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-statefulset-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-statefulset-and-deploy-no-patch.yml
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-statefulset-no-patch.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -661,8 +661,8 @@ jobs:
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+  - task: apply-statefulset-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-statefulset-and-deploy-no-patch.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -961,8 +961,8 @@ jobs:
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
-  - task: apply-service-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+  - task: apply-statefulset-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-statefulset-and-deploy-no-patch.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))

--- a/tasks/kubectl-apply-service-and-statefulset-no-patch.yml
+++ b/tasks/kubectl-apply-service-and-statefulset-no-patch.yml
@@ -1,0 +1,46 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-gcr/gcloud-kubectl
+
+params:
+  GCP_PROJECT_NAME:
+  KUBERNETES_CLUSTER:
+  KUBERNETES_STATEFULSET_NAME:
+  KUBERNETES_FILE_PATH:
+  KUBERNETES_FILE_PREFIX:
+  KUBERNETES_SELECTOR:
+  SERVICE_ACCOUNT_JSON:
+  WAIT_UNTIL_AVAILABLE_TIMEOUT:
+
+inputs:
+  - name: kubernetes-repo
+run:
+  path: sh
+  args:
+    - -exc
+    - |
+      cat >~/gcloud-service-key.json <<EOL
+      $SERVICE_ACCOUNT_JSON
+      EOL
+
+      # Use gcloud service account to configure kubectl
+      gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+      gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
+
+      # Apply service config
+      kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-service.yml --record
+
+      # Apply statefulset config
+      kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-statefulset.yml --record
+
+      # Patch statefulset with timestamp to force pod recreation
+      kubectl patch sts ${KUBERNETES_STATEFULSET_NAME} -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"timestamp\":\"`date +'%s'`\"}}}}}" --record
+
+      # Wait for rollout to finish
+      kubectl rollout status sts ${KUBERNETES_STATEFULSET_NAME} --watch=true --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT}
+
+      # Get statefulset status
+      kubectl get sts "-l ${KUBERNETES_SELECTOR}" -o wide

--- a/tasks/kubectl-apply-service-and-statefulset.yml
+++ b/tasks/kubectl-apply-service-and-statefulset.yml
@@ -1,0 +1,50 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-gcr/gcloud-kubectl
+
+params:
+  GCP_PROJECT_NAME:
+  KUBERNETES_CLUSTER:
+  KUBERNETES_STATEFULSET_NAME:
+  KUBERNETES_FILE_PATH:
+  KUBERNETES_FILE_PREFIX:
+  KUBERNETES_SELECTOR:
+  SERVICE_ACCOUNT_JSON:
+  WAIT_UNTIL_AVAILABLE_TIMEOUT:
+
+inputs:
+  - name: kubernetes-repo
+  - name: docker-image-resource
+run:
+  path: sh
+  args:
+    - -exc
+    - |
+      cat >~/gcloud-service-key.json <<EOL
+      $SERVICE_ACCOUNT_JSON
+      EOL
+
+      # Use gcloud service account to configure kubectl
+      gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+      gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
+
+      # Apply service config
+      kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-service.yml --record
+
+      # Apply statefulset config
+      kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-statefulset.yml --record
+
+      # Patch statefulset to use docker image specified in pipeline rather than statefulset script
+      kubectl patch sts ${KUBERNETES_STATEFULSET_NAME} --type='json' -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/image\",\"value\":\"$(cat docker-image-resource/repository)\"}]" --record
+
+      # Patch statefulset with timestamp/image digest to force pod recreation
+      kubectl patch sts ${KUBERNETES_STATEFULSET_NAME} -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"timestamp\":\"`date +'%s'`\",\"image-digest\":\"$(cat docker-image-resource/digest | cut -d':' -f2 | cut -c1-60)\"}}}}}" --record
+
+      # Wait for rollout to finish
+      kubectl rollout status sts ${KUBERNETES_STATEFULSET_NAME} --watch=true --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT}
+
+      # Get statefulset status
+      kubectl get sts "-l ${KUBERNETES_SELECTOR}" -o wide


### PR DESCRIPTION
# Motivation and Context
Exception Manager and Action Scheduler should only ever have a single instance running. By making them a stateful set, we can guarantee that.

# What has changed
Make 'em stateful sets.

# How to test?
Try it.

# Links
Trello: https://trello.com/c/l4PHfk10