### PR TITLE
Update rollout wait for action scheduler to stateful set

### DIFF
--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -1177,7 +1177,7 @@ jobs:
             kubectl scale deployment uacqidservice --replicas=$UAC_QID_REPLICAS
 
             # Wait for rollout to finish
-            kubectl rollout status deploy action-scheduler --watch=true --timeout=200s
+            kubectl rollout status sts action-scheduler --watch=true --timeout=200s
             kubectl rollout status deploy action-worker --watch=true --timeout=400s
             kubectl rollout status deploy action-processor --watch=true --timeout=200s
             kubectl rollout status deploy case-api --watch=true --timeout=200s


### PR DESCRIPTION
# Motivation and Context
Action scheduler is now a stateful set so the rollout check fails because it's looking for a deployment

# What has changed
1 word

# How to test?
Run the pipeline.  Cross fingers and toes.
