### PR TITLE
fix command to scale action-scheduler as its not a statefulset in perf pipeline

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -536,7 +536,7 @@ jobs:
             gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
             # Scale apps down
-            kubectl scale deployment action-scheduler --replicas=0
+            kubectl scale statefulset action-scheduler --replicas=0
             kubectl scale deployment action-worker --replicas=0
             kubectl scale deployment action-processor --replicas=0
             kubectl scale deployment case-api --replicas=0
@@ -1168,7 +1168,7 @@ jobs:
             gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
             # Scale apps up
-            kubectl scale deployment action-scheduler --replicas=1
+            kubectl scale statefulset action-scheduler --replicas=1
             kubectl scale deployment action-worker --replicas=$ACTION_WORKER_REPLICAS
             kubectl scale deployment action-processor --replicas=$ACTION_PROCESSOR_REPLICAS
             kubectl scale deployment case-api --replicas=1


### PR DESCRIPTION
# Motivation and Context
THe performance pipeline has some tasks which scale certain services up and down, the action scheduler has been changed to be a stateful set so the scale command needs to change as well

# What has changed
changed the kubectl scale command for action-scheduler to use statefulset instead of deployment
