### PR TITLE
Customise preprod and prod pipelines as needed for security

### DIFF
--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -117,7 +117,7 @@ jobs:
 
         - name: census-rm-preprod
           team: rm
-          config_file: census-rm-deploy/pipelines/manual-release-pipeline.yml
+          config_file: census-rm-deploy/pipelines/prod-manual-release-pipeline.yml
           vars:
             gcp-environment-name: preprod
             gcp-project-name: census-rm-preprod
@@ -128,7 +128,7 @@ jobs:
 
         - name: census-rm-prod
           team: rm
-          config_file: census-rm-deploy/pipelines/manual-release-pipeline.yml
+          config_file: census-rm-deploy/pipelines/prod-manual-release-pipeline.yml
           vars:
             gcp-environment-name: prod
             gcp-project-name: census-rm-prod

--- a/pipelines/prod-manual-release-pipeline.yml
+++ b/pipelines/prod-manual-release-pipeline.yml
@@ -1,0 +1,1093 @@
+---
+groups:
+- name: "Overview"
+  jobs:
+  - "Trigger Deployment"
+  - "Apply Database Patches"
+  - "Action Scheduler"
+  - "Action Worker"
+  - "Action Processor"
+  - "Case API"
+  - "Case Processor"
+  - "UAC QID Service"
+  - "PubSub Adapter"
+  - "Ops UI"
+  - "Print File Service"
+  - "Fieldwork Adapter"
+  - "Notify Processor"
+  - "QID Batch Runner"
+  - "Exception Manager"
+  - "Toolbox"
+  - "Database Monitor"
+  - "Rabbit Monitor"
+  - "Regional Counts"
+  - "Data Exporter"
+  - "Report Deployment Success"
+  - "Trigger Terraform"
+  - "Preview Terraform Changes"
+  - "Run Terraform"
+  - "Run Helm"
+  - "Deploy Monitoring"
+  - "Report Terraform Success"
+  - "Dewhitelist Nightly"
+
+- name: "Infrastructure"
+  jobs:
+  - "Trigger Terraform"
+  - "Preview Terraform Changes"
+  - "Run Terraform"
+  - "Run Helm"
+  - "Deploy Monitoring"
+  - "Report Terraform Success"
+  - "Dewhitelist Nightly"
+
+- name: "App Deployment"
+  jobs:
+  - "Trigger Deployment"
+  - "Apply Database Patches"
+  - "Action Scheduler"
+  - "Action Worker"
+  - "Action Processor"
+  - "Case API"
+  - "Case Processor"
+  - "UAC QID Service"
+  - "PubSub Adapter"
+  - "Ops UI"
+  - "Print File Service"
+  - "Fieldwork Adapter"
+  - "Notify Processor"
+  - "QID Batch Runner"
+  - "Exception Manager"
+  - "Toolbox"
+  - "Database Monitor"
+  - "Rabbit Monitor"
+  - "Regional Counts"
+  - "Data Exporter"
+  - "Report Deployment Success"
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+
+
+- name: cron-resource
+  type: docker-image
+  source:
+    repository: cftoolsmiths/cron-resource
+
+resources:
+
+- name: every-midnight
+  type: cron-resource
+  source:
+    expression: "0 0 * * *"
+    fire_immediately: true
+
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: ((slack.webhook))
+
+- name: census-rm-deploy
+  type: git
+  source:
+    uri: git@github.com:ONSdigital/census-rm-deploy.git
+    private_key: ((github.service_account_private_key))
+
+- name: census-rm-terraform-release
+  type: github-release
+  source:
+    owner: ONSdigital
+    repository: census-rm-terraform
+    access_token: ((github.access_token))
+
+- name: census-rm-kubernetes-release
+  type: github-release
+  source:
+    owner: ONSdigital
+    repository: census-rm-kubernetes
+    access_token: ((github.access_token))
+
+- name: every-minute
+  type: time
+  source:
+    interval: 1m
+
+templating:
+
+slack_failure_alert: &slack_failure_alert
+  put: slack-alert
+  params:
+    icon_emoji: ":concourse:"
+    username: Concourse
+    attachments: [
+      {
+        "fallback": "$BUILD_JOB_NAME failed. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "title": "$BUILD_JOB_NAME failed",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "fields": [
+          {
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Environment",
+            "value": "((gcp-environment-name))",
+            "short": true
+          },
+          {
+            "title": "Project",
+            "value": "((gcp-project-name))",
+            "short": true
+          },
+          {
+            "title": "Build",
+            "value": "#$BUILD_NAME",
+            "short": true
+          }
+        ],
+          "color": "#ff0000"
+      }
+    ]
+
+slack_error_alert: &slack_error_alert
+  put: slack-alert
+  params:
+    icon_emoji: ":concourse:"
+    username: Concourse
+    attachments: [
+      {
+        "fallback": "$BUILD_JOB_NAME errored. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "title": "$BUILD_JOB_NAME errored",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME",
+        "fields": [
+          {
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Environment",
+            "value": "((gcp-environment-name))",
+            "short": true
+          },
+          {
+            "title": "Project",
+            "value": "((gcp-project-name))",
+            "short": true
+          },
+          {
+            "title": "Build",
+            "value": "#$BUILD_NAME",
+            "short": true
+          }
+        ],
+        "color": "#f58a3d"
+      }
+    ]
+
+slack_success_alert: &slack_success_alert
+  put: slack-alert
+  params:
+    icon_emoji: ":concourse:"
+    username: Concourse
+    attachments: [
+      {
+        "fallback": "((gcp-environment-name)) release succeeded. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+        "title": "((gcp-environment-name)) Release Succeeded",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+        "fields": [
+          {
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Environment",
+            "value": "((gcp-environment-name))",
+            "short": true
+          },
+          {
+            "title": "Project",
+            "value": "((gcp-project-name))",
+            "short": true
+          }
+        ],
+        "color": "#36a64f"
+      }
+    ]
+
+slack_in_progress_alert: &slack_in_progress_alert
+  put: slack-alert
+  params:
+    icon_emoji: ":concourse:"
+    username: Concourse
+    attachments: [
+      {
+        "fallback": "((gcp-environment-name)) release started. See build: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+        "title": "((gcp-environment-name)) Release Started",
+        "title_link": "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME",
+        "fields": [
+          {
+            "title": "Pipeline",
+            "value": "$BUILD_PIPELINE_NAME",
+            "short": true
+          },
+          {
+            "title": "Environment",
+            "value": "((gcp-environment-name))",
+            "short": true
+          },
+          {
+            "title": "Project",
+            "value": "((gcp-project-name))",
+            "short": true
+          }
+        ],
+        "color": "#ffe100"
+      }
+    ]
+
+
+jobs:
+
+- name: "Trigger Deployment"
+  serial: true
+  plan:
+    - get: every-minute
+    - get: census-rm-kubernetes-release
+
+- name: "Apply Database Patches"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [apply-database-patches,
+                  action-scheduler,
+                  action-worker,
+                  action-processor,
+                  case-api,
+                  case-processor,
+                  uac-qid-service,
+                  pubsub-adapter,
+                  ops-ui,
+                  print-file-service,
+                  fieldwork-adapter,
+                  notify-processor,
+                  exception-manager,
+                  toolbox,
+                  database-monitor,
+                  rabbitmonitor,
+                  regionalcounts,
+                  dataexporter]
+  on_failure: *slack_failure_alert
+  plan:
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger Deployment"]
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Trigger Deployment"]
+  - get: census-rm-deploy
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-database-patches
+    file: census-rm-deploy/tasks/kubectl-apply-ddl-patches.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Action Scheduler"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [action-scheduler]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: [ "Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked} 
+  - task: apply-statefulset
+    file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_STATEFULSET_NAME: action-scheduler
+      KUBERNETES_SELECTOR: app=action-scheduler
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: action-scheduler
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Action Worker"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [action-worker]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: action-worker
+      KUBERNETES_SELECTOR: app=action-worker
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: action-worker
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Action Processor"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [action-processor]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: [ "Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: action-processor
+      KUBERNETES_SELECTOR: app=action-processor
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: action-processor
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Case API"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [case-api]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: case-api
+      KUBERNETES_SELECTOR: app=case-api
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: case-api
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Case Processor"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [case-processor]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: case-processor
+      KUBERNETES_SELECTOR: app=case-processor
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: case-processor
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "UAC QID Service"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [uac-qid-service]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-service-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: uacqidservice
+      KUBERNETES_SELECTOR: app=uacqidservice
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: uac-qid-service
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "PubSub Adapter"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [pubsub-adapter]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: pubsub-adapter
+      KUBERNETES_SELECTOR: app=pubsub-adapter
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: pubsub-adapter
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Ops UI"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [ops-ui]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-deploy-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: ops-ui
+      KUBERNETES_SELECTOR: app=ops-ui
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: ops-ui
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Print File Service"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [print-file-service]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_STATEFULSET_NAME: printfilesvc
+      KUBERNETES_SELECTOR: app=printfilesvc
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: print-file-service
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Fieldwork Adapter"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [fieldwork-adapter]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: fieldwork-adapter
+      KUBERNETES_SELECTOR: app=fieldwork-adapter
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: fieldwork-adapter
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Notify Processor"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [notify-processor]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: notify-processor
+      KUBERNETES_SELECTOR: app=notify-processor
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: notify-processor
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "QID Batch Runner"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [qid-batch-runner]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: qid-batch-runner
+      KUBERNETES_SELECTOR: app=qid-batch-runner
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
+      KUBERNETES_FILE_PREFIX: qid-batch-runner
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Exception Manager"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [exception-manager]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-statefulset-and-deploy
+    file: census-rm-deploy/tasks/kubectl-apply-service-and-statefulset-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_STATEFULSET_NAME: exception-manager
+      KUBERNETES_SELECTOR: app=exception-manager
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/microservices
+      KUBERNETES_FILE_PREFIX: exception-manager
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Toolbox"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [toolbox]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-statefulset
+    file: census-rm-deploy/tasks/kubectl-apply-statefulset-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_STATEFULSET_NAME: census-rm-toolbox
+      KUBERNETES_SELECTOR: app=census-rm-toolbox
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
+      KUBERNETES_FILE_PREFIX: census-rm-toolbox
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Database Monitor"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [database-monitor]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: database-monitor
+      KUBERNETES_SELECTOR: app=database-monitor
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
+      KUBERNETES_FILE_PREFIX: database-monitor
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Rabbit Monitor"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [rabbitmonitor]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: rabbitmonitor
+      KUBERNETES_SELECTOR: app=rabbitmonitor
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
+      KUBERNETES_FILE_PREFIX: rabbitmonitor
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Regional Counts"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [regionalcounts]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-deployment-no-patch.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: regionalcounts
+      KUBERNETES_SELECTOR: app=regionalcounts
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
+      KUBERNETES_FILE_PREFIX: regional-counts
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Data Exporter"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [dataexporter]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - get: census-rm-deploy
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches"]
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: apply-deployment
+    file: census-rm-deploy/tasks/kubectl-apply-cronjob-and-pv.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      KUBERNETES_DEPLOYMENT_NAME: data-exporter
+      KUBERNETES_FILE_PATH: kubernetes-repo/release/optional
+      KUBERNETES_FILE_PREFIX: dataexporter
+      WAIT_UNTIL_AVAILABLE_TIMEOUT: 200s
+    input_mapping: {kubernetes-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Report Deployment Success"
+  disable_manual_trigger: true
+  serial: true
+  plan:
+  - get: every-minute
+    trigger: true
+    passed: ["Apply Database Patches",
+            "Action Scheduler",
+            "Action Worker",
+            "Action Processor",
+            "Case API",
+            "Case Processor",
+            "UAC QID Service",
+            "PubSub Adapter",
+            "Print File Service",
+            "Ops UI",
+            "Fieldwork Adapter",
+            "Notify Processor",
+            "Exception Manager",
+            "Toolbox",
+            "Database Monitor",
+            "Rabbit Monitor",
+            "Regional Counts",
+            "Data Exporter"]
+
+# Infrastructure
+- name: "Trigger Terraform"
+  serial: true
+  serial_groups: [
+    action-scheduler,
+    action-worker,
+    action-processor,
+    case-api,
+    case-processor,
+    fieldwork-adapter,
+    notify-processor,
+    uac-qid-service,
+    pubsub-adapter,
+    print-file-service,
+    exception-manager,
+    toolbox,
+    rabbitmonitor,
+    dataexporter]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+    - get: every-minute
+
+- name: "Preview Terraform Changes"
+  plan:
+  - get: census-rm-terraform-release
+    params: {include_source_tarball: true}
+  - get: census-rm-deploy
+  - task: unpack-terraform-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-terraform-release}
+    output_mapping: {unpacked-release: census-rm-terraform-release-unpacked}
+  - task: "Preview Terraform Changes"
+    file: census-rm-deploy/tasks/preview-changes-terraform-env.yml
+    params:
+      ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      ENV: ((gcp-environment-name))
+      VAR_FILE: ./tfvars/((gcp-project-name)).tfvars
+      KUBERNETES_CLUSTER: rm-k8s-cluster
+    input_mapping: {census-rm-terraform: census-rm-terraform-release-unpacked}
+
+
+- name: "Run Terraform"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [action-scheduler,
+                  action-worker,
+                  action-processor,
+                  case-api,
+                  case-processor,
+                  fieldwork-adapter,
+                  notify-processor,
+                  uac-qid-service,
+                  pubsub-adapter,
+                  print-file-service,
+                  exception-manager,
+                  toolbox,
+                  rabbitmonitor,
+                  dataexporter]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: every-minute
+    trigger: true
+    passed: ["Trigger Terraform"]
+  - get: census-rm-terraform-release
+    params: {include_source_tarball: true}
+  - get: census-rm-deploy
+  - task: unpack-terraform-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-terraform-release}
+    output_mapping: {unpacked-release: census-rm-terraform-release-unpacked} 
+  - task: "Run Terraform"
+    file: census-rm-deploy/tasks/terraform-env.yml
+    params:
+      ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      ENV: ((gcp-environment-name))
+      VAR_FILE: ./tfvars/((gcp-project-name)).tfvars
+      KUBERNETES_CLUSTER: rm-k8s-cluster
+    input_mapping: {census-rm-terraform: census-rm-terraform-release-unpacked}
+
+- name: "Run Helm"
+  disable_manual_trigger: true
+  serial: true
+  serial_groups: [action-scheduler,
+                  action-worker,
+                  action-processor,
+                  case-api,
+                  case-processor,
+                  fieldwork-adapter,
+                  notify-processor,
+                  uac-qid-service,
+                  pubsub-adapter,
+                  print-file-service,
+                  exception-manager,
+                  toolbox,
+                  rabbitmonitor,
+                  dataexporter]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+  - get: every-minute
+    trigger: true
+    passed: ["Run Terraform"]
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+  - get: census-rm-deploy
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+  - task: "Run Helm"
+    file: census-rm-deploy/tasks/helm.yml
+    params:
+      ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      ENV: ((gcp-environment-name))
+      KUBERNETES_CLUSTER: rm-k8s-cluster
+      RABBITMQ_CONFIG_VALUES_FILE: ((rabbit-config))
+    input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Deploy Monitoring"
+  serial: true
+  serial_groups: [action-scheduler,
+                  action-worker,
+                  action-processor,
+                  case-api,
+                  case-processor,
+                  fieldwork-adapter,
+                  notify-processor,
+                  uac-qid-service,
+                  pubsub-adapter,
+                  print-file-service,
+                  exception-manager,
+                  toolbox,
+                  rabbitmonitor,
+                  dataexporter]
+  on_error: *slack_error_alert
+  on_failure: *slack_failure_alert
+  plan:
+    - get: every-minute
+      trigger: true
+      passed: ["Run Helm"]
+    - get: census-rm-kubernetes-release
+      params: {include_source_tarball: true}
+    - get: census-rm-deploy
+    - task: unpack-kubernetes-release
+      file: census-rm-deploy/tasks/unpack-release.yml
+      input_mapping: {release: census-rm-kubernetes-release}
+      output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
+    - task: "Deploy Monitoring"
+      file: census-rm-deploy/tasks/monitoring.yml
+      params:
+        ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+        ENV: ((gcp-environment-name))
+        KUBERNETES_CLUSTER: rm-k8s-cluster
+        RABBITMQ_CONFIG_VALUES_FILE: ((rabbit-config))
+        PROMETHEUS_CONFIG_VALUES_FILE: ((prometheus-config))
+        GRAFANA_CONFIG_VALUES_FILE: ((grafana-config))
+      input_mapping: {census-rm-kubernetes-monitoring-repo: census-rm-kubernetes-release-unpacked}
+
+- name: "Report Terraform Success"
+  disable_manual_trigger: true
+  serial: true
+  on_success: *slack_success_alert
+  plan:
+  - get: every-minute
+    trigger: true
+    passed: [
+      "Run Terraform",
+      "Run Helm"]
+
+- name: "Dewhitelist Nightly"
+  serial: true
+  on_failure: *slack_failure_alert
+  on_error: *slack_error_alert
+  plan:
+  - get: every-midnight
+    trigger: true
+  - get: census-rm-deploy
+  - task: dewhitelist-nightly
+    file: census-rm-deploy/tasks/prod-dewhitelist.yml
+    params:
+      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+      GCP_PROJECT_NAME: ((gcp-project-name))
+      KUBERNETES_CLUSTER: ((kubernetes-cluster-name))
+      CI_NAT_IP: ((secretips.ci-nat-ip))

