### PR TITLE
Update Grey Lodge pipeline for Rabbit K8S Operator

### DIFF
--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -114,7 +114,7 @@ jobs:
             rabbit-config: release/rabbitmq/values_prod.yml
             prometheus-config: release/monitoring/prometheus-values.yml
             grafana-config: release/monitoring/grafana-deployment.yml
-            rabbitmq-file: census-rm-deploy/tasks/prod-helm.yml
+            rabbitmq-file: census-rm-deploy/tasks/rabbitmq-provision.yml
             rabbitmq-production-setup: true
 
         - name: census-rm-preprod


### PR DESCRIPTION
# Motivation and Context
We're using a Kubernetes Operator to build the Rabbit cluster now.

# What has changed
Pointed the GL pipeline at the new file it needs to use.

# How to test?
Well, it's difficult, but we essentially will just fail forwards. It'll get tested in Grey Lodge really soon.

# Links
Trello: https://trello.com/c/pSdIVI95