### PR TITLE
Changing blacklodge pipeline to use rabbit prod config.

### DIFF
--- a/pipelines/concourse-pipelines-dev.yml
+++ b/pipelines/concourse-pipelines-dev.yml
@@ -128,7 +128,7 @@ jobs:
             gcp-environment-name: blacklodge
             gcp-project-name: census-rm-blacklodge
             kubernetes-cluster-name: rm-k8s-cluster
-            rabbit-config: release/rabbitmq/values.yml
+            rabbit-config: release/rabbitmq/values_prod.yml
             prometheus-config: release/monitoring/prometheus-values.yml
             grafana-config: release/monitoring/grafana-deployment.yml
 


### PR DESCRIPTION
# Motivation and Context
Blacklodge crashed due to processing a 24 million sample file but it only had 8Gig disks. We are now setting up blacklodge to use prod spec configuration.