### PR TITLE
Remove break glass spike from WL pipeline

### DIFF
--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -394,12 +394,6 @@ resources:
     uri: git@github.com:ONSdigital/census-rm-whitelist.git
     private_key: ((github.service_account_private_key))
 
-- name: breakglass-master
-  type: git
-  source:
-    uri: git@github.com:ONSdigital/census-rm-breakglass.git
-    private_key: ((github.service_account_private_key))
-
 # Docker images
 - name: action-scheduler-docker-image-ci
   type: docker-image
@@ -4719,21 +4713,4 @@ jobs:
       KUBERNETES_CLUSTER: ((wl-kubernetes-cluster-name))
     input_mapping: {
       census-rm-whitelist: whitelist-master
-      }
-
-- name: "WL Break Glass"
-  plan:
-  - get: breakglass-master
-    trigger: true
-  - get: census-rm-deploy
-  - task: break-the-darn-glass
-    file: census-rm-deploy/tasks/breakglass.yml
-    on_failure: *slack_failure_alert_wl
-    on_error: *slack_error_alert_wl
-    params:
-      SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-      GCP_PROJECT_NAME: ((wl-gcp-project-name))
-      KUBERNETES_CLUSTER: ((wl-kubernetes-cluster-name))
-    input_mapping: {
-      census-rm-breakglass: breakglass-master
       }

--- a/pipelines/build-deploy-test-CI-WL.yml
+++ b/pipelines/build-deploy-test-CI-WL.yml
@@ -163,7 +163,6 @@ groups:
   - "WL Deploy Bulk Processor"
   - "WL Whitelist"
   - "WL Whitelist Nightly"
-  - "WL Break Glass"
 
 resource_types:
 


### PR DESCRIPTION
# Motivation and Context
Looks like we can elevate our permissions ourselves, given some credential trickery in Google Groups.

# What has changed
Removed break glass proof-of-concept from WL pipeline.

# How to test?
Don't. Just fly and check the bad job has gone.

# Links
Trello: https://trello.com/c/Vh35gDOF