### PR TITLE
Removed helm config from all pipelines before pre-prod

### DIFF
--- a/pipelines/concourse-pipelines-dev.yml
+++ b/pipelines/concourse-pipelines-dev.yml
@@ -130,7 +130,6 @@ jobs:
             gcp-environment-name: blacklodge
             gcp-project-name: census-rm-blacklodge
             kubernetes-cluster-name: rm-k8s-cluster
-            rabbit-config: release/rabbitmq/values_prod.yml
             prometheus-config: release/monitoring/prometheus-values.yml
             grafana-config: release/monitoring/grafana-deployment.yml
             rabbitmq-file: census-rm-deploy/tasks/rabbitmq-provision.yml
@@ -159,4 +158,3 @@ jobs:
             terraform-branch: master
             rabbitmq-file: census-rm-deploy/tasks/performance-rabbitmq-provision.yml
             rabbitmq-production-setup: true
-            rabbit-config: release/rabbitmq/values_prod.yml

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -111,7 +111,6 @@ jobs:
             gcp-environment-name: greylodge
             gcp-project-name: census-rm-greylodge
             kubernetes-cluster-name: rm-k8s-cluster
-            rabbit-config: release/rabbitmq/values_prod.yml
             prometheus-config: release/monitoring/prometheus-values.yml
             grafana-config: release/monitoring/grafana-deployment.yml
             rabbitmq-file: census-rm-deploy/tasks/rabbitmq-provision.yml

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -1067,7 +1067,6 @@ jobs:
       ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
       ENV: ((gcp-environment-name))
       KUBERNETES_CLUSTER: rm-k8s-cluster
-      RABBITMQ_CONFIG_VALUES_FILE: ((rabbit-config))
       RABBITMQ_PRODUCTION_SETUP: ((rabbitmq-production-setup))
     input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release-unpacked}
 

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -641,7 +641,6 @@ jobs:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: performance
         KUBERNETES_CLUSTER: rm-k8s-cluster
-        RABBITMQ_CONFIG_VALUES_FILE: ((rabbit-config))
         RABBITMQ_PRODUCTION_SETUP: ((rabbitmq-production-setup))
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release-unpacked}
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Now that we've removed the helm rabbit from some environments, we can start removing the config it used for some tasks.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Removed `rabbitmq-config` from the pipelines that don't use helm rabbit anymore

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Can't really test

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/f3fWeheM/)

# Screenshots (if appropriate):