--- a/tasks/prod-dewhitelist.yml
+++ b/tasks/prod-dewhitelist.yml
@@ -1,0 +1,40 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: eu.gcr.io/census-gcr-rm/rm/census-rm-dev-tools
+    username: _json_key
+    password: ((gcp.service_account_json))
+params:
+  GCP_PROJECT_NAME:
+  SERVICE_ACCOUNT_JSON:
+  KUBERNETES_CLUSTER:
+  CI_NAT_IP:
+run:
+  path: bash
+  args:
+    - -exc
+    - |
+      export GOOGLE_APPLICATION_CREDENTIALS=/home/dev-tools/gcloud-service-key.json
+      export GCP_PROJECT=$GCP_PROJECT_NAME
+      cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
+      $SERVICE_ACCOUNT_JSON
+      EOL
+      gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+      gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT}
+
+      cd /home/dev-tools
+
+      cat >only_ci_nat_whitelist <<EOL
+      [
+        {
+          "name": "CI NAT",
+          "ip": "$CI_NAT_IP",
+          "cluster": true,
+          "database": false,
+          "services": []
+        }
+      ]
+      EOL
+
+      ./whitelist.sh $GCP_PROJECT only_ci_nat_whitelist


### PR DESCRIPTION
# Motivation and Context
Our production environment (and preprod) are the most secure environments of all. As such, the whitelisting mechanism we use for test environment convenience is not appropriate. Also, the "ops" test tool should never be deployed to prod.

# What has changed
* Created 'prod' version of manual release pipeline
* Removed whitelisting jobs
* Added job to dewhitelist any IPs which any ops person might've forgotten to dewhitelist
* Removed ops

# How to test?
Eyeball it.

# Links
Trello: https://trello.com/c/Eh64BB0X