### PR TITLE
change the GL pipeline to use the new helm3 tasks for monitoring deploy

### DIFF
--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -1100,7 +1100,7 @@ jobs:
       input_mapping: {release: census-rm-kubernetes-release}
       output_mapping: {unpacked-release: census-rm-kubernetes-release-unpacked}
     - task: "Deploy Monitoring"
-      file: census-rm-deploy/tasks/monitoring.yml
+      file: census-rm-deploy/tasks/monitoring-helm3.yml
       params:
         ADMIN_SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
         ENV: ((gcp-environment-name))


### PR DESCRIPTION
# Motivation and Context
need to change the Greylodge pipeline to use the new helm3 tasks to deploy prometheus

# What has changed
update the manual-release-pipeline.yml to use the new taks

