### PR TITLE
Split pipeline pipeline in to prod and dev

### DIFF
--- a/pipelines/concourse-pipelines-dev.yml
+++ b/pipelines/concourse-pipelines-dev.yml
@@ -1,0 +1,166 @@
+resource_types:
+
+  # Recent release 3.0.0 needs the fly version to be 6.1.0 to work. Ours is currently 5.6.0 so we need to pin the resource 
+  # to a previous release instead of using the latest image.
+  - name: concourse-pipeline
+    type: docker-image
+    source:
+      repository: concourse/concourse-pipeline-resource
+      tag: 2.2.0
+
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+
+resources:
+
+  - name: slack-alert
+    type: slack-notification
+    source:
+      url: ((slack.webhook))
+
+  - name: census-rm-deploy
+    type: git
+    source:
+      uri: git@github.com:ONSdigital/census-rm-deploy.git
+      paths:
+      - "pipelines"
+      - "tasks"
+      private_key: ((github.service_account_private_key))
+
+  - name: pipelines
+    type: concourse-pipeline
+    source:
+      target: http://concourse-web:8080/
+      teams:
+      - name: rm
+        username: rm
+        password: ((concourse.team-pass))
+
+jobs:
+
+  - name: fly-dev-pipelines
+    plan:
+    - get: census-rm-deploy
+      trigger: true
+    - put: pipelines
+      on_failure:
+        put: slack-alert
+        params:
+          icon_emoji: ":concourse:"
+          username: Concourse
+          attachments: [
+            {
+              "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+              "title": "$BUILD_JOB_NAME failed",
+              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+              "fields": [
+                {
+                  "title": "Pipeline",
+                  "value": "$BUILD_PIPELINE_NAME",
+                  "short": true
+                },
+                {
+                  "title": "Build",
+                  "value": "#$BUILD_NAME",
+                  "short": true
+                }
+              ],
+              "color": "#ff0000"
+            }
+          ]
+
+      on_error:
+        put: slack-alert
+        params:
+          icon_emoji: ":concourse:"
+          username: Concourse
+          attachments: [
+            {
+              "fallback": "$BUILD_JOB_NAME errored. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+              "title": "$BUILD_JOB_NAME errored",
+              "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+              "fields": [
+                {
+                  "title": "Pipeline",
+                  "value": "$BUILD_PIPELINE_NAME",
+                  "short": true
+                },
+                {
+                  "title": "Build",
+                  "value": "#$BUILD_NAME",
+                  "short": true
+                }
+              ],
+              "color": "#f58a3d"
+            }
+          ]
+
+      params:
+        pipelines:
+
+        - name: fly-dev-pipelines
+          team: rm
+          config_file: census-rm-deploy/pipelines/concourse-pipelines-dev.yml
+          unpaused: true
+
+        - name: CI-Whitelodge Deploy
+          team: rm
+          config_file: census-rm-deploy/pipelines/build-deploy-test-CI-WL.yml
+          unpaused: true
+          vars:
+            acceptance-tests-image: eu.gcr.io/census-gcr-rm/rm/census-rm-acceptance-tests:latest
+            ci-gcp-environment-name: ci
+            ci-gcp-project-name: census-rm-ci
+            ci-kubernetes-cluster-name: rm-k8s-cluster
+            wl-gcp-environment-name: whitelodge
+            wl-gcp-project-name: census-rm-whitelodge
+            wl-kubernetes-cluster-name: rm-k8s-cluster
+            terraform-branch: master
+            docker-registry-ci: eu.gcr.io/census-rm-ci
+            docker-registry-gcr: eu.gcr.io/census-gcr-rm
+
+        - name: census-rm-blacklodge
+          team: rm
+          config_file: census-rm-deploy/pipelines/manual-release-pipeline.yml
+          vars:
+            gcp-environment-name: blacklodge
+            gcp-project-name: census-rm-blacklodge
+            kubernetes-cluster-name: rm-k8s-cluster
+            rabbit-config: release/rabbitmq/values.yml
+            prometheus-config: release/monitoring/prometheus-values.yml
+            grafana-config: release/monitoring/grafana-deployment.yml
+
+        - name: release-images
+          team: rm
+          config_file: census-rm-deploy/pipelines/build-release-images.yml
+          unpaused: true
+          vars:
+            docker-registry-ci: eu.gcr.io/census-rm-ci
+            docker-registry-gcr: eu.gcr.io/census-gcr-rm
+
+        - name: census-rm-performance
+          team: rm
+          config_file: census-rm-deploy/pipelines/performance-tests-pipeline.yml
+          unpaused: true
+          vars:
+            performance-gcp-project-name: census-rm-performance
+            performance-kubernetes-cluster-name: rm-k8s-cluster
+            performance-tests-image: eu.gcr.io/census-gcr-rm/rm/census-rm-performance-tests
+            case-processor-replicas: 4
+            action-worker-replicas: 10
+            action-processor-replicas: 2
+            uac-qid-replicas: 2
+            terraform-branch: master
+
+        - name: census-rm-greylodge
+          team: rm
+          config_file: census-rm-deploy/pipelines/manual-release-pipeline.yml
+          vars:
+            gcp-environment-name: greylodge
+            gcp-project-name: census-rm-greylodge
+            kubernetes-cluster-name: rm-k8s-cluster
+            rabbit-config: release/rabbitmq/values.yml
+            prometheus-config: release/monitoring/prometheus-values.yml
+            grafana-config: release/monitoring/grafana-deployment.yml

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -43,7 +43,6 @@ jobs:
   - name: fly-pipelines
     plan:
     - get: census-rm-deploy
