### PR TITLE
fix action scheduler and exception manager to use correct task in perf pipeline

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -536,7 +536,7 @@ jobs:
             gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
             # Scale apps down
-            kubectl scale deployment action-scheduler --replicas=0
+            kubectl scale statefulset action-scheduler --replicas=0
             kubectl scale deployment action-worker --replicas=0
             kubectl scale deployment action-processor --replicas=0
             kubectl scale deployment case-api --replicas=0
@@ -1168,7 +1168,7 @@ jobs:
             gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
             # Scale apps up
-            kubectl scale deployment action-scheduler --replicas=1
+            kubectl scale statefulset action-scheduler --replicas=1
             kubectl scale deployment action-worker --replicas=$ACTION_WORKER_REPLICAS
             kubectl scale deployment action-processor --replicas=$ACTION_PROCESSOR_REPLICAS
             kubectl scale deployment case-api --replicas=1

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -662,7 +662,7 @@ jobs:
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-statefulset-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-statefulset-and-deploy-no-patch.yml
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-statefulset-no-patch.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -962,7 +962,7 @@ jobs:
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-statefulset-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-statefulset-and-deploy-no-patch.yml
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-statefulset-no-patch.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))


### PR DESCRIPTION
# Motivation and Context
action-scheduler and exception-manager are configured to use a task that doesn;t exist in the perf pipeline

# What has changed
changed the action-scheduler and exception-manager deploy jobs to use the correct task
