### PR TITLE
Rabbit updates for performance pipeline

### DIFF
--- a/pipelines/concourse-pipelines-dev.yml
+++ b/pipelines/concourse-pipelines-dev.yml
@@ -157,6 +157,6 @@ jobs:
             action-processor-replicas: 2
             uac-qid-replicas: 2
             terraform-branch: master
-            rabbitmq-file: census-rm-deploy/tasks/rabbitmq-provision.yml
+            rabbitmq-file: census-rm-deploy/tasks/performance-rabbitmq-provision.yml
             rabbitmq-production-setup: true
             rabbit-config: release/rabbitmq/values_prod.yml

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -1256,6 +1256,7 @@ jobs:
     passed: ["Performance Tests"]
   - get: census-rm-kubernetes-release
     params: {include_source_tarball: true}
+  - get: census-rm-deploy
   - task: unpack-kubernetes-release
     file: census-rm-deploy/tasks/unpack-release.yml
     input_mapping: {release: census-rm-kubernetes-release}

--- a/tasks/performance-rabbitmq-provision.yml
+++ b/tasks/performance-rabbitmq-provision.yml
@@ -1,0 +1,28 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: google/cloud-sdk
+params:
+  ENV:
+  ADMIN_SERVICE_ACCOUNT_JSON:
+  KUBERNETES_CLUSTER:
+  RABBITMQ_PRODUCTION_SETUP:
+inputs:
+  - name: census-rm-kubernetes-dependencies-repo
+run:
+  path: bash
+  args:
+    - -exc
+    - |
+      export GOOGLE_APPLICATION_CREDENTIALS=/root/gcloud-service-key.json
+      export GCP_PROJECT=census-rm-$ENV
+      cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
+      $ADMIN_SERVICE_ACCOUNT_JSON
+      EOL
+      gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+      gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT}
+
+      cd census-rm-kubernetes-dependencies-repo
+
+      ENV=${ENV} RABBITMQ_PRODUCTION_SETUP=${RABBITMQ_PRODUCTION_SETUP} ./setup-rabbitmq.sh


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The teardown job is missing the census-rm-deploy resource so that's been added to the job. What realised is that the performance pipeline needs to run the install as well so I've created a new task to run the `setup-rabbitmq.sh`. This should be able to determine whether to run the install or update depending if the CRD is there.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added census-rm-deploy resource to teardown job
- Created new rabbit file to be used for performance

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Test in the pipeline

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/bpg2AZWM/1732-release-rabbitmq-operator-to-the-performance-env)