-      trigger: true
     - put: pipelines
       on_failure:
         put: slack-alert
@@ -105,55 +104,6 @@ jobs:
           config_file: census-rm-deploy/pipelines/concourse-pipelines.yml
           unpaused: true
 
-        - name: CI-Whitelodge Deploy
-          team: rm
-          config_file: census-rm-deploy/pipelines/build-deploy-test-CI-WL.yml
-          unpaused: true
-          vars:
-            acceptance-tests-image: eu.gcr.io/census-gcr-rm/rm/census-rm-acceptance-tests:latest
-            ci-gcp-environment-name: ci
-            ci-gcp-project-name: census-rm-ci
-            ci-kubernetes-cluster-name: rm-k8s-cluster
-            wl-gcp-environment-name: whitelodge
-            wl-gcp-project-name: census-rm-whitelodge
-            wl-kubernetes-cluster-name: rm-k8s-cluster
-            terraform-branch: master
-            docker-registry-ci: eu.gcr.io/census-rm-ci
-            docker-registry-gcr: eu.gcr.io/census-gcr-rm
-
-        - name: census-rm-blacklodge
-          team: rm
-          config_file: census-rm-deploy/pipelines/manual-release-pipeline.yml
-          vars:
-            gcp-environment-name: blacklodge
-            gcp-project-name: census-rm-blacklodge
-            kubernetes-cluster-name: rm-k8s-cluster
-            rabbit-config: release/rabbitmq/values.yml
-            prometheus-config: release/monitoring/prometheus-values.yml
-            grafana-config: release/monitoring/grafana-deployment.yml
-
-        - name: release-images
-          team: rm
-          config_file: census-rm-deploy/pipelines/build-release-images.yml
-          unpaused: true
-          vars:
-            docker-registry-ci: eu.gcr.io/census-rm-ci
-            docker-registry-gcr: eu.gcr.io/census-gcr-rm
-
-        - name: census-rm-performance
-          team: rm
-          config_file: census-rm-deploy/pipelines/performance-tests-pipeline.yml
-          unpaused: true
-          vars:
-            performance-gcp-project-name: census-rm-performance
-            performance-kubernetes-cluster-name: rm-k8s-cluster
-            performance-tests-image: eu.gcr.io/census-gcr-rm/rm/census-rm-performance-tests
-            case-processor-replicas: 4
-            action-worker-replicas: 10
-            action-processor-replicas: 2
-            uac-qid-replicas: 2
-            terraform-branch: master
-
         - name: census-rm-preprod
           team: rm
           config_file: census-rm-deploy/pipelines/manual-release-pipeline.yml
@@ -173,16 +123,5 @@ jobs:
             gcp-project-name: census-rm-prod
             kubernetes-cluster-name: rm-k8s-cluster
             rabbit-config: release/rabbitmq/values_prod.yml
-            prometheus-config: release/monitoring/prometheus-values.yml
-            grafana-config: release/monitoring/grafana-deployment.yml
-
-        - name: census-rm-greylodge
-          team: rm
-          config_file: census-rm-deploy/pipelines/manual-release-pipeline.yml
-          vars:
-            gcp-environment-name: greylodge
-            gcp-project-name: census-rm-greylodge
-            kubernetes-cluster-name: rm-k8s-cluster
-            rabbit-config: release/rabbitmq/values.yml
             prometheus-config: release/monitoring/prometheus-values.yml
             grafana-config: release/monitoring/grafana-deployment.yml


### PR DESCRIPTION
# Motivation and Context
We are splitting our dev/test pipelines into a new rm-dev space.
 
# What has changed
* Split dev pipelines into new concourse-pipelines-dev pipeline
* Remove auto trigger from prod pipeline pipeline, pipeline changes will now have to be triggered manually

# How to test?
Eyeball it

# Links
https://trello.com/c/CNwGP1qp/1482-move-non-prod-pipeline-to-new-rm-dev-concourse-space