### PR TITLE
fix action-scheduler deploy to use correct task

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -536,7 +536,7 @@ jobs:
             gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
             # Scale apps down
-            kubectl scale deployment action-scheduler --replicas=0
+            kubectl scale statefulset action-scheduler --replicas=0
             kubectl scale deployment action-worker --replicas=0
             kubectl scale deployment action-processor --replicas=0
             kubectl scale deployment case-api --replicas=0
@@ -1168,7 +1168,7 @@ jobs:
             gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
 
             # Scale apps up
-            kubectl scale deployment action-scheduler --replicas=1
+            kubectl scale statefulset action-scheduler --replicas=1
             kubectl scale deployment action-worker --replicas=$ACTION_WORKER_REPLICAS
             kubectl scale deployment action-processor --replicas=$ACTION_PROCESSOR_REPLICAS
             kubectl scale deployment case-api --replicas=1

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -662,7 +662,7 @@ jobs:
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-statefulset-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-statefulset-and-deploy-no-patch.yml
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-statefulset-no-patch.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))
@@ -962,7 +962,7 @@ jobs:
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-statefulset-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-statefulset-and-deploy-no-patch.yml
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-statefulset-no-patch.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -662,7 +662,7 @@ jobs:
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: apply-statefulset-and-deploy
-    file: census-rm-deploy/tasks/kubectl-apply-service-and-statefulset-no-patch.yml
+    file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((performance-gcp-project-name))


### PR DESCRIPTION
# Motivation and Context
action-scheduler has no k8s service config in "prod" like envs but the deploy job in the perf pipeline tries to deploy one

# What has changed
updated the action-scheduler job to use the kubectl-apply-statefulset-no-patch.yml task
