### PR TITLE
Move greylodge pipeline to prod workspace

### DIFF
--- a/pipelines/concourse-pipelines-dev.yml
+++ b/pipelines/concourse-pipelines-dev.yml
@@ -153,14 +153,3 @@ jobs:
             action-processor-replicas: 2
             uac-qid-replicas: 2
             terraform-branch: master
-
-        - name: census-rm-greylodge
-          team: rm-dev
-          config_file: census-rm-deploy/pipelines/manual-release-pipeline.yml
-          vars:
-            gcp-environment-name: greylodge
-            gcp-project-name: census-rm-greylodge
-            kubernetes-cluster-name: rm-k8s-cluster
-            rabbit-config: release/rabbitmq/values.yml
-            prometheus-config: release/monitoring/prometheus-values.yml
-            grafana-config: release/monitoring/grafana-deployment.yml

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -105,7 +105,7 @@ jobs:
           unpaused: true
 
         - name: census-rm-greylodge
-          team: rm-dev
+          team: rm
           config_file: census-rm-deploy/pipelines/manual-release-pipeline.yml
           vars:
             gcp-environment-name: greylodge

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -104,6 +104,17 @@ jobs:
           config_file: census-rm-deploy/pipelines/concourse-pipelines.yml
           unpaused: true
 
+        - name: census-rm-greylodge
+          team: rm-dev
+          config_file: census-rm-deploy/pipelines/manual-release-pipeline.yml
+          vars:
+            gcp-environment-name: greylodge
+            gcp-project-name: census-rm-greylodge
+            kubernetes-cluster-name: rm-k8s-cluster
+            rabbit-config: release/rabbitmq/values.yml
+            prometheus-config: release/monitoring/prometheus-values.yml
+            grafana-config: release/monitoring/grafana-deployment.yml
+
         - name: census-rm-preprod
           team: rm
           config_file: census-rm-deploy/pipelines/manual-release-pipeline.yml

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -1177,7 +1177,7 @@ jobs:
             kubectl scale deployment uacqidservice --replicas=$UAC_QID_REPLICAS
 
             # Wait for rollout to finish
-            kubectl rollout status deploy action-scheduler --watch=true --timeout=200s
+            kubectl rollout status sts action-scheduler --watch=true --timeout=200s
             kubectl rollout status deploy action-worker --watch=true --timeout=400s
             kubectl rollout status deploy action-processor --watch=true --timeout=200s
             kubectl rollout status deploy case-api --watch=true --timeout=200s


### PR DESCRIPTION
# Motivation and Context
Greylodge is now a prod like environment so should be part of the locked down rm (prod) group in Concourse to prevent any unauthorised triggering of it.

# What has changed
<!--- What code changes has been made -->
Moved the greylodge pipeline deployment from the dev space (rm-dev) to the prod space (rm).

# How to test?
Merge it and run the fly pipelines job. It should appear in the right space - note - the old one in the other space will need to be manually deleted but it should not longer work anyway as the dev service account perms have been removed.

# Links
- https://trello.com/c/tNwdvZB2