### PR TITLE
Updating performance pipeline to point to new rabbit

### DIFF
--- a/pipelines/concourse-pipelines-dev.yml
+++ b/pipelines/concourse-pipelines-dev.yml
@@ -157,6 +157,6 @@ jobs:
             action-processor-replicas: 2
             uac-qid-replicas: 2
             terraform-branch: master
-            rabbitmq-file: census-rm-deploy/tasks/prod-helm.yml
+            rabbitmq-file: census-rm-deploy/tasks/rabbitmq-provision.yml
             rabbitmq-production-setup: true
             rabbit-config: release/rabbitmq/values_prod.yml

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -1288,10 +1288,10 @@ jobs:
               gsutil -m rm gs://census-rm-performance-sent-print-files/** || true
 
   - task: "Tear Down Rabbit"
-    input_mapping: {census-rm-kubernetes-release-unpacked: unpacked-release}
+    input_mapping: {census-rm-kubernetes-repo: census-rm-kubernetes-release-unpacked}
     config:
       inputs:
-      - name: census-rm-kubernetes-release-unpacked
+      - name: census-rm-kubernetes-repo
       platform: linux
       image_resource:
         type: docker-image
@@ -1314,7 +1314,7 @@ jobs:
             gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
             gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
             
-            cd census-rm-kubernetes-release-unpacked
+            cd census-rm-kubernetes-repo
             ./teardown-rabbitmq.sh
 
 

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -1254,6 +1254,12 @@ jobs:
   - get: every-minute
     trigger: true
     passed: ["Performance Tests"]
+  - get: census-rm-kubernetes-release
+    params: {include_source_tarball: true}
+  - task: unpack-kubernetes-release
+    file: census-rm-deploy/tasks/unpack-release.yml
+    input_mapping: {release: census-rm-kubernetes-release}
+    output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
   - task: "Remove Print Files"
     config:
         platform: linux
@@ -1282,7 +1288,10 @@ jobs:
               gsutil -m rm gs://census-rm-performance-sent-print-files/** || true
 
   - task: "Tear Down Rabbit"
+    input_mapping: {census-rm-kubernetes-release-unpacked: unpacked-release}
     config:
+      inputs:
+      - name: census-rm-kubernetes-release-unpacked
       platform: linux
       image_resource:
         type: docker-image
@@ -1304,18 +1313,10 @@ jobs:
             # Use gcloud service account to configure kubectl
             gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
             gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
+            
+            cd census-rm-kubernetes-release-unpacked
+            ./teardown-rabbitmq.sh
 
-            # Install helm and helm-tiller
-            apt-get install -y procps  # NB: procps is used by Helm
-            curl -L https://git.io/get_helm.sh | bash -s -- --version v2.16.3
-            helm init --client-only
-            helm plugin install https://github.com/rimusz/helm-tiller
-            # Purge Rabbit helm
-            helm tiller run helm delete rm --purge
-            # Delete Rabbit persistent volumes
-            kubectl delete pvc data-rabbitmq-0
-            kubectl delete pvc data-rabbitmq-1
-            kubectl delete pvc data-rabbitmq-2
 
   - task: "Remove node-pools"
     config:


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For the release of the rabbit operator into the performance env, we need to change the variables it flies for the pipeline. We also need to change the teardown job to run the new teardown script.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Performance pipeline now uses new rabbit operator
- update teardown job to use teardown-rabbitmq.sh

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Hard to test

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/bpg2AZWM/1732-release-rabbitmq-operator-to-the-performance-env)
# Screenshots (if appropriate):