### PR TITLE
Manual pipeline action scheduler service missing

### DIFF
--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -337,7 +337,7 @@ jobs:
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked} 
   - task: apply-statefulset-and-service
-    file: census-rm-deploy/task/kubectl-apply-service-and-statefulset-no-patch.yml
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-statefulset-no-patch.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -336,8 +336,8 @@ jobs:
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked} 
-  - task: apply-statefulset
-    file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
+  - task: apply-statefulset-and-service
+    file: census-rm-deploy/task/kubectl-apply-service-and-statefulset-no-patch.yml
     params:
       SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       GCP_PROJECT_NAME: ((gcp-project-name))


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Yogi was unable to connect to ops tool in blacklodge due to the action scheduler missing its service. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Changed to use the service and stateful set task
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Fly and hope
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):