### PR TITLE
Togglerable RabbitMQ Node Pools

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -2367,6 +2367,7 @@ jobs:
         ENV: ci
         KUBERNETES_CLUSTER: rm-k8s-cluster
         RABBITMQ_PRODUCTION_SETUP: ((rabbitmq-production-setup))
+        NODE_POOL_NAME: ((node-pool-name))
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-dependencies-repo}
 
 
@@ -3757,6 +3758,7 @@ jobs:
         ENV: whitelodge
         KUBERNETES_CLUSTER: rm-k8s-cluster
         RABBITMQ_PRODUCTION_SETUP: ((rabbitmq-production-setup))
+        NODE_POOL_NAME: ((node-pool-name))
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-dependencies-repo}
 
 # Apply Database Patches

--- a/pipelines/concourse-pipelines-dev.yml
+++ b/pipelines/concourse-pipelines-dev.yml
@@ -122,6 +122,7 @@ jobs:
             docker-registry-gcr: eu.gcr.io/census-gcr-rm
             rabbitmq-file: census-rm-deploy/tasks/rabbitmq-provision.yml
             rabbitmq-production-setup: false
+            node-pool-name: rabbit-node-pool
 
         - name: census-rm-blacklodge
           team: rm-dev
@@ -134,6 +135,7 @@ jobs:
             grafana-config: release/monitoring/grafana-deployment.yml
             rabbitmq-file: census-rm-deploy/tasks/rabbitmq-provision.yml
             rabbitmq-production-setup: true
+            node-pool-name: rabbit-node-pool
 
         - name: release-images
           team: rm-dev
@@ -158,3 +160,4 @@ jobs:
             terraform-branch: master
             rabbitmq-file: census-rm-deploy/tasks/performance-rabbitmq-provision.yml
             rabbitmq-production-setup: true
+            node-pool-name: rabbit-node-pool

--- a/pipelines/concourse-pipelines.yml
+++ b/pipelines/concourse-pipelines.yml
@@ -115,6 +115,7 @@ jobs:
             grafana-config: release/monitoring/grafana-deployment.yml
             rabbitmq-file: census-rm-deploy/tasks/rabbitmq-provision.yml
             rabbitmq-production-setup: true
+            node-pool-name: rabbit-node-pool
 
         - name: census-rm-preprod
           team: rm
@@ -128,6 +129,7 @@ jobs:
             grafana-config: release/monitoring/grafana-deployment.yml
             rabbitmq-file: census-rm-deploy/tasks/rabbitmq-provision.yml
             rabbitmq-production-setup: true
+            node-pool-name: rabbit-node-pool
 
         - name: census-rm-prod
           team: rm
@@ -141,3 +143,4 @@ jobs:
             grafana-config: release/monitoring/grafana-deployment.yml
             rabbitmq-file: census-rm-deploy/tasks/rabbitmq-provision.yml
             rabbitmq-production-setup: true
+            node-pool-name: rabbit-node-pool

--- a/pipelines/manual-release-pipeline.yml
+++ b/pipelines/manual-release-pipeline.yml
@@ -1068,6 +1068,7 @@ jobs:
       ENV: ((gcp-environment-name))
       KUBERNETES_CLUSTER: rm-k8s-cluster
       RABBITMQ_PRODUCTION_SETUP: ((rabbitmq-production-setup))
+      NODE_POOL_NAME: ((node-pool-name))
     input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Deploy Monitoring"

--- a/pipelines/performance-tests-pipeline.yml
+++ b/pipelines/performance-tests-pipeline.yml
@@ -642,6 +642,7 @@ jobs:
         ENV: performance
         KUBERNETES_CLUSTER: rm-k8s-cluster
         RABBITMQ_PRODUCTION_SETUP: ((rabbitmq-production-setup))
+        NODE_POOL_NAME: ((node-pool-name))
       input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Action Scheduler"

--- a/pipelines/prod-manual-release-pipeline.yml
+++ b/pipelines/prod-manual-release-pipeline.yml
@@ -1024,6 +1024,7 @@ jobs:
       KUBERNETES_CLUSTER: rm-k8s-cluster
       RABBITMQ_CONFIG_VALUES_FILE: ((rabbit-config))
       RABBITMQ_PRODUCTION_SETUP: ((rabbitmq-production-setup))
+      NODE_POOL_NAME: ((node-pool-name))
     input_mapping: {census-rm-kubernetes-dependencies-repo: census-rm-kubernetes-release-unpacked}
 
 - name: "Deploy Monitoring"

--- a/tasks/performance-rabbitmq-provision.yml
+++ b/tasks/performance-rabbitmq-provision.yml
@@ -25,4 +25,4 @@ run:
 
       cd census-rm-kubernetes-dependencies-repo
 
-      ENV=${ENV} RABBITMQ_PRODUCTION_SETUP=${RABBITMQ_PRODUCTION_SETUP} ./setup-rabbitmq.sh
+      ENV=${ENV} RABBITMQ_PRODUCTION_SETUP=${RABBITMQ_PRODUCTION_SETUP} NODE_POOL_NAME=${NODE_POOL_NAME} ./setup-rabbitmq.sh

--- a/tasks/rabbitmq-provision.yml
+++ b/tasks/rabbitmq-provision.yml
@@ -25,4 +25,4 @@ run:
 
       cd census-rm-kubernetes-dependencies-repo
 
-      ENV=${ENV} RABBITMQ_PRODUCTION_SETUP=${RABBITMQ_PRODUCTION_SETUP} ./rabbitmq-update.sh
+      ENV=${ENV} RABBITMQ_PRODUCTION_SETUP=${RABBITMQ_PRODUCTION_SETUP} NODE_POOL_NAME=${NODE_POOL_NAME} ./rabbitmq-update.sh


### PR DESCRIPTION
We need to be able to create a second rabbitmq node-pool to seamlessly move to.

The RabbitMQ second/standby node pool will also be under Terraform's control. The rabbit node pools will be toggleable.
This will be accompanied by a runbook and can be invoked to handle expected high CPU and/or memory pressure.