### PR TITLE
Add specific prod configuration to the prod pipeline for Helm

### DIFF
--- a/pipelines/prod-manual-release-pipeline.yml
+++ b/pipelines/prod-manual-release-pipeline.yml
@@ -1017,7 +1017,7 @@ jobs:
     input_mapping: {release: census-rm-kubernetes-release}
     output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: "Run Helm"
-    file: census-rm-deploy/tasks/helm.yml
+    file: census-rm-deploy/tasks/prod-helm.yml
     params:
       ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       ENV: ((gcp-environment-name))

--- a/tasks/prod-helm.yml
+++ b/tasks/prod-helm.yml
@@ -1,0 +1,36 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: google/cloud-sdk
+params:
+  ENV:
+  ADMIN_SERVICE_ACCOUNT_JSON:
+  KUBERNETES_CLUSTER:
+  RABBITMQ_CONFIG_VALUES_FILE:
+inputs:
+  - name: census-rm-kubernetes-dependencies-repo
+run:
+  path: bash
+  args:
+    - -exc
+    - |
+      export GOOGLE_APPLICATION_CREDENTIALS=/root/gcloud-service-key.json
+      export GCP_PROJECT=census-rm-$ENV
+      cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
+      $ADMIN_SERVICE_ACCOUNT_JSON
+      EOL
+      gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+      gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT}
+
+      apt-get install -y procps  # NB: procps is used by Helm
+      curl -L https://git.io/get_helm.sh | bash -s -- --version v2.16.3
+      helm init --client-only
+      helm plugin install https://github.com/rimusz/helm-tiller
+
+      cd census-rm-kubernetes-dependencies-repo
+      export HELM_TILLER_SILENT=true
+
+      cd release
+      
+      ENV=${ENV} RABBITMQ_CONFIG_VALUES_FILE=${RABBITMQ_CONFIG_VALUES_FILE} ./setup-dependencies.sh


### PR DESCRIPTION
# Motivation and Context
Rabbit is using our non-release scripts and dependencies YAML config when it runs in the pipeline.

# What has changed
Added prod specific version of the helm task.

# How to test?
Fly it. Try it.

# Links
Trello: https://trello.com/c/9Sks0qDF