### PR TITLE
Removal of Timestamp Patch Related To Prod Manual Release Pipeline

### DIFF
--- a/tasks/kubectl-apply-deployment-no-patch.yml
+++ b/tasks/kubectl-apply-deployment-no-patch.yml
@@ -33,9 +33,6 @@ run:
       # Apply deployment config
       kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-deployment.yml --record
 
-      # Patch deployment with timestamp to force pod recreation
-      kubectl patch deployment ${KUBERNETES_DEPLOYMENT_NAME} -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"timestamp\":\"`date +'%s'`\"}}}}}" --record
-      
       # Wait for rollout to finish
       kubectl rollout status deploy ${KUBERNETES_DEPLOYMENT_NAME} --watch=true --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT}
 

--- a/tasks/kubectl-apply-service-and-statefulset-no-patch.yml
+++ b/tasks/kubectl-apply-service-and-statefulset-no-patch.yml
@@ -36,9 +36,6 @@ run:
       # Apply statefulset config
       kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-statefulset.yml --record
 
-      # Patch statefulset with timestamp to force pod recreation
-      kubectl patch sts ${KUBERNETES_STATEFULSET_NAME} -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"timestamp\":\"`date +'%s'`\"}}}}}" --record
-
       # Wait for rollout to finish
       kubectl rollout status sts ${KUBERNETES_STATEFULSET_NAME} --watch=true --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT}
 

--- a/tasks/kubectl-apply-statefulset-no-patch.yml
+++ b/tasks/kubectl-apply-statefulset-no-patch.yml
@@ -33,9 +33,6 @@ run:
       # Apply statefulset config
       kubectl apply -f ${KUBERNETES_FILE_PATH}/${KUBERNETES_FILE_PREFIX}-statefulset.yml --record
 
-      # Patch statefulset with timestamp to force pod recreation
-      kubectl patch sts ${KUBERNETES_STATEFULSET_NAME} -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"timestamp\":\"`date +'%s'`\"}}}}}" --record
-
       # Wait for rollout to finish
       kubectl rollout status sts ${KUBERNETES_STATEFULSET_NAME} --watch=true --timeout=${WAIT_UNTIL_AVAILABLE_TIMEOUT}
 


### PR DESCRIPTION
# Motivation and Context
Currently, our concourse jobs will force a rolling restart even if that same tag is already deployed. This is because we patch the deployment to force a re-deploy due to the k8s/docker latest tag issue

# What has changed
Removed timestamp patch line from 3 .yml task files related to prod manual release

# How to test?
Deploy and look at it manually

# Links
https://trello.com/c/K2UJSyL2