### PR TITLE
update CI/WL pipelines to use new monitoring helm3 concourse task

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2250,7 +2250,7 @@ jobs:
     - get: census-rm-deploy
     - get: census-rm-terraform
     - task: "CI Monitoring"
-      file: census-rm-deploy/tasks/monitoring.yml
+      file: census-rm-deploy/tasks/monitoring-helm3.yml
       params:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: ci
@@ -3652,7 +3652,7 @@ jobs:
     - get: census-rm-terraform
       passed: ["WL Terraform"]
     - task: "WL Monitoring"
-      file: census-rm-deploy/tasks/monitoring.yml
+      file: census-rm-deploy/tasks/monitoring-helm3.yml
       params:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: whitelodge

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -591,7 +591,7 @@ jobs:
       input_mapping: {release: census-rm-kubernetes-release}
       output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
     - task: "Monitoring"
-      file: census-rm-deploy/tasks/monitoring.yml
+      file: census-rm-deploy/tasks/monitoring-helm3.yml
       params:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: performance

--- a/tasks/monitoring-helm3.yml
+++ b/tasks/monitoring-helm3.yml
@@ -1,0 +1,32 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: google/cloud-sdk
+params:
+  ADMIN_SERVICE_ACCOUNT_JSON:
+  ENV:
+  KUBERNETES_CLUSTER:
+  PROMETHEUS_CONFIG_VALUES_FILE:
+  GRAFANA_CONFIG_VALUES_FILE:
+inputs:
+  - name: census-rm-kubernetes-monitoring-repo
+run:
+  path: bash
+  args:
+    - -exc
+    - |
+      export GOOGLE_APPLICATION_CREDENTIALS=/root/gcloud-service-key.json
+      export GCP_PROJECT=census-rm-$ENV
+      cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
+      $ADMIN_SERVICE_ACCOUNT_JSON
+      EOL
+      gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+      gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT}
+
+      apt-get install -y procps  # NB: procps is used by Helm
+      curl -L https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+      helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+
+      cd census-rm-kubernetes-monitoring-repo
+      ENV=${ENV} PROMETHEUS_CONFIG_VALUES_FILE=${PROMETHEUS_CONFIG_VALUES_FILE} GRAFANA_CONFIG_VALUES_FILE=${GRAFANA_CONFIG_VALUES_FILE} ./setup-monitoring.sh

--- a/tasks/monitoring-helm3.yml
+++ b/tasks/monitoring-helm3.yml
@@ -25,7 +25,7 @@ run:
       gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT}
 
       apt-get install -y procps  # NB: procps is used by Helm
-      curl -L https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+      curl -L https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash -s -- --version v3.4.2
       helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 
       cd census-rm-kubernetes-monitoring-repo


### PR DESCRIPTION
# Motivation and Context
helm2 has been deprecated and our monitoring deployments have started to fail

# What has changed
- added a new monitoring task to use helm3 to deploy prometheus
- updated the CI/WL pipeline to use the new monitoring task

# How to test?
an example of this task in use can be seen in here: https://concourse.rm.census-gcp.onsdigital.uk/teams/main/pipelines/daves-test-pipeline